### PR TITLE
Address HttpSM::attach_server_session crash

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2773,6 +2773,9 @@ HttpSM::tunnel_handler_post(int event, void *data)
       default:
         break;
       }
+    } else if (static_cast<HttpSmPost_t>(p->handler_state) == HttpSmPost_t::SERVER_FAIL) {
+      handle_post_failure();
+      break;
     }
     break;
   case VC_EVENT_WRITE_READY: // iocore may callback first before send.


### PR DESCRIPTION
This addresses the following assertion crash in HttpSM::attach_server_session:

hsm_release_assert(server_entry == nullptr);

The history shows this:

```
$1 = History(capacity=65, history_pos=118, num_entries=65) = {
HttpSM.cc:5018            do_cache_lookup_and_read                           TS_EVENT_NONE (0)                                       reent=     22,
HttpSM.cc:844             state_watch_for_client_abort                       TS_EVENT_VCONN_READ_READY (100)                         reent=      1,
HttpSM.cc:844             state_watch_for_client_abort                       TS_EVENT_VCONN_READ_READY (100)                         reent=      1,
HttpSM.cc:844             state_watch_for_client_abort                       TS_EVENT_VCONN_READ_READY (100)                         reent=      1,
HttpSM.cc:844             state_watch_for_client_abort                       TS_EVENT_VCONN_READ_READY (100)                         reent=      1,
HttpSM.cc:844             state_watch_for_client_abort                       TS_EVENT_VCONN_READ_READY (100)                         reent=      1,
HttpSM.cc:2081            state_send_server_request_header                   TS_EVENT_VCONN_WRITE_COMPLETE (103)                     reent=      1,
HttpSM.cc:6354            do_setup_client_request_body_tunnel                NO_EVENT (34463)                                        reent=      1,
HttpSM.cc:3897            tunnel_handler_post_server                         TS_EVENT_ERROR (3)                                      reent=      0,
HttpSM.cc:2735            tunnel_handler_post                                TS_EVENT_HTTP_TUNNEL_EVENT_DONE (2301)                  reent=      1,
HttpSM.cc:5979            handle_post_failure                                TS_EVENT_NONE (0)                                       reent=      1,
HttpCacheSM.cc:104        state_cache_open_read                              TS_EVENT_CACHE_OPEN_READ_FAILED (1103)                  reent= -31073,
HttpSM.cc:2561            state_cache_open_read                              TS_EVENT_CACHE_OPEN_READ_FAILED (1103)                  reent=      7,
HttpSM.cc:2221            add_to_existing_request                            NO_EVENT (34463)                                        reent=     11,
HttpSM.cc:5018            do_cache_lookup_and_read                           TS_EVENT_NONE (0)                                       reent=      6,
HttpSM.cc:1769            state_http_server_open                             TS_EVENT_VCONN_EOS (104)                                reent=      1,
HttpSM.cc:1769            state_http_server_open                             Unknown event 1400 (1400)                               reent=      1}
```

Notice that an error occurs in tunnel_handler_post_server with the expectation that tunnel_handler_post would handle it. But tunnel_handler_post only handled UA failures, not SERVER ones. This updates it to handle server failures too.

Fixes: #12240