### PR TITLE
Expose JSON client timeout to CLI

### DIFF
--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -85,14 +85,14 @@ CtrlCommand::execute()
 }
 
 std::string
-RPCAccessor::invoke_rpc(std::string const &request)
+RPCAccessor::invoke_rpc(std::string const &request, std::chrono::milliseconds timeout_ms, int attempts)
 {
   if (_printer->print_rpc_message()) {
     std::string text;
     swoc::bwprint(text, "--> {}", request);
     _printer->write_debug(std::string_view{text});
   }
-  if (auto resp = _rpcClient.invoke(request); !resp.empty()) {
+  if (auto resp = _rpcClient.invoke(request, timeout_ms, attempts); !resp.empty()) {
     // all good.
     if (_printer->print_rpc_message()) {
       std::string text;
@@ -106,18 +106,19 @@ RPCAccessor::invoke_rpc(std::string const &request)
 }
 
 shared::rpc::JSONRPCResponse
-RPCAccessor::invoke_rpc(shared::rpc::ClientRequest const &request)
+RPCAccessor::invoke_rpc(shared::rpc::ClientRequest const &request, std::chrono::milliseconds timeout_ms, int attempts)
 {
   std::string encodedRequest = Codec::encode(request);
-  std::string resp           = invoke_rpc(encodedRequest);
+  std::string resp           = invoke_rpc(encodedRequest, timeout_ms, attempts);
   return Codec::decode(resp);
 }
 
 void
-RPCAccessor::invoke_rpc(shared::rpc::ClientRequest const &request, std::string &resp)
+RPCAccessor::invoke_rpc(shared::rpc::ClientRequest const &request, std::string &resp, std::chrono::milliseconds timeout_ms,
+                        int attempts)
 {
   std::string encodedRequest = Codec::encode(request);
-  resp                       = invoke_rpc(encodedRequest);
+  resp                       = invoke_rpc(encodedRequest, timeout_ms, attempts);
 }
 // -----------------------------------------------------------------------------------------------------------------------------------
 ConfigCommand::ConfigCommand(ts::Arguments *args) : RecordCommand(args)
@@ -164,6 +165,24 @@ RecordCommand::record_fetch(ts::ArgumentData argData, bool isRegex, RecordQueryT
                         recQueryType == RecordQueryType::CONFIG ? shared::rpc::CONFIG_REC_TYPES : shared::rpc::METRIC_REC_TYPES);
   }
   return invoke_rpc(request);
+}
+
+std::string
+CtrlCommand::invoke_rpc(std::string const &request)
+{
+  auto timeout  = std::chrono::milliseconds(std::stoi(get_parsed_arguments()->get("read-timeout").value()));
+  auto attempts = std::stoi(get_parsed_arguments()->get("read-attempts").value());
+
+  return RPCAccessor::invoke_rpc(request, timeout, attempts);
+}
+
+shared::rpc::JSONRPCResponse
+CtrlCommand::invoke_rpc(shared::rpc::ClientRequest const &request)
+{
+  auto timeout  = std::chrono::milliseconds(std::stoi(get_parsed_arguments()->get("read-timeout").value()));
+  auto attempts = std::stoi(get_parsed_arguments()->get("read-attempts").value());
+
+  return RPCAccessor::invoke_rpc(request, timeout, attempts);
 }
 
 void

--- a/src/traffic_ctl/FileConfigCommand.h
+++ b/src/traffic_ctl/FileConfigCommand.h
@@ -67,8 +67,7 @@ struct FlatYAMLAccessor {
   }
 
 protected:
-  std::vector<YAML::Node>      _docs;
-  std::unique_ptr<BasePrinter> _printer; //!< Specific output formatter. This should be created by the derived class.
+  std::vector<YAML::Node> _docs;
 };
 
 /// @brief Class used to deal with the config file changes. Append or modify an existing records.yaml field

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -78,7 +78,9 @@ main([[maybe_unused]] int argc, const char **argv)
     .add_option("--version", "-V", "Print version string")
     .add_option("--help", "-h", "Print usage information")
     .add_option("--run-root", "", "using TS_RUNROOT as sandbox", "TS_RUNROOT", 1)
-    .add_option("--format", "-f", "Use a specific output format {json|rpc}", "", 1, "", "format");
+    .add_option("--format", "-f", "Use a specific output format {json|rpc}", "", 1, "", "format")
+    .add_option("--read-timeout-ms", "", "Read timeout for RPC (in milliseconds)", "", 1, "1000", "read-timeout")
+    .add_option("--read-attempts", "", "Read attempts for RPC", "", 1, "10", "read-attempts");
 
   auto &config_command     = parser.add_command("config", "Manipulate configuration records").require_commands();
   auto &metric_command     = parser.add_command("metric", "Manipulate performance metrics").require_commands();

--- a/src/traffic_top/stats.h
+++ b/src/traffic_top/stats.h
@@ -22,6 +22,7 @@
 */
 #pragma once
 
+#include <chrono>
 #include <map>
 #include <string>
 #include <sys/types.h>
@@ -483,7 +484,7 @@ private:
       rpc::RPCClient rpcClient;
 
       // invoke the rpc.
-      auto const &rpcResponse = rpcClient.invoke<>(request);
+      auto const &rpcResponse = rpcClient.invoke<>(request, std::chrono::milliseconds(1000), 10);
 
       if (!rpcResponse.is_error()) {
         auto const &records = rpcResponse.result.as<rpc::RecordLookUpResponse>();


### PR DESCRIPTION
This allows the user to change the timeout when reading a response from the JSONRPC server.

This exposes the attempts and timeout (in ms) separately, but I'm open to changing this to a simpler single config if that makes more sense.