### PR TITLE
Add metric when parent marked down from inactive timeout

### DIFF
--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -261,6 +261,7 @@ struct HttpStatsBlock {
   Metrics::Counter::AtomicType *total_client_connections_uds;
   Metrics::Counter::AtomicType *total_incoming_connections;
   Metrics::Counter::AtomicType *total_parent_marked_down_count;
+  Metrics::Counter::AtomicType *total_parent_marked_down_timeout;
   Metrics::Counter::AtomicType *total_parent_proxy_connections;
   Metrics::Counter::AtomicType *total_parent_retries;
   Metrics::Counter::AtomicType *total_parent_retries_exhausted;

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -488,6 +488,7 @@ register_stat_callbacks()
   http_rsb.total_client_connections_uds      = Metrics::Counter::createPtr("proxy.process.http.total_client_connections_uds");
   http_rsb.total_incoming_connections        = Metrics::Counter::createPtr("proxy.process.http.total_incoming_connections");
   http_rsb.total_parent_marked_down_count    = Metrics::Counter::createPtr("proxy.process.http.total_parent_marked_down_count");
+  http_rsb.total_parent_marked_down_timeout  = Metrics::Counter::createPtr("proxy.process.http.total_parent_marked_down_timeout");
   http_rsb.total_parent_proxy_connections    = Metrics::Counter::createPtr("proxy.process.http.total_parent_proxy_connections");
   http_rsb.total_parent_retries              = Metrics::Counter::createPtr("proxy.process.http.total_parent_retries");
   http_rsb.total_parent_retries_exhausted    = Metrics::Counter::createPtr("proxy.process.http.total_parent_retries_exhausted");

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -248,8 +248,11 @@ markParentDown(HttpTransact::State *s)
     return;
   }
 
-  if (s->current.state == HttpTransact::INACTIVE_TIMEOUT && s->txn_conf->enable_parent_timeout_markdowns == 0) {
-    return;
+  if (s->current.state == HttpTransact::INACTIVE_TIMEOUT) {
+    if (s->txn_conf->enable_parent_timeout_markdowns == 0) {
+      return;
+    }
+    Metrics::Counter::increment(http_rsb.total_parent_marked_down_timeout);
   }
 
   if (s->response_action.handled) {


### PR DESCRIPTION
Similar to `parent_marked_down_count`, add metric for when parent is marked down because of inactive timeouts. Provides more visibility 