### PR TITLE
Fix docs about Overridable Variables

### DIFF
--- a/doc/developer-guide/config-vars.en.rst
+++ b/doc/developer-guide/config-vars.en.rst
@@ -310,7 +310,7 @@ required for generic access:
 
 #. Add a value to the ``TSOverridableConfigKey`` enumeration in |apidefs.h.in|_.
 
-#. Augment ``Overridable_Map`` in |overridable_txn_vars.cc|_ to include configuration variable.
+#. Augment ``ts::Overridable_Txn_Vars`` in |overridable_txn_vars.cc|_ to include configuration variable.
 
 #. Update the function ``_conf_to_memberp`` in |InkAPI.cc|_ to have a case for the enumeration value
    in ``TSOverridableConfigKey``.


### PR DESCRIPTION
Fix the name of the map in the `overridable_txn_vars.cc`.
https://github.com/apache/trafficserver/blob/02139d56ece499599a31b066f8ab28e8225cd957/src/shared/overridable_txn_vars.cc#L29