### PR TITLE
xdebug: release the client request MLoc

### DIFF
--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -778,6 +778,8 @@ XScanRequestHeaders(TSCont /* contp */, TSEvent event, void *edata)
     }
   }
 
+  // Release the request header MLoc.
+  TSHandleMLocRelease(buffer, TS_NULL_MLOC, hdr);
   return TS_EVENT_NONE;
 }
 


### PR DESCRIPTION
XScanRequestHeaders missed a TSHandleMLocRelease call for the client request MLoc resource.