### PR TITLE
Return captive_action from HttpCachSM if read retry event is scheduled

### DIFF
--- a/include/proxy/http/HttpCacheSM.h
+++ b/include/proxy/http/HttpCacheSM.h
@@ -86,7 +86,7 @@ public:
     captive_action.init(this);
   }
   void reset();
-  void cleanup();
+  void cancel_pending_action();
 
   Action *open_read(const HttpCacheKey *key, URL *url, HTTPHdr *hdr, const OverridableHttpConfigParams *params,
                     time_t pin_in_cache);

--- a/src/proxy/http/HttpCacheSM.cc
+++ b/src/proxy/http/HttpCacheSM.cc
@@ -55,9 +55,7 @@ HttpCacheAction::cancel(Continuation *c)
   ink_assert(this->cancelled == false);
 
   this->cancelled = true;
-  if (_cache_sm->pending_action) {
-    _cache_sm->pending_action->cancel();
-  }
+  _cache_sm->cancel_pending_action();
 }
 
 ////
@@ -74,12 +72,16 @@ HttpCacheSM::reset()
 }
 
 void
-HttpCacheSM::cleanup()
+HttpCacheSM::cancel_pending_action()
 {
-  ink_release_assert(this->mutex && this->mutex->thread_holding == this_ethread());
+  if (pending_action != nullptr) {
+    pending_action->cancel();
+    pending_action = nullptr;
+  }
 
   if (_read_retry_event != nullptr) {
     _read_retry_event->cancel();
+    _read_retry_event = nullptr;
   }
 }
 
@@ -329,10 +331,11 @@ HttpCacheSM::do_cache_open_read(const HttpCacheKey &key)
   } else {
     // In some cases, CacheProcessor::open_read calls back to `state_cache_open_read` with a cache event. If the event is
     // CACHE_EVENT_OPEN_READ_FAILED, a read retry event might be scheduled. In this case, CacheProcessor::open_read returns
-    // ACTION_RESULT_DONE, even though the read retry event is still pending. To indicate this situation to HttpSM, the scheduled
-    // read retry event is returned. HttpSM can cancel the event if necessary.
+    // ACTION_RESULT_DONE, even though the read retry event is still pending. To indicate this situation to HttpSM, `captive_action`
+    // is returned. HttpSM can cancel the event though this `captive_action` if necessary.
     if (_read_retry_event && _read_retry_event->cancelled != true) {
-      return _read_retry_event;
+      captive_action.cancelled = false;
+      return &captive_action;
     } else {
       return ACTION_RESULT_DONE;
     }
@@ -423,11 +426,12 @@ HttpCacheSM::open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, Cac
     return &captive_action;
   } else {
     // In some cases, CacheProcessor::open_write calls back to `state_cache_open_write` with a cache event. If the event is
-    // CACHE_EVENT_OPEN_WRITE_FAILED, a read retry event might be scheduled. In this case, CacheProcessor::open_read returns
-    // ACTION_RESULT_DONE, even though the read retry event is still pending. To indicate this situation to HttpSM, the scheduled
-    // read retry event is returned. HttpSM can cancel the event if necessary.
+    // CACHE_EVENT_OPEN_WRITE_FAILED, a read retry event might be scheduled. In this case, CacheProcessor::open_write returns
+    // ACTION_RESULT_DONE, even though the read retry event is still pending. To indicate this situation to HttpSM, `captive_action`
+    // is returned. HttpSM can cancel the event though this `captive_action` if necessary.
     if (_read_retry_event && _read_retry_event->cancelled != true) {
-      return _read_retry_event;
+      captive_action.cancelled = false;
+      return &captive_action;
     } else {
       return ACTION_RESULT_DONE;
     }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -260,7 +260,7 @@ HttpSM::cleanup()
   HttpConfig::release(t_state.http_config_param);
   m_remap->release();
 
-  cache_sm.cleanup();
+  cache_sm.cancel_pending_action();
 
   mutex.clear();
   tunnel.mutex.clear();


### PR DESCRIPTION
We found that #12193 made below crash.

```
#0  0x0000561ef3087a14 in PendingAction::operator= (this=0x7ff5e541eac8, action=<optimized out>) at /include/tscore/PendingAction.h:109
#1  HttpSM::state_cache_open_write (this=0x7ff5e541c000, event=1108, data=0x7ff5e541e8f0) at /src/proxy/http/HttpSM.cc:2435
#2  0x0000561ef3072903 in HttpSM::main_handler (this=0x7ff5e541c000, event=1108, data=0x7ff5e541e8f0) at /src/proxy/http/HttpSM.cc:2656
#3  0x0000561ef304b325 in HttpCacheSM::state_cache_open_write (this=<optimized out>, event=<optimized out>, data=<optimized out>) at /include/iocore/eventsystem/Continuation.h:236
#4  0x0000561ef3207ab5 in Continuation::handleEvent (this=<optimized out>, event=1108, data=0x7ffa2b19b400) at /include/iocore/eventsystem/Continuation.h:236
#5  CacheVC::callcont (this=0x7ffa2b19b400, event=1108) at /src/iocore/cache/P_CacheInternal.h:262
#6  0x0000561ef32176ce in CacheVC::openWriteStartDone (this=0x7ffa2b19b400, event=<optimized out>, e=<optimized out>) at /src/iocore/cache/CacheWrite.cc:1497
#7  0x0000561ef3218885 in Continuation::handleEvent (this=0x7ffa2b19b400, event=3900, data=0x0) at /include/iocore/eventsystem/Continuation.h:236
#8  Cache::open_write (this=0x7ffa344ff000, cont=0x7ff5e541e878, key=0x7ff5e541e968, info=0x0, apin_in_cache=0, type=CACHE_FRAG_TYPE_HTTP, hostname=0x0, host_len=0) at /src/iocore/cache/CacheWrite.cc:1744
#9  0x0000561ef304b570 in CacheProcessor::open_write (cont=0x7ff5e541e878, key=0x7ff5e541e958, old_info=0x0, type=CACHE_FRAG_TYPE_HTTP, this=<optimized out>, pin_in_cache=<optimized out>) at /src/iocore/cache/Cache.cc:1993
#10 HttpCacheSM::open_write (this=0x7ff5e541e878, key=0x7ff5e541e958, url=<optimized out>, request=<optimized out>, old_info=<optimized out>, pin_in_cache=<optimized out>, retry=<optimized out>, allow_multiple=<optimized out>) at /src/proxy/http/HttpCacheSM.cc:430
#11 0x0000561ef304b058 in HttpCacheSM::state_cache_open_write (this=0x7ff5e541e878, event=2, data=0x7ff99fa01b40) at /src/proxy/http/HttpCacheSM.cc:295
#12 0x0000561ef333d795 in Continuation::handleEvent (this=<optimized out>, event=2, data=0x7ff99fa01b40) at /include/iocore/eventsystem/Continuation.h:236
#13 EThread::process_event (this=0x7ffa42e0af80, e=0x7ff99fa01b40, calling_code=2) at /src/iocore/eventsystem/UnixEThread.cc:162
#14 0x0000561ef333e08d in EThread::execute_regular (this=0x7ffa42e0af80) at /src/iocore/eventsystem/UnixEThread.cc:269
#15 0x0000561ef333e854 in EThread::execute (this=0x7ffa42e0af80) at /src/iocore/eventsystem/UnixEThread.cc:348
#16 0x0000561ef333c6c7 in spawn_thread_internal (a=0x7ffa496894a0) at /src/iocore/eventsystem/Thread.cc:75
#17 0x00007ffa49a897e2 in start_thread () from /lib64/libc.so.6
#18 0x00007ffa49b0e800 in clone3 () from /lib64/libc.so.6
```

The root cause is the `_read_retry_event` is returned to `HttpSM` from `HttpCacheSM` directly.  The pointer stored in the , `HttpSM::pending_action` becomes invalid when `HttpCacheSM` handles or cancels the event. 

To avoid the crash, `HttpCacheSM` returns `captive_action` like other scheduled events do.