### PR TITLE
initialize the OptionInfo in the ESI plugin using default member initializer

### DIFF
--- a/plugins/esi/esi.cc
+++ b/plugins/esi/esi.cc
@@ -52,10 +52,10 @@ using namespace EsiLib;
 using namespace Stats;
 
 struct OptionInfo {
-  bool packed_node_support;
-  bool private_response;
-  bool disable_gzip_output;
-  bool first_byte_flush;
+  bool packed_node_support{false};
+  bool private_response{false};
+  bool disable_gzip_output{false};
+  bool first_byte_flush{false};
   unsigned max_inclusion_depth{3};
 };
 


### PR DESCRIPTION
# Problem
In the ESI plugin, `OptionInfo` is not properly initialized, posing a risk that unspecified options may become enabled. This issue does not occur in the master branch. Below is an example of a case where the problem arises.

First, enable the ESI plugin in `plugin.config` without specifying any options:
```
esi.so
```

Next, enable the ESI plugin's debug log in `records.config`:
```
CONFIG proxy.config.diags.debug.enabled INT 1
CONFIG proxy.config.diags.debug.tags STRING plugin_esi
```

When I started `traffic_server` and checked the log in my environment, `packed-node-support` and `private-response` had unintended values:
```
[Jun 25 09:15:08.273] traffic_server DIAG: (plugin_esi) [esiPluginInit] Plugin started, \
packed-node-support: 42, private-response: 40, disable-gzip-output: 0, first-byte-flush: 0, max-inclusion-depth 3
```

# Cause
This issue is caused by PR #12296. In the PR, the initialization method for `OptionInfo` was changed from `memset` to a constructor, but the member variables, except for `max_inclusion_depth`, remain uninitialized.
https://github.com/apache/trafficserver/pull/12296/files#diff-03700cb0f4ba03f85d4a11acf274c9b63eef3f41b2a68ccb2614b94b85243101L1592-R1636

# Fix
In the master branch, the `OptionInfo` structure is initialized using default member initializer. The same method has been applied to the 9.2.x branch.
https://github.com/apache/trafficserver/blob/132e01c4aea486c209fa5ea8e39cb34627442304/plugins/esi/esi.cc#L55-L62

After the fix, it was confirmed that `OptionInfo` is properly initialized:
```
[Jun 25 09:23:21.797] traffic_server DIAG: (plugin_esi) [esiPluginInit] Plugin started, \
packed-node-support: 0, private-response: 0, disable-gzip-output: 0, first-byte-flush: 0, max-inclusion-depth 3
```