### PR TITLE
hrw4u: add inbound.cookie

### DIFF
--- a/doc/admin-guide/configuration/hrw4u.en.rst
+++ b/doc/admin-guide/configuration/hrw4u.en.rst
@@ -149,7 +149,8 @@ cond %{CACHE} =hit-fresh        cache() == "hit-fresh"             Cache lookup 
 cond %{CIDR:24,48} =ip          cidr(24,48) == "ip"                Match masked client IP address
 cond %{CLIENT-HEADER:X} =foo    inbound.req.X == "foo"             Original client request header
 cond %{CLIENT-URL:<C> =bar      inbound.url.<C> == "bar"           URL component match, ``C`` is ``host``, ``path`` etc.
-cond %{COOKIE:foo} =bar         cookie.foo == "bar"                Check a cookie value
+cond %{COOKIE:foo} =bar         cookie.foo == "bar" ||             Check a cookie value
+                                inbound.cookie.foo == "bar"
 cond %{FROM-URL:<C>} =bar       from.url.<C> == "bar"              Remap ``From URL`` component match, ``C`` is ``host`` etc.
 cond %{HEADER:X} =foo           {in,out}bound.req.X == "foo"       Context sensitive header conditions
 cond %{ID:UNIQUE} =...          id.UNIQUE == "..."                 Unique transaction identifier

--- a/tools/hrw4u/src/symbols.py
+++ b/tools/hrw4u/src/symbols.py
@@ -30,6 +30,7 @@ class SymbolResolver:
         "http.status.reason": ("set-status-reason", Validator.quoted_or_simple(), False, None),
         "http.status": ("set-status", Validator.range(0, 999), False, None),
         "inbound.conn.dscp": ("set-conn-dscp", Validator.nbit_int(6), False, None),
+        "inbound.cookie.": (["rm-cookie", "set-cookie"], Validator.quoted_or_simple(), False, None),
         "inbound.req.": (["rm-header", "set-header"], Validator.quoted_or_simple(), False, None),
         "inbound.resp.body": ("set-body", Validator.quoted_or_simple(), False, None),
         "inbound.resp.": (["rm-header", "set-header"], Validator.quoted_or_simple(), False, None),

--- a/tools/hrw4u/tests/data/conds/cookie.input.txt
+++ b/tools/hrw4u/tests/data/conds/cookie.input.txt
@@ -3,3 +3,8 @@ REMAP {
       inbound.req.X-Cookie = "there";
     }
 }
+REMAP {
+    if inbound.cookie.bar ~ /bar/ {
+      inbound.req.X-Another-Cookie = "here";
+    }
+}

--- a/tools/hrw4u/tests/data/conds/cookie.output.txt
+++ b/tools/hrw4u/tests/data/conds/cookie.output.txt
@@ -1,3 +1,7 @@
 cond %{REMAP_PSEUDO_HOOK} [AND]
 cond %{COOKIE:foobar} /foo/
     set-header X-Cookie "there"
+
+cond %{REMAP_PSEUDO_HOOK} [AND]
+cond %{COOKIE:bar} /bar/
+    set-header X-Another-Cookie "here"


### PR DESCRIPTION
This allows an configuration to either write conditionals with cookie (which stems from original header_rewrite), or a new inbound.cookie -- which might be more expected given the other 'contextual' objects.