### PR TITLE
Add a setting to choose the data source of IP address for ACL

### DIFF
--- a/doc/admin-guide/configuration/proxy-protocol.en.rst
+++ b/doc/admin-guide/configuration/proxy-protocol.en.rst
@@ -52,6 +52,10 @@ configured with :ts:cv:`proxy.config.http.proxy_protocol_allowlist`.
        :ts:cv:`proxy.config.http.server_ports` configuration, regardless of whether
        the connections have the Proxy Protocol header.
 
+By default, |TS| uses client's IP address that is from the peer when it applies ACL. If you configure a port to
+enable PROXY protocol and want to apply ACL against the IP address delivered by PROXY protocol, you need to have ``PROXY`` in
+:ts:cv:`proxy.config.acl.subjects`.
+
 1. HTTP Forwarded Header
 
 The client IP address in the PROXY protocol header is passed to the origin server via an HTTP `Forwarded:

--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -2162,6 +2162,20 @@ IP Allow
    the use of this file, see :file:`ip_allow.yaml`. If this is a relative path,
    |TS| loads it relative to the ``SYSCONFDIR`` directory.
 
+.. ts:cv:: CONFIG proxy.config.acl.subjects STRING PEER
+
+   Specifies the list of data sources for getting client's IP address for ACL.
+   The value is a comma separated string, and the first available data source
+   will be used. If you configure a port to enable PROXY protocol, you probably
+   need to adjust this setting to have ``PROXY`` in the list.
+
+   ============= ======================================================================
+   Value         Description
+   ============= ======================================================================
+   ``PEER``      Use the IP address of the peer
+   ``PROXY``     Use the IP address from PROXY protocol
+   ============= ======================================================================
+
 
 Cache Control
 =============

--- a/include/proxy/IPAllow.h
+++ b/include/proxy/IPAllow.h
@@ -147,6 +147,8 @@ public:
 
   static constexpr const char *MODULE_NAME = "IPAllow";
 
+  enum Subject { PEER, PROXY, MAX_SUBJECTS };
+
   /** An access control record and support data.
    * The primary point of this is to hold the backing configuration in memory while the ACL
    * is in use.
@@ -251,6 +253,8 @@ public:
    * @return True if there are no rules in ip_allow.yaml, false otherwise.
    */
   static bool has_no_rules();
+
+  static uint8_t subjects[Subject::MAX_SUBJECTS];
 
 private:
   static size_t       configid;         ///< Configuration ID for update management.

--- a/src/proxy/IPAllow.cc
+++ b/src/proxy/IPAllow.cc
@@ -24,6 +24,8 @@
   limitations under the License.
  */
 
+#include <string_view>
+
 #include "proxy/IPAllow.h"
 #include "records/RecCore.h"
 #include "swoc/Errata.h"
@@ -67,8 +69,9 @@ enum AclOp {
 const IpAllow::Record IpAllow::ALLOW_ALL_RECORD(ALL_METHOD_MASK);
 const IpAllow::ACL    IpAllow::DENY_ALL_ACL;
 
-size_t IpAllow::configid       = 0;
-bool   IpAllow::accept_check_p = true; // initializing global flag for fast deny
+size_t  IpAllow::configid       = 0;
+bool    IpAllow::accept_check_p = true; // initializing global flag for fast deny
+uint8_t IpAllow::subjects[Subject::MAX_SUBJECTS];
 
 static ConfigUpdateHandler<IpAllow> *ipAllowUpdate;
 
@@ -212,6 +215,32 @@ IpAllow::IpAllow(const char *ip_allow_config_var, const char *ip_categories_conf
   if (!path.empty()) {
     ip_categories_config_file = ats_scoped_str(path).get();
   }
+
+  RecString subjects_char;
+  REC_ReadConfigStringAlloc(subjects_char, "proxy.config.acl.subjects");
+  std::string_view            subjects_sv{subjects_char};
+  int                         i = 0;
+  std::string_view::size_type s, e;
+  for (s = 0, e = 0; s < subjects_sv.size() && e != subjects_sv.npos; s = e + 1) {
+    e                           = subjects_sv.find(",", s);
+    std::string_view subject_sv = subjects_sv.substr(s, e);
+    if (i >= MAX_SUBJECTS) {
+      Error("Too many ACL subjects were provided");
+    }
+    if (subject_sv == "PEER") {
+      subjects[i] = Subject::PEER;
+      ++i;
+    } else if (subject_sv == "PROXY") {
+      subjects[i] = Subject::PROXY;
+      ++i;
+    } else {
+      Dbg(dbg_ctl_ip_allow, "Unknown subject %.*s was ignored", static_cast<int>(subject_sv.length()), subject_sv.data());
+    }
+  }
+  if (i < Subject::MAX_SUBJECTS) {
+    subjects[i] = Subject::MAX_SUBJECTS;
+  }
+  ats_free(subjects_char);
 }
 
 BufferWriter &

--- a/src/proxy/http/HttpSessionAccept.cc
+++ b/src/proxy/http/HttpSessionAccept.cc
@@ -35,11 +35,25 @@ DbgCtl dbg_ctl_http_seq{"http_seq"};
 bool
 HttpSessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReader *reader)
 {
-  sockaddr const     *client_ip;
+  sockaddr const     *client_ip = nullptr;
   IpAllow::ACL        acl;
   ip_port_text_buffer ipb;
 
-  client_ip = netvc->get_remote_addr();
+  for (int i = 0; i < IpAllow::Subject::MAX_SUBJECTS; ++i) {
+    if (IpAllow::Subject::PEER == IpAllow::subjects[i]) {
+      client_ip = netvc->get_remote_addr();
+      break;
+    } else if (IpAllow::Subject::PROXY == IpAllow::subjects[i] &&
+               netvc->get_proxy_protocol_version() != ProxyProtocolVersion::UNDEFINED) {
+      client_ip = netvc->get_proxy_protocol_src_addr();
+      break;
+    }
+  }
+
+  if (client_ip == nullptr) {
+    // Use addresses from peer if none of the configured sources are avaialable
+    client_ip = netvc->get_remote_addr();
+  }
 
   if (ats_is_ip(client_ip)) {
     acl = IpAllow::match(client_ip, IpAllow::SRC_ADDR);

--- a/src/proxy/http/remap/UrlRewrite.cc
+++ b/src/proxy/http/remap/UrlRewrite.cc
@@ -458,8 +458,26 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, const url_mapping *const
     int method        = s->hdr_info.client_request.method_get_wksidx();
     int method_wksidx = (method != -1) ? (method - HTTP_WKSIDX_CONNECT) : -1;
 
-    const IpEndpoint *src_addr;
-    src_addr = &s->client_info.src_addr;
+    const IpEndpoint    *src_addr   = nullptr;
+    const IpEndpoint    *local_addr = nullptr;
+    const ProxyProtocol &pp_info    = s->state_machine->get_ua_txn()->get_netvc()->get_proxy_protocol_info();
+    for (int i = 0; i < IpAllow::Subject::MAX_SUBJECTS; ++i) {
+      if (IpAllow::Subject::PEER == IpAllow::subjects[i]) {
+        src_addr   = &s->client_info.src_addr;
+        local_addr = &s->client_info.dst_addr;
+        break;
+      } else if (IpAllow::Subject::PROXY == IpAllow::subjects[i] && pp_info.version != ProxyProtocolVersion::UNDEFINED) {
+        src_addr   = &pp_info.src_addr;
+        local_addr = &pp_info.dst_addr;
+        break;
+      }
+    }
+
+    if (src_addr == nullptr) {
+      // Use addresses from peer if none of the configured sources are avaialable
+      src_addr   = &s->client_info.src_addr;
+      local_addr = &s->client_info.dst_addr;
+    }
 
     s->client_connection_allowed = true; // Default is that we allow things unless some filter matches
 
@@ -527,16 +545,14 @@ UrlRewrite::PerformACLFiltering(HttpTransact::State *s, const url_mapping *const
       if (ip_matches && rp->in_ip_valid) {
         bool in_ip_matches = false;
         for (int j = 0; j < rp->in_ip_cnt && !in_ip_matches; j++) {
-          IpEndpoint incoming_addr;
-          incoming_addr.assign(s->state_machine->get_ua_txn()->get_netvc()->get_local_addr());
           if (dbg_ctl_url_rewrite.on()) {
             char buf1[128], buf2[128], buf3[128];
-            ats_ip_ntop(incoming_addr, buf1, sizeof(buf1));
+            ats_ip_ntop(local_addr, buf1, sizeof(buf1));
             rp->in_ip_array[j].start.toString(buf2, sizeof(buf2));
             rp->in_ip_array[j].end.toString(buf3, sizeof(buf3));
             Dbg(dbg_ctl_url_rewrite, "Trying to match incoming address %s in range %s - %s.", buf1, buf2, buf3);
           }
-          bool in_range = rp->in_ip_array[j].contains(incoming_addr);
+          bool in_range = rp->in_ip_array[j].contains(*local_addr);
           if (rp->in_ip_array[j].invert) {
             if (!in_range) {
               in_ip_matches = true;

--- a/src/proxy/http2/Http2SessionAccept.cc
+++ b/src/proxy/http2/Http2SessionAccept.cc
@@ -42,8 +42,20 @@ Http2SessionAccept::~Http2SessionAccept() = default;
 bool
 Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferReader *reader)
 {
-  sockaddr const *client_ip   = netvc->get_remote_addr();
-  IpAllow::ACL    session_acl = IpAllow::match(client_ip, IpAllow::SRC_ADDR);
+  sockaddr const *client_ip = netvc->get_remote_addr();
+
+  for (int i = 0; i < IpAllow::Subject::MAX_SUBJECTS; ++i) {
+    if (IpAllow::Subject::PEER == IpAllow::subjects[i]) {
+      client_ip = netvc->get_remote_addr();
+      break;
+    } else if (IpAllow::Subject::PROXY == IpAllow::subjects[i] &&
+               netvc->get_proxy_protocol_version() != ProxyProtocolVersion::UNDEFINED) {
+      client_ip = netvc->get_proxy_protocol_src_addr();
+      break;
+    }
+  }
+
+  IpAllow::ACL session_acl = IpAllow::match(client_ip, IpAllow::SRC_ADDR);
   if (!session_acl.isValid()) {
     ip_port_text_buffer ipb;
     Warning("HTTP/2 client '%s' prohibited by ip-allow policy", ats_ip_ntop(client_ip, ipb, sizeof(ipb)));

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -142,6 +142,14 @@ static const RecordElement RecordsConfig[] =
 
   //##############################################################################
   //#
+  //# ACL
+  //#
+  //##############################################################################
+  {RECT_CONFIG, "proxy.config.acl.subjects", RECD_STRING, "PEER", RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  ,
+
+  //##############################################################################
+  //#
   //# Support for disabling check for Accept-* / Content-* header mismatch
   //#
   //##############################################################################

--- a/tests/gold_tests/ip_allow/replays/http_proxy_protocol.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/http_proxy_protocol.replay.yaml
@@ -1,0 +1,54 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The replay file executes various HTTP requests to verify the ip_allow policy
+# applies by default to all methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: proxy-protocol
+    version: 2
+    src-addr: "1.2.3.4:1111"
+    dst-addr: "5.6.7.8:2222"
+  transactions:
+
+  # GET
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, 1 ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/remap/remap_acl_get_post_allowed_pp.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_get_post_allowed_pp.replay.yaml
@@ -1,0 +1,132 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# This expects a remap.config that allows GET and POST, but denies all other
+# methods.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - standard_response: &standard_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 20 ]
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: proxy-protocol
+    version: 2
+    src-addr: "1.2.3.4:1111"
+    dst-addr: "5.6.7.8:2222"
+  transactions:
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /test/ip_allow/test_get
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ uuid, get ]
+        - [ X-Request, get ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  # POST also is in the allow list.
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /test/ip_allow/test_post
+      headers:
+        fields:
+        - [Content-Length, 10]
+        - [ uuid, post ]
+        - [ X-Request, post ]
+
+    <<: *standard_response
+
+    proxy-response:
+      status: 200
+
+  # PUT rejected
+  - client-request:
+      method: "PUT"
+      version: "1.1"
+      url: /test/ip_allow/test_put
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, put ]
+        - [ X-Request, put ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    # Not received.
+    <<: *standard_response
+
+    # Verify that ATS rejected the PUSH.
+    proxy-response:
+      status: 403
+
+  # DELETE rejected
+  - client-request:
+      method: "DELETE"
+      version: "1.1"
+      url: /test/ip_allow/test_delete
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, delete ]
+        - [ X-Request, delete ]
+        - [ Content-Length, 0 ]
+
+    <<: *standard_response
+
+    # Verify that ATS rejects the DELETE.
+    proxy-response:
+      status: 403
+
+  # PUSH rejected
+  - client-request:
+      method: "PUSH"
+      version: "1.1"
+      url: /test/ip_allow/test_push
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, push ]
+        - [ X-Request, push ]
+        - [ Content-Length, 113 ]
+      content:
+        encoding: plain
+        data: "HTTP/1.1 200 OK\nServer: ATS/10.0.0\nAccept-Ranges: bytes\nContent-Length: 6\nCache-Control: public,max-age=2\n\nCACHED"
+
+    <<: *standard_response
+
+    # Verify that ATS rejected the PUSH.
+    proxy-response:
+      status: 403

--- a/tests/gold_tests/tls/replay/ip_allow_proxy.replay.yaml
+++ b/tests/gold_tests/tls/replay/ip_allow_proxy.replay.yaml
@@ -1,0 +1,113 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+    version: '1.0'
+
+sessions:
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: pp.block.me.com
+  - name: proxy-protocol
+    version: 2
+    src-addr: "1.2.3.4:1111"
+    dst-addr: "5.6.7.8:2222"
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  #
+  # This request should be blocked per sni.yaml ip_allow.
+  #
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, pp.block.me.com ]
+        - [ :path, /pictures/flower.jpeg ]
+        - [ uuid, blocked-request ]
+
+    #
+    # The request should not make it to the server and the client should simply
+    # receive a connection close.
+    #
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ Content-Type, image/jpeg ]
+        - [ X-Response, blocked-response ]
+      content:
+        size: 3432
+
+- protocol:
+  - name: http
+    version: 2
+  - name: tls
+    sni: pp.allow.me.com
+  - name: proxy-protocol
+    version: 2
+    src-addr: "1.2.3.4:1111"
+    dst-addr: "5.6.7.8:2222"
+  - name: tcp
+  - name: ip
+
+  transactions:
+
+  #
+  # This request, on the other hand, should be allowed.
+  #
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, pp.allow.me.com ]
+        - [ :path, /pictures/flower.jpeg ]
+        - [ Content-Type, image/jpeg ]
+        - [ uuid, allowed-request ]
+      content:
+        size: 399
+
+    proxy-request:
+      url:
+      - [ path, { value: flower.jpeg, as: contains } ]
+
+    #
+    # The request should not make it to the server and the client should simply
+    # receive a connection close.
+    #
+    server-response:
+      headers:
+        fields:
+        - [ :status, 200 ]
+        - [ Date, "Sat, 16 Mar 2019 03:11:36 GMT" ]
+        - [ Content-Type, image/jpeg ]
+        - [ X-Response, allowed-response ]
+      content:
+        size: 35
+
+    proxy-response:
+      headers:
+        fields:
+        - [ :status, { value: 200, as: equal } ]
+        - [ X-Response, { value: allowed-response, as: equal } ]


### PR DESCRIPTION
* Add a setting to choose the data source of IP address for ACL

* Address compile errors

* Address more issues

* Add missing files

(cherry picked from commit 91a654dfa4de0c48aa222b87bfb909f9f21b03e0)

 Conflicts:
	src/proxy/http2/Http2SessionAccept.cc