### PR TITLE
Fix autest syntax and remove test file copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,7 @@ tests/gold_tests/bigobj/check_ramp
 tests/gold_tests/bigobj/push_request
 tests/gold_tests/chunked_encoding/smuggle-client
 tests/gold_tests/tls/ssl-post
+tests/gold_tests_filtered/
 
 src/iocore/cache/test_*
 src/iocore/cache/unit_tests/var/trafficserver/cache.db

--- a/.gitignore
+++ b/.gitignore
@@ -205,7 +205,6 @@ tests/gold_tests/bigobj/check_ramp
 tests/gold_tests/bigobj/push_request
 tests/gold_tests/chunked_encoding/smuggle-client
 tests/gold_tests/tls/ssl-post
-tests/gold_tests_filtered/
 
 src/iocore/cache/test_*
 src/iocore/cache/unit_tests/var/trafficserver/cache.db

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ add_subdirectory(gold_tests/tls)
 set(RUNPIPENV PIPENV_VENV_IN_PROJECT=True ${PipEnv})
 
 set(CMAKE_GOLD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gold_tests")
-set(CMAKE_SKIP_GOLD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/_gold_tests")
+set(CMAKE_SKIP_GOLD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/_skipped_uds_gold_tests")
 set(CURL_UDS_FLAG "")
 if(ENABLE_AUTEST_UDS)
   set(CURL_UDS_FLAG "--curl-uds")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,15 +38,15 @@ endfunction()
 add_subdirectory(tools/plugins)
 set(RUNPIPENV PIPENV_VENV_IN_PROJECT=True ${PipEnv})
 
-set(CMAKE_GOLD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gold_tests_filtered")
+set(CMAKE_GOLD_DIR "${CMAKE_CURRENT_BINARY_DIR}/gold_tests")
 set(CURL_UDS_FLAG "")
 if(ENABLE_AUTEST_UDS)
   set(CURL_UDS_FLAG "--curl-uds")
   # Copy everything except dirs: h2, tls
   # Other specific tests will be skipped
   file(
-    COPY ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/
-    DESTINATION ${CMAKE_GOLD_DIR}
+    COPY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION ${CMAKE_BINARY_DIR}
     FILES_MATCHING
     PATTERN "*"
     PATTERN "h2" EXCLUDE
@@ -56,21 +56,21 @@ if(ENABLE_AUTEST_UDS)
 else()
   # Copy everything except autest_uds tests that are only for curl uds option
   file(
-    COPY ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/
-    DESTINATION ${CMAKE_GOLD_DIR}
+    COPY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION ${CMAKE_BINARY_DIR}
     FILES_MATCHING
     PATTERN "*"
   )
-  add_subdirectory(gold_tests_filtered/tls)
+  add_subdirectory(gold_tests/tls)
 endif()
 
-add_subdirectory(gold_tests_filtered/chunked_encoding)
-add_subdirectory(gold_tests_filtered/continuations/plugins)
-add_subdirectory(gold_tests_filtered/jsonrpc/plugins)
-add_subdirectory(gold_tests_filtered/pluginTest/polite_hook_wait)
-add_subdirectory(gold_tests_filtered/pluginTest/tsapi)
-add_subdirectory(gold_tests_filtered/pluginTest/TSVConnFd)
-add_subdirectory(gold_tests_filtered/timeout)
+add_subdirectory(gold_tests/chunked_encoding)
+add_subdirectory(gold_tests/continuations/plugins)
+add_subdirectory(gold_tests/jsonrpc/plugins)
+add_subdirectory(gold_tests/pluginTest/polite_hook_wait)
+add_subdirectory(gold_tests/pluginTest/tsapi)
+add_subdirectory(gold_tests/pluginTest/TSVConnFd)
+add_subdirectory(gold_tests/timeout)
 
 configure_file(Pipfile Pipfile COPYONLY)
 configure_file(autest.sh.in autest.sh)
@@ -91,10 +91,9 @@ add_custom_target(
   autest_no_install
   COMMAND ${RUNPIPENV} install
   COMMAND
-    ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/remap:$ENV{PYTHONPATH} ${RUNPIPENV} run
-    env autest --directory ${CMAKE_CURRENT_SOURCE_DIR}/gold_tests --ats-bin=${CMAKE_INSTALL_PREFIX}/bin
-    --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX}
-    ${CURL_UDS_FLAG} ${AUTEST_OPTIONS}
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_GOLD_DIR}/remap:$ENV{PYTHONPATH} ${RUNPIPENV} run env autest --directory
+    ${CMAKE_GOLD_DIR} --ats-bin=${CMAKE_INSTALL_PREFIX}/bin --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root
+    ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX} ${CURL_UDS_FLAG} ${AUTEST_OPTIONS}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   USES_TERMINAL
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,34 +36,6 @@ function(ADD_AUTEST_PLUGIN _NAME)
 endfunction()
 
 add_subdirectory(tools/plugins)
-set(RUNPIPENV PIPENV_VENV_IN_PROJECT=True ${PipEnv})
-
-set(CMAKE_GOLD_DIR "${CMAKE_CURRENT_BINARY_DIR}/gold_tests")
-set(CURL_UDS_FLAG "")
-if(ENABLE_AUTEST_UDS)
-  set(CURL_UDS_FLAG "--curl-uds")
-  # Copy everything except dirs: h2, tls
-  # Other specific tests will be skipped
-  file(
-    COPY ${CMAKE_CURRENT_SOURCE_DIR}
-    DESTINATION ${CMAKE_BINARY_DIR}
-    FILES_MATCHING
-    PATTERN "*"
-    PATTERN "h2" EXCLUDE
-    PATTERN "tls*" EXCLUDE
-    PATTERN "tls/ssl/**"
-  )
-else()
-  # Copy everything except autest_uds tests that are only for curl uds option
-  file(
-    COPY ${CMAKE_CURRENT_SOURCE_DIR}
-    DESTINATION ${CMAKE_BINARY_DIR}
-    FILES_MATCHING
-    PATTERN "*"
-  )
-  add_subdirectory(gold_tests/tls)
-endif()
-
 add_subdirectory(gold_tests/chunked_encoding)
 add_subdirectory(gold_tests/continuations/plugins)
 add_subdirectory(gold_tests/jsonrpc/plugins)
@@ -71,6 +43,16 @@ add_subdirectory(gold_tests/pluginTest/polite_hook_wait)
 add_subdirectory(gold_tests/pluginTest/tsapi)
 add_subdirectory(gold_tests/pluginTest/TSVConnFd)
 add_subdirectory(gold_tests/timeout)
+add_subdirectory(gold_tests/tls)
+
+set(RUNPIPENV PIPENV_VENV_IN_PROJECT=True ${PipEnv})
+
+set(CMAKE_GOLD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gold_tests")
+set(CMAKE_SKIP_GOLD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/_gold_tests")
+set(CURL_UDS_FLAG "")
+if(ENABLE_AUTEST_UDS)
+  set(CURL_UDS_FLAG "--curl-uds")
+endif()
 
 configure_file(Pipfile Pipfile COPYONLY)
 configure_file(autest.sh.in autest.sh)
@@ -94,6 +76,23 @@ add_custom_target(
     ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_GOLD_DIR}/remap:$ENV{PYTHONPATH} ${RUNPIPENV} run env autest --directory
     ${CMAKE_GOLD_DIR} --ats-bin=${CMAKE_INSTALL_PREFIX}/bin --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root
     ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX} ${CURL_UDS_FLAG} ${AUTEST_OPTIONS}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  USES_TERMINAL
+)
+
+# autest uds specific target that skips tests and runs with curl flag
+add_custom_target(
+  autest-uds
+  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target install
+  COMMAND ${RUNPIPENV} install
+  COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_GOLD_DIR}/h2 ${CMAKE_SKIP_GOLD_DIR}/h2
+  COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_GOLD_DIR}/tls ${CMAKE_SKIP_GOLD_DIR}/tls
+  COMMAND
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_GOLD_DIR}/remap:$ENV{PYTHONPATH} ${RUNPIPENV} run env autest --directory
+    ${CMAKE_GOLD_DIR} --ats-bin=${CMAKE_INSTALL_PREFIX}/bin --proxy-verifier-bin ${PROXY_VERIFIER_PATH} --build-root
+    ${CMAKE_BINARY_DIR} --sandbox ${AUTEST_SANDBOX} ${CURL_UDS_FLAG} ${AUTEST_OPTIONS}
+  COMMAND ${CMAKE_COMMAND} -E rename {CMAKE_SKIP_GOLD_DIR}/h2 ${CMAKE_GOLD_DIR}/h2
+  COMMAND ${CMAKE_COMMAND} -E rename ${CMAKE_SKIP_GOLD_DIR}/tls ${CMAKE_GOLD_DIR}/tls
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   USES_TERMINAL
 )

--- a/tests/autest.sh.in
+++ b/tests/autest.sh.in
@@ -27,12 +27,15 @@ ${RUNPIPENV} run env autest \
   ${CURL_UDS_FLAG} ${AUTEST_OPTIONS} \
   "$@"
 
-# Restore tests back to source tree
+# Restore tests back to source tree and remove temp dir
 if [ -n "${CURL_UDS_FLAG}" ]; then
   if [ -d "${CMAKE_SKIP_GOLD_DIR}/h2" ]; then
     mv "${CMAKE_SKIP_GOLD_DIR}/h2" "${CMAKE_GOLD_DIR}/h2"
   fi
   if [ -d "${CMAKE_SKIP_GOLD_DIR}/tls" ]; then
     mv "${CMAKE_SKIP_GOLD_DIR}/tls" "${CMAKE_GOLD_DIR}/tls"
+  fi
+  if [ -d "${CMAKE_SKIP_GOLD_DIR}" ]; then
+    rm -rf "${CMAKE_SKIP_GOLD_DIR}"
   fi
 fi

--- a/tests/autest.sh.in
+++ b/tests/autest.sh.in
@@ -7,6 +7,17 @@
 export LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib
 export PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/gold_tests/remap:$PYTHONPATH
 
+# Define tests to skip for CURL_UDS_FLAG
+if [ -n "${CURL_UDS_FLAG}" ]; then
+  mkdir -p "${CMAKE_SKIP_GOLD_DIR}"
+  if [ -d "${CMAKE_GOLD_DIR}/h2" ]; then
+    mv "${CMAKE_GOLD_DIR}/h2" "${CMAKE_SKIP_GOLD_DIR}/h2"
+  fi
+  if [ -d "${CMAKE_GOLD_DIR}/tls" ]; then
+    mv "${CMAKE_GOLD_DIR}/tls" "${CMAKE_SKIP_GOLD_DIR}/tls"
+  fi
+fi
+
 ${RUNPIPENV} run env autest \
   --sandbox ${AUTEST_SANDBOX} \
   --directory ${CMAKE_GOLD_DIR} \
@@ -15,3 +26,13 @@ ${RUNPIPENV} run env autest \
   --build-root ${CMAKE_BINARY_DIR} \
   ${CURL_UDS_FLAG} ${AUTEST_OPTIONS} \
   "$@"
+
+# Restore tests back to source tree
+if [ -n "${CURL_UDS_FLAG}" ]; then
+  if [ -d "${CMAKE_SKIP_GOLD_DIR}/h2" ]; then
+    mv "${CMAKE_SKIP_GOLD_DIR}/h2" "${CMAKE_GOLD_DIR}/h2"
+  fi
+  if [ -d "${CMAKE_SKIP_GOLD_DIR}/tls" ]; then
+    mv "${CMAKE_SKIP_GOLD_DIR}/tls" "${CMAKE_GOLD_DIR}/tls"
+  fi
+fi

--- a/tests/gold_tests/autest-site/curl.test.ext
+++ b/tests/gold_tests/autest-site/curl.test.ext
@@ -30,7 +30,7 @@ Tools to help with TestRun commands
 #
 
 
-def spawn_curl_commands(self, cmdstr, count, retcode=0, use_default=True, ts=None):
+def spawn_curl_commands(self, cmdstr, count, ts, retcode=0, use_default=True):
     ret = []
 
     if self.Variables.get("CurlUds", False):

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -34,8 +34,6 @@ if Arguments.ats_bin is not None:
 
 if Arguments.build_root is not None:
     ENV['BUILD_ROOT'] = Arguments.build_root
-    # If running from build root, assume build root is in repo directory tree
-    repo_root = dirname(Arguments.build_root)
 else:
     # Assume the build root is the same directory tree as the test location.
     ENV['BUILD_ROOT'] = repo_root

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -116,7 +116,7 @@ Variables.VerifierBinPath = ENV['VERIFIER_BIN']
 Variables.BuildRoot = ENV['BUILD_ROOT']
 Variables.RepoDir = repo_root
 Variables.AtsTestPluginsDir = os.path.join(Variables.BuildRoot, 'tests', 'tools', 'plugins', '.libs')
-Variables.AtsBuildGoldTestsDir = os.path.join(Variables.BuildRoot, 'tests', 'gold_tests_filtered')
+Variables.AtsBuildGoldTestsDir = os.path.join(Variables.BuildRoot, 'tests', 'gold_tests')
 Variables.CurlUds = Arguments.curl_uds
 
 # modify delay times as we always have to kill Trafficserver

--- a/tests/gold_tests/autest-site/setup.cli.ext
+++ b/tests/gold_tests/autest-site/setup.cli.ext
@@ -34,6 +34,8 @@ if Arguments.ats_bin is not None:
 
 if Arguments.build_root is not None:
     ENV['BUILD_ROOT'] = Arguments.build_root
+    # If running from build root, assume build root is in repo directory tree
+    repo_root = dirname(Arguments.build_root)
 else:
     # Assume the build root is the same directory tree as the test location.
     ENV['BUILD_ROOT'] = repo_root

--- a/tests/gold_tests/basic/copy_config.test.py
+++ b/tests/gold_tests/basic/copy_config.test.py
@@ -44,7 +44,7 @@ t.StillRunningAfter += ts2
 
 # setup a testrun
 t = Test.AddTestRun("Talk to ts2")
-t.MakeCurlCommandMulti("{{curl_base}} 127.0.0.1:{port}".format(port=ts2.Variables.port))
+t.MakeCurlCommandMulti("{{curl_base}} 127.0.0.1:{port}".format(port=ts2.Variables.port), ts=ts2)
 t.ReturnCode = 0
 t.StillRunningAfter = ts1
 t.StillRunningAfter += ts2

--- a/tests/gold_tests/bigobj/bigobj.test.py
+++ b/tests/gold_tests/bigobj/bigobj.test.py
@@ -87,19 +87,19 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression("Content-length: 1
 
 if not Condition.CurlUsingUnixDomainSocket():
     tr = Test.AddTestRun("GET bigobj: TLS, HTTP/1.1, IPv4")
-    tr.MakeCurlCommand(f'--verbose --ipv4 --http1.1 --insecure https://localhost:{ts.Variables.ssl_port}/bigobj')
+    tr.MakeCurlCommand(f'--verbose --ipv4 --http1.1 --insecure https://localhost:{ts.Variables.ssl_port}/bigobj', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 200 OK", "Should fetch pushed object")
     tr.Processes.Default.Streams.All = Testers.ContainsExpression("Content-length: 102400", "Content size should be accurate")
 
     tr = Test.AddTestRun("GET bigobj: TLS, HTTP/2, IPv4")
-    tr.MakeCurlCommand(f'--verbose --ipv4 --http2 --insecure https://localhost:{ts.Variables.ssl_port}/bigobj')
+    tr.MakeCurlCommand(f'--verbose --ipv4 --http2 --insecure https://localhost:{ts.Variables.ssl_port}/bigobj', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Should fetch pushed object")
     tr.Processes.Default.Streams.All = Testers.ContainsExpression("content-length: 102400", "Content size should be accurate")
 
     tr = Test.AddTestRun("GET bigobj: TLS, HTTP/2, IPv6")
-    tr.MakeCurlCommand(f'--verbose --ipv6 --http2 --insecure https://localhost:{ts.Variables.ssl_portv6}/bigobj')
+    tr.MakeCurlCommand(f'--verbose --ipv6 --http2 --insecure https://localhost:{ts.Variables.ssl_portv6}/bigobj', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Should fetch pushed object")
     tr.Processes.Default.Streams.All = Testers.ContainsExpression("content-length: 102400", "Content size should be accurate")

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -100,7 +100,7 @@ Test.Setup.Copy(os.path.join(Test.Variables.AtsBuildGoldTestsDir, 'chunked_encod
 tr = Test.AddTestRun()
 tr.TimeOut = 5
 if Condition.CurlUsingUnixDomainSocket():
-    tr.MakeCurlCommand('--http1.1 -H "Host: www.example.com" "http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port))
+    tr.MakeCurlCommand('--http1.1 -H "Host: www.example.com" "http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 else:
     tr.MakeCurlCommand('--http1.1 --proxy 127.0.0.1:{0} http://www.example.com --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
@@ -122,7 +122,8 @@ if not Condition.CurlUsingUnixDomainSocket():
     tr.TimeOut = 5
     tr.MakeCurlCommand(
         '--http2 -k https://127.0.0.1:{0} --verbose -H "Host: www.anotherexample.com" -d "Knock knock"'.format(
-            ts.Variables.ssl_port))
+            ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.Processes.Default.Streams.stderr = "gold/h2_chunked_POST_200.gold"
 

--- a/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding_h2.test.py
@@ -84,7 +84,8 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server2)
 tr.MakeCurlCommand(
     '--http2 -k https://127.0.0.1:{}/post-full --verbose -H "Transfer-encoding: chunked" -d "Knock knock"'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Request should succeed")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("< content-length:", "Response should include content length")
@@ -99,7 +100,8 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server3)
 tr.MakeCurlCommand(
     '--http2 -k https://127.0.0.1:{}/post-chunked --verbose -H "Transfer-encoding: chunked" -d "Knock knock"'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 200", "Request should succeed")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("< content-length:", "Response should not include content length")

--- a/tests/gold_tests/continuations/double_h2.test.py
+++ b/tests/gold_tests/continuations/double_h2.test.py
@@ -81,7 +81,7 @@ tr = Test.AddTestRun()
 # Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCurlCommands.
 # On Fedora 28/29, it seems that curl will occasionally timeout after a couple seconds and return exitcode 2
 # Examining the packet capture shows that Traffic Server dutifully sends the response
-ps = tr.SpawnCurlCommands(cmdstr=cmd, count=numberOfRequests, retcode=Any(0, 2))
+ps = tr.SpawnCurlCommands(cmdstr=cmd, count=numberOfRequests, retcode=Any(0, 2), ts=ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = Any(0, 2)
 

--- a/tests/gold_tests/continuations/openclose_h2.test.py
+++ b/tests/gold_tests/continuations/openclose_h2.test.py
@@ -68,7 +68,7 @@ tr = Test.AddTestRun()
 # Create a bunch of curl commands to be executed in parallel. Default.Process is set in SpawnCurlCommands.
 # On Fedora 28/29, it seems that curl will occasionally timeout after a couple seconds and return exitcode 2
 # Examining the packet capture shows that Traffic Server dutifully sends the response
-ps = tr.SpawnCurlCommands(cmdstr=cmd, count=numberOfRequests, retcode=Any(0, 2))
+ps = tr.SpawnCurlCommands(cmdstr=cmd, count=numberOfRequests, retcode=Any(0, 2), ts=ts)
 tr.Processes.Default.Env = ts.Env
 tr.Processes.Default.ReturnCode = Any(0, 2)
 

--- a/tests/gold_tests/continuations/session_id.test.py
+++ b/tests/gold_tests/continuations/session_id.test.py
@@ -82,7 +82,7 @@ tr.StillRunningAfter = server
 if not Condition.CurlUsingUnixDomainSocket():
     tr = Test.AddTestRun("Perform HTTP/2 transactions")
     cmd = '-v -k --http2 -H "host:example.com" https://127.0.0.1:{0}'.format(ts.Variables.ssl_port)
-    ps = tr.SpawnCurlCommands(cmdstr=cmd, count=numberOfRequests, retcode=Any(0, 2))
+    ps = tr.SpawnCurlCommands(cmdstr=cmd, count=numberOfRequests, retcode=Any(0, 2), ts=ts)
     tr.Processes.Default.Env = ts.Env
     tr.Processes.Default.ReturnCode = Any(0, 2)
 

--- a/tests/gold_tests/cripts/cripts.test.py
+++ b/tests/gold_tests/cripts/cripts.test.py
@@ -95,8 +95,8 @@ class CriptsBasicTest:
     def runCertsTest(self):
         tr = Test.AddTestRun('Exercise Cripts certificate introspection.')
         tr.MakeCurlCommand(
-            f'-v --http1.1 -k -H "Host: www.example.com:{self.ts.Variables.ssl_port}" https://127.0.0.1:{self.ts.Variables.ssl_port}'
-        )
+            f'-v --http1.1 -k -H "Host: www.example.com:{self.ts.Variables.ssl_port}" https://127.0.0.1:{self.ts.Variables.ssl_port}',
+            ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stderr = "gold/certs_cript.gold"
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/forward_proxy/forward_proxy.test.py
+++ b/tests/gold_tests/forward_proxy/forward_proxy.test.py
@@ -85,7 +85,8 @@ class ForwardProxyTest:
         tr.MakeCurlCommand(
             f'--proxy-insecure -v -H "uuid: 1" '
             f'--proxy "https://127.0.0.1:{self.ts.Variables.ssl_port}/" '
-            f'http://example.com/')
+            f'http://example.com/',
+            ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.StillRunningAfter = self.server
         tr.StillRunningAfter = self.ts

--- a/tests/gold_tests/h2/h2disable.test.py
+++ b/tests/gold_tests/h2/h2disable.test.py
@@ -58,7 +58,7 @@ ts.Disk.sni_yaml.AddLines([
 ])
 
 tr = Test.AddTestRun("Negotiate-h2")
-tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -70,7 +70,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
-tr2.MakeCurlCommand("-v -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
@@ -80,7 +80,7 @@ tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
-tr2.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5

--- a/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2disable_no_accept_threads.test.py
@@ -58,7 +58,7 @@ ts.Disk.sni_yaml.AddLines([
 ])
 
 tr = Test.AddTestRun("Negotiate-h2")
-tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -70,7 +70,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?2
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
-tr2.MakeCurlCommand("-v -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
@@ -80,7 +80,7 @@ tr2.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do not negotiate h2")
-tr2.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5

--- a/tests/gold_tests/h2/h2enable.test.py
+++ b/tests/gold_tests/h2/h2enable.test.py
@@ -58,7 +58,7 @@ ts.Disk.sni_yaml.AddLines([
 ])
 
 tr = Test.AddTestRun("Do-not-Negotiate-h2")
-tr.MakeCurlCommand("-v -k --ipv4 --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k --ipv4 --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -70,7 +70,7 @@ tr.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2
 tr.TimeOut = 10
 
 tr2 = Test.AddTestRun("Do negotiate h2")
-tr2.MakeCurlCommand("-v -k --ipv4 --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --ipv4 --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 10
@@ -80,7 +80,8 @@ tr2.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?
 tr2.TimeOut = 10
 
 tr2 = Test.AddTestRun("Do negotiate h2")
-tr2.MakeCurlCommand("-v -k --ipv4 --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand(
+    "-v -k --ipv4 --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 10

--- a/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
+++ b/tests/gold_tests/h2/h2enable_no_accept_threads.test.py
@@ -58,7 +58,7 @@ ts.Disk.sni_yaml.AddLines([
 ])
 
 tr = Test.AddTestRun("Do-not-Negotiate-h2")
-tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -70,7 +70,7 @@ tr.Processes.Default.Streams.All += Testers.ExcludesExpression("[Uu]sing HTTP/?2
 tr.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do negotiate h2")
-tr2.MakeCurlCommand("-v -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5
@@ -80,7 +80,7 @@ tr2.Processes.Default.Streams.All += Testers.ContainsExpression("[Uu]sing HTTP/?
 tr2.TimeOut = 5
 
 tr2 = Test.AddTestRun("Do negotiate h2")
-tr2.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.Processes.Default.TimeOut = 5

--- a/tests/gold_tests/h2/http2.test.py
+++ b/tests/gold_tests/h2/http2.test.py
@@ -203,7 +203,8 @@ tr.StillRunningAfter = server
 # on the post body
 tr = Test.AddTestRun("post with chunked body")
 tr.MakeCurlCommand(
-    '-s -k -H "Transfer-Encoding: chunked" -d "{0}" https://127.0.0.1:{1}/postchunked'.format(post_body, ts.Variables.ssl_port))
+    '-s -k -H "Transfer-Encoding: chunked" -d "{0}" https://127.0.0.1:{1}/postchunked'.format(post_body, ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/post_chunked.gold"
 tr.StillRunningAfter = server
@@ -213,7 +214,8 @@ tr.StillRunningAfter = server
 # on the post body
 tr = Test.AddTestRun("post with big chunked body")
 tr.MakeCurlCommand(
-    '-s -k -H "Transfer-Encoding: chunked" -d @big_post_body https://127.0.0.1:{0}/bigpostchunked'.format(ts.Variables.ssl_port))
+    '-s -k -H "Transfer-Encoding: chunked" -d @big_post_body https://127.0.0.1:{0}/bigpostchunked'.format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = "gold/post_chunked.gold"
 tr.StillRunningAfter = server
@@ -223,7 +225,7 @@ tr = Test.AddTestRun("huge response header")
 # Different versions of curl have "bytes data" at various places in the output.
 # Normalize them by simply filtering out those lines since they are not
 # important to this test.
-tr.MakeCurlCommand(f'-vs -k --http2 https://127.0.0.1:{ts.Variables.ssl_port}/huge_resp_hdrs |& grep -v "bytes data"')
+tr.MakeCurlCommand(f'-vs -k --http2 https://127.0.0.1:{ts.Variables.ssl_port}/huge_resp_hdrs |& grep -v "bytes data"', ts=ts)
 tr.Processes.Default.ReturnCode = 0
 # Different versions of curl will have different cases for HTTP/2 field names.
 tr.Processes.Default.Streams.stdout = Testers.GoldFile("gold/http2_8_stdout.gold", case_insensitive=True)
@@ -231,7 +233,7 @@ tr.StillRunningAfter = server
 
 # Test Case 9: Header Only Response - e.g. 204
 tr = Test.AddTestRun("header only response")
-tr.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/status/204'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/status/204'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/http2_9_stdout.gold"
 # Different versions of curl will have different cases for HTTP/2 field names.

--- a/tests/gold_tests/h2/http2_priority.test.py
+++ b/tests/gold_tests/h2/http2_priority.test.py
@@ -69,7 +69,7 @@ ts.Disk.records_config.update(
 
 # Test Case 0:
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/bigfile | cksum'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/bigfile | cksum'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.TimeOut = 5
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Port))

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -81,7 +81,7 @@ json_printer = f'''
 
 # Test Case 0: Basic request and response
 test_run = Test.AddTestRun()
-test_run.MakeCurlCommand("-vs -k --http2 https://127.0.0.1:{0}/get | {1}".format(ts.Variables.ssl_port, json_printer))
+test_run.MakeCurlCommand("-vs -k --http2 https://127.0.0.1:{0}/get | {1}".format(ts.Variables.ssl_port, json_printer), ts=ts)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
 test_run.Processes.Default.StartBefore(Test.Processes.ts)
@@ -93,7 +93,7 @@ test_run.StillRunningAfter = httpbin
 # Test Case 1: Attempt an empty response body.
 # This test case requires go-httpbin@v2.6.0 or later.
 test_run = Test.AddTestRun()
-test_run.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/bytes/0'.format(ts.Variables.ssl_port))
+test_run.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/bytes/0'.format(ts.Variables.ssl_port), ts=ts)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_1_stdout.gold"
 # Different versions of curl will have different cases for HTTP/2 field names.
@@ -102,7 +102,8 @@ test_run.StillRunningAfter = httpbin
 
 # Test Case 2: Chunked
 test_run = Test.AddTestRun()
-test_run.MakeCurlCommand('-vs -k --http2 https://127.0.0.1:{0}/stream-bytes/102400?seed=0 | cksum'.format(ts.Variables.ssl_port))
+test_run.MakeCurlCommand(
+    '-vs -k --http2 https://127.0.0.1:{0}/stream-bytes/102400?seed=0 | cksum'.format(ts.Variables.ssl_port), ts=ts)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_2_stdout.gold"
 # Different versions of curl will have different cases for HTTP/2 field names.
@@ -113,7 +114,8 @@ test_run.StillRunningAfter = httpbin
 test_run = Test.AddTestRun()
 test_run.MakeCurlCommand(
     "-vs -k --http2 https://127.0.0.1:{0}/post --data 'key=value' -H 'Expect: 100-continue' --max-time 5 | {1}".format(
-        ts.Variables.ssl_port, json_printer))
+        ts.Variables.ssl_port, json_printer),
+    ts=ts)
 test_run.Processes.Default.ReturnCode = 0
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_3_stdout.gold"
 # Different versions of curl will have different cases for HTTP/2 field names.

--- a/tests/gold_tests/headers/accept_webp.test.py
+++ b/tests/gold_tests/headers/accept_webp.test.py
@@ -61,7 +61,8 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.MakeCurlCommand(
     '-s -D - -v --ipv4 --http1.1 -H "Accept: image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5" -H "Host: www.example.com" http://localhost:{0}/'
-    .format(ts.Variables.port))
+    .format(ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/accept_webp.gold"
 tr.StillRunningAfter = ts
@@ -70,7 +71,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '-s -D - -v --ipv4 --http1.1 -H "Accept: image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5" -H "Host: www.example.com" http://localhost:{0}/'
-    .format(ts.Variables.port))
+    .format(ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/accept_webp_cache.gold"
 tr.StillRunningAfter = ts
@@ -79,7 +81,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '-s -D - -v --ipv4 --http1.1 -H "Accept: image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5" -H "Host: www.example.com" http://localhost:{0}/'
-    .format(ts.Variables.port))
+    .format(ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/accept_webp_jpeg.gold"
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/headers/cache_and_req_body.test.py
+++ b/tests/gold_tests/headers/cache_and_req_body.test.py
@@ -126,7 +126,8 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
 tr.MakeCurlCommand(
     '-s -D - -v --ipv4 --http1.1 -H "x-debug: x-cache,x-cache-key,via" -H "Host: www.example.com" http://localhost:{port}/'.format(
-        port=ts.Variables.port))
+        port=ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.CurlHeader(cache_and_req_body_miss)
 tr.StillRunningAfter = ts
@@ -135,7 +136,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '-s -D - -v --ipv4 --http1.1 -H "x-debug: x-cache,x-cache-key,via" -H "Host: www.example.com" http://localhost:{}'.format(
-        ts.Variables.port))
+        ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.CurlHeader(cache_and_req_body_hit)
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/headers/cachedIMSRange.test.py
+++ b/tests/gold_tests/headers/cachedIMSRange.test.py
@@ -187,14 +187,14 @@ tr.StillRunningAfter = server
 if not Condition.CurlUsingUnixDomainSocket():
     # Test 4 - Test 304 response served from a regex-remap rule with HTTPS.
     tr = Test.AddTestRun()
-    tr.MakeCurlCommand(f'-vs -k https://127.0.0.1:{ts.Variables.ssl_port}/ -H "Host: {default_304_host}"')
+    tr.MakeCurlCommand(f'-vs -k https://127.0.0.1:{ts.Variables.ssl_port}/ -H "Host: {default_304_host}"', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.Processes.Default.Streams.All = Testers.GoldFile("gold/http1_304.gold", case_insensitive=True)
     tr.StillRunningAfter = server
 
     # Test 5 - Test 304 response served from a regex-remap rule with HTTP/2.
     tr = Test.AddTestRun()
-    tr.MakeCurlCommand(f'-vs -k --http2 https://127.0.0.1:{ts.Variables.ssl_port}/ -H "Host: {default_304_host}"')
+    tr.MakeCurlCommand(f'-vs -k --http2 https://127.0.0.1:{ts.Variables.ssl_port}/ -H "Host: {default_304_host}"', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.Processes.Default.Streams.All = Testers.GoldFile("gold/http2_304.gold", case_insensitive=True)
     tr.StillRunningAfter = server

--- a/tests/gold_tests/headers/forwarded.test.py
+++ b/tests/gold_tests/headers/forwarded.test.py
@@ -151,14 +151,14 @@ tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.Po
 # Delay on readiness of our ssl ports
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 #
-tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts.Variables.port))
+tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 
 def TestHttp1_1(host):
 
     tr = Test.AddTestRun()
-    tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://{}'.format(ts.Variables.port, host))
+    tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://{}'.format(ts.Variables.port, host), ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
 
@@ -201,7 +201,7 @@ tr = Test.AddTestRun()
 # Delay on readiness of our ssl ports
 tr.Processes.Default.StartBefore(Test.Processes.ts2)
 #
-tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port))
+tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port), ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 # Call traffic_ctrl to set insert_forwarded
@@ -217,41 +217,45 @@ tr.Processes.Default.ReturnCode = 0
 tr = Test.AddTestRun()
 # Delay to give traffic_ctl config change time to take effect.
 tr.DelayStart = 15
-tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port))
+tr.MakeCurlCommand('--verbose --ipv4 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port), ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 # HTTP 1.0
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--verbose --ipv4 --http1.0 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port))
+tr.MakeCurlCommand('--verbose --ipv4 --http1.0 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.port), ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 # HTTP 1.0 -- Forwarded headers already present
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     "--verbose -H 'forwarded:for=0.6.6.6' -H 'forwarded:for=_argh' --ipv4 --http1.0" +
-    " --proxy localhost:{} http://www.no-oride.com".format(ts2.Variables.port))
+    " --proxy localhost:{} http://www.no-oride.com".format(ts2.Variables.port),
+    ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 # HTTP 2
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '--verbose --ipv4 --http2 --insecure --header "Host: www.no-oride.com"' +
-    ' https://localhost:{}'.format(ts2.Variables.ssl_port))
+    ' https://localhost:{}'.format(ts2.Variables.ssl_port),
+    ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 # TLS
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
-    '--verbose --ipv4 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'.format(ts2.Variables.ssl_port))
+    '--verbose --ipv4 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'.format(ts2.Variables.ssl_port),
+    ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 # IPv6
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--verbose --ipv6 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.portv6))
+tr.MakeCurlCommand('--verbose --ipv6 --http1.1 --proxy localhost:{} http://www.no-oride.com'.format(ts2.Variables.portv6), ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
-    '--verbose --ipv6 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'.format(ts2.Variables.ssl_portv6))
+    '--verbose --ipv6 --http1.1 --insecure --header "Host: www.no-oride.com" https://localhost:{}'.format(ts2.Variables.ssl_portv6),
+    ts=ts2)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/headers/hsts.test.py
+++ b/tests/gold_tests/headers/hsts.test.py
@@ -55,7 +55,8 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.MakeCurlCommand(
     '-s -D - --verbose --ipv4 --http1.1 --insecure --header "Host: {0}" https://localhost:{1}'.format(
-        'www.example.com', ts.Variables.ssl_port))
+        'www.example.com', ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "hsts.200.gold"
 tr.StillRunningAfter = ts
@@ -64,7 +65,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '-s -D - --verbose --ipv4 --http1.1 --insecure --header "Host: {0}" https://localhost:{1}'.format(
-        'bad_host', ts.Variables.ssl_port))
+        'bad_host', ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "hsts.404.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/headers/via.test.py
+++ b/tests/gold_tests/headers/via.test.py
@@ -101,7 +101,8 @@ if not Condition.CurlUsingUnixDomainSocket():
     # HTTP 2
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
-        '--verbose --ipv4 --http2 --insecure --header "Host: www.example.com" https://localhost:{}'.format(ts.Variables.ssl_port))
+        '--verbose --ipv4 --http2 --insecure --header "Host: www.example.com" https://localhost:{}'.format(ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
     tr.StillRunningAfter = server
@@ -112,7 +113,8 @@ if not Condition.CurlUsingUnixDomainSocket():
         tr = Test.AddTestRun()
         tr.MakeCurlCommand(
             '--verbose --ipv4 --http3 --insecure --header "Host: www.example.com" https://localhost:{}'.format(
-                ts.Variables.ssl_port))
+                ts.Variables.ssl_port),
+            ts=ts)
         tr.Processes.Default.ReturnCode = 0
         tr.StillRunningAfter = server
         tr.StillRunningAfter = ts
@@ -120,7 +122,8 @@ if not Condition.CurlUsingUnixDomainSocket():
     # TLS
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
-        '--verbose --ipv4 --http1.1 --insecure --header "Host: www.example.com" https://localhost:{}'.format(ts.Variables.ssl_port))
+        '--verbose --ipv4 --http1.1 --insecure --header "Host: www.example.com" https://localhost:{}'.format(ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
     tr.StillRunningAfter = server
@@ -138,7 +141,8 @@ if not Condition.CurlUsingUnixDomainSocket():
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
         '--verbose --ipv6 --http1.1 --insecure --header "Host: www.example.com" https://localhost:{}'.format(
-            ts.Variables.ssl_portv6))
+            ts.Variables.ssl_portv6),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
     tr.StillRunningAfter = server

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -141,7 +141,7 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.SSL_Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
-tr.MakeCurlCommand('--verbose -H "Host: www.example.com" http://localhost:{ts_port}/get'.format(ts_port=ts.Variables.port))
+tr.MakeCurlCommand('--verbose -H "Host: www.example.com" http://localhost:{ts_port}/get'.format(ts_port=ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = 'gold/200.gold'
 tr.StillRunningAfter = ts
@@ -152,7 +152,8 @@ tr.StillRunningAfter = server
 # not in the allowlist.
 #
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--verbose -X CONNECT -H "Host: localhost" http://localhost:{ts_port}/connect'.format(ts_port=ts.Variables.port))
+tr.MakeCurlCommand(
+    '--verbose -X CONNECT -H "Host: localhost" http://localhost:{ts_port}/connect'.format(ts_port=ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = 'gold/403.gold'
 tr.StillRunningAfter = ts
@@ -164,7 +165,8 @@ tr.StillRunningAfter = server
 #
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(
-    '--http2 --verbose -k -X PUSH -H "Host: localhost" https://localhost:{ts_port}/h2_push'.format(ts_port=ts.Variables.ssl_port))
+    '--http2 --verbose -k -X PUSH -H "Host: localhost" https://localhost:{ts_port}/h2_push'.format(ts_port=ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = 'gold/403_h2.gold'
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
+++ b/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
@@ -25,7 +25,7 @@ from string import Template
 Test.Summary = 'Test jsonrpc admin API'
 
 # set the schema folder.
-schema_folder = os.path.join(Test.Variables.RepoDir, "src", "mgmt", "rpc", "schema")
+schema_folder = os.path.join(Test.Variables.TestDirectory, '..', '..', '..', "src", "mgmt", "rpc", "schema")
 
 
 def substitute_context_in_file(process, file, context):

--- a/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
+++ b/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
@@ -25,7 +25,7 @@ from string import Template
 Test.Summary = 'Test jsonrpc admin API'
 
 # set the schema folder.
-schema_folder = os.path.join(Test.Variables.TestDirectory, '..', '..', '..', "src", "mgmt", "rpc", "schema")
+schema_folder = os.path.join(Test.TestDirectory, '..', '..', '..', "src", "mgmt", "rpc", "schema")
 
 
 def substitute_context_in_file(process, file, context):

--- a/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
+++ b/tests/gold_tests/jsonrpc/jsonrpc_api_schema.test.py
@@ -25,7 +25,7 @@ from string import Template
 Test.Summary = 'Test jsonrpc admin API'
 
 # set the schema folder.
-schema_folder = os.path.join(Test.TestDirectory, '..', '..', '..', "src", "mgmt", "rpc", "schema")
+schema_folder = os.path.join(Test.Variables.RepoDir, "src", "mgmt", "rpc", "schema")
 
 
 def substitute_context_in_file(process, file, context):

--- a/tests/gold_tests/logging/custom-log.test.py
+++ b/tests/gold_tests/logging/custom-log.test.py
@@ -51,36 +51,36 @@ Test.Disk.File(os.path.join(ts.Variables.LOGDIR, 'test_log_field.log'), exists=T
 
 # first test is a miss for default
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.1.1.1:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.1.1.1:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.2.2.2:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.2.2.2:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.3.3.3:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.3.3.3:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.3.0.1:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.3.0.1:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.43.2.1:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.43.2.1:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.213.213.132:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.213.213.132:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('"http://127.123.32.243:{0}" --verbose'.format(ts.Variables.port))
+tr.MakeCurlCommand('"http://127.123.32.243:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.

--- a/tests/gold_tests/logging/log_retention.test.py
+++ b/tests/gold_tests/logging/log_retention.test.py
@@ -65,7 +65,7 @@ class TestLogRetention:
         the caller doesn't have to.
         """
         tr = Test.AddTestRun("Initialize processes for ts{}".format(TestLogRetention.__ts_counter - 1))
-        tr.MakeCurlCommand(self.get_curl_command())
+        tr.MakeCurlCommand(self.get_curl_command(), ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         if not TestLogRetention.__server_is_started:
             self.server.StartBefore(self.ts)
@@ -189,7 +189,7 @@ test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_deletion.log_{specified_hostname}.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 
 test.tr.StillRunningAfter = test.ts
@@ -231,7 +231,7 @@ test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_deletion.log_{specified_hostname}.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed")
 
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
@@ -258,7 +258,7 @@ test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
 test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "The rolled logfile.*test_log_interface.log_.*was auto-deleted.*bytes were reclaimed", "Verify that space was reclaimed")
 
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
@@ -319,7 +319,7 @@ test.ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     f"The rolled logfile.*test_high_priority_deletion.log_{hostname}.*was auto-deleted.*bytes were reclaimed",
     "Verify that space was reclaimed from test_high_priority_deletion")
 
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
@@ -351,7 +351,7 @@ test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
 
 # This test doesn't require a log rotation. We just verify that the logs communicate
 # the appropriate min_count values above.
-test.tr.MakeCurlCommand(test.get_curl_command())
+test.tr.MakeCurlCommand(test.get_curl_command(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
@@ -398,7 +398,7 @@ test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
 test.ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
     "The rolled logfile.*test_deletion.log_.*was auto-deleted.*bytes were reclaimed", "Verify that space was reclaimed")
 
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
@@ -435,7 +435,7 @@ logging:
 test.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
     "rolled logfile.*test_deletion.log.*old.* was auto-deleted", "Verify test_deletion.log was trimmed")
 
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_thrice())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_thrice(), ts=test.ts)
 test.tr.Processes.Default.ReturnCode = 0
 test.tr.StillRunningAfter = test.ts
 test.tr.StillRunningAfter = test.server
@@ -488,7 +488,7 @@ tr.StillRunningAfter = test.ts
 tr.StillRunningAfter = test.server
 
 tr = Test.AddTestRun("Get the log to rotate.")
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once())
+test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = test.ts
 tr.StillRunningAfter = test.server

--- a/tests/gold_tests/logging/new_log_flds.test.py
+++ b/tests/gold_tests/logging/new_log_flds.test.py
@@ -84,14 +84,16 @@ tr.Processes.Default.ReturnCode = 0
 
 if not Condition.CurlUsingUnixDomainSocket():
     tr = Test.AddTestRun()
-    tr.MakeCurlCommand('"https://127.0.0.1:{0}" "https://127.0.0.1:{0}" --http2 --insecure --verbose'.format(ts.Variables.ssl_port))
+    tr.MakeCurlCommand(
+        '"https://127.0.0.1:{0}" "https://127.0.0.1:{0}" --http2 --insecure --verbose'.format(ts.Variables.ssl_port), ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
         (
             '"https://reallyreallyreallyreallylong.com:{0}" --http2 --insecure --verbose' +
-            ' --resolve reallyreallyreallyreallylong.com:{0}:127.0.0.1').format(ts.Variables.ssl_port))
+            ' --resolve reallyreallyreallyreallylong.com:{0}:127.0.0.1').format(ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
 # Wait for log file to appear, then wait one extra second to make sure TS is done writing it.

--- a/tests/gold_tests/parent_proxy/parent-retry.test.py
+++ b/tests/gold_tests/parent_proxy/parent-retry.test.py
@@ -40,7 +40,7 @@ class ParentRetryTest:
     def run(self):
         tr = Test.AddTestRun()
         tr.Processes.Default.StartBefore(self.ts_child)
-        tr.MakeCurlCommand(f'"{self.ts_child.Variables.port}" --verbose')
+        tr.MakeCurlCommand(f'"{self.ts_child.Variables.port}" --verbose', ts=self.ts_child)
         tr.StillRunningAfter = self.ts_child
 
 

--- a/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
+++ b/tests/gold_tests/pluginTest/cert_update/cert_update.test.py
@@ -79,7 +79,8 @@ Test.PrepareInstalledPlugin('cert_update.so', ts)
 tr = Test.AddTestRun("Server-Cert-Pre")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.MakeCurlCommand('--verbose --insecure --ipv4 --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--verbose --insecure --ipv4 --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.Streams.stderr = "gold/server-cert-pre.gold"
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
@@ -96,7 +97,8 @@ ts.StillRunningAfter = server
 # after use traffic_ctl to update server cert, curl should see bar.com cert from bob
 tr = Test.AddTestRun("Server-Cert-After")
 tr.Processes.Default.Env = ts.Env
-tr.MakeCurlCommand('--verbose --insecure --ipv4 --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--verbose --insecure --ipv4 --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.Streams.stderr = "gold/server-cert-after.gold"
 tr.Processes.Default.ReturnCode = 0
 ts.StillRunningAfter = server
@@ -108,7 +110,7 @@ s_server = tr.Processes.Process(
     "s_server", "openssl s_server -www -key {0}/server1.pem -cert {0}/server1.pem -accept {1} -Verify 1 -msg".format(
         ts.Variables.SSLDir, ts.Variables.s_server_port))
 s_server.Ready = When.PortReady(ts.Variables.s_server_port)
-tr.MakeCurlCommand('--verbose --insecure --ipv4 --header "Host: foo.com" https://localhost:{}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('--verbose --insecure --ipv4 --header "Host: foo.com" https://localhost:{}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.StartBefore(s_server)
 s_server.Streams.all = "gold/client-cert-pre.gold"
 tr.Processes.Default.ReturnCode = 0
@@ -132,7 +134,8 @@ s_server = tr.Processes.Process(
 s_server.Ready = When.PortReady(ts.Variables.s_server_port)
 tr.Processes.Default.Env = ts.Env
 # Move client2.pem to replace client1.pem since cert path matters in client context mapping
-tr.MakeCurlCommand('--verbose --insecure --ipv4 --header "Host: foo.com" https://localhost:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--verbose --insecure --ipv4 --header "Host: foo.com" https://localhost:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.StartBefore(s_server)
 s_server.Streams.all = "gold/client-cert-after.gold"
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/esi/esi_nested_include.test.py
+++ b/tests/gold_tests/pluginTest/esi/esi_nested_include.test.py
@@ -120,7 +120,8 @@ class EsiTest():
         tr = Test.AddTestRun("First request")
         tr.MakeCurlCommand(
             f'http://127.0.0.1:{self._ts.Variables.port}/main.php -H"Host: www.example.com" '
-            '-H"Accept: */*" --verbose')
+            '-H"Accept: */*" --verbose',
+            ts=self._ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout = "gold/nested_include_body.gold"
         tr.StillRunningAfter = self._server

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_url.test.py
@@ -92,7 +92,8 @@ tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '--proxy 127.0.0.1:{0} "http://www.example.com/from_path/hrw-sets.png" '
     '-H "Proxy-Connection: keep-alive" -H "X-Testing: foo,bar" '
-    '--verbose'.format(ts.Variables.port))
+    '--verbose'.format(ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/ext-sets.gold"
 tr.StillRunningAfter = server
@@ -103,7 +104,8 @@ tr = Test.AddTestRun()
 tr.MakeCurlCommand(
     '--proxy 127.0.0.1:{0} "http://www.example.com/from_path/hrw-sets.png" '
     '-H "Proxy-Connection: keep-alive" -H "X-Testing: elif" '
-    '--verbose'.format(ts.Variables.port))
+    '--verbose'.format(ts.Variables.port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/cond-elif.gold"
 tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/healthchecks/healthchecks.test.py
+++ b/tests/gold_tests/pluginTest/healthchecks/healthchecks.test.py
@@ -88,7 +88,7 @@ class TestFileChangeBehavior:
         self._positive_hc_counter += 1
         counter = self._positive_hc_counter
         tr = Test.AddTestRun(f'Positive acme healthchecks: {counter}')
-        tr.MakeCurlCommand(f'-v http://127.0.0.1:{self._ts.Variables.port}/acme')
+        tr.MakeCurlCommand(f'-v http://127.0.0.1:{self._ts.Variables.port}/acme', ts=self._ts)
         curl_acme = tr.Processes.Default
         if not self._ts_started:
             curl_acme.StartBefore(self._ts)
@@ -97,7 +97,7 @@ class TestFileChangeBehavior:
 
         # Repeat for acme-ssl
         tr2 = Test.AddTestRun(f'Positive acme-ssl healthchecks: {counter}')
-        tr2.MakeCurlCommand(f'-kv https://127.0.0.1:{self._ts.Variables.ssl_port}/acme-ssl')
+        tr2.MakeCurlCommand(f'-kv https://127.0.0.1:{self._ts.Variables.ssl_port}/acme-ssl', ts=self._ts)
         curl_acme_ssl = tr2.Processes.Default
         if not self._ts_started:
             curl_acme_ssl.StartBefore(self._ts)
@@ -118,7 +118,7 @@ class TestFileChangeBehavior:
         :return: None
         '''
         tr = Test.AddTestRun('Expect 200 for acme after acme-ssl removal')
-        tr.MakeCurlCommand(f'-v http://127.0.0.1:{self._ts.Variables.port}/acme')
+        tr.MakeCurlCommand(f'-v http://127.0.0.1:{self._ts.Variables.port}/acme', ts=self._ts)
         curl_acme = tr.Processes.Default
         if not self._ts_started:
             curl_acme.StartBefore(self._ts)
@@ -126,7 +126,7 @@ class TestFileChangeBehavior:
         curl_acme.Streams.All += Testers.ContainsExpression('HTTP/1.1 200', 'Verify 200 response for /acme after acme-ssl removal')
 
         tr2 = Test.AddTestRun('Expect 404 for acme-ssl after removal')
-        tr2.MakeCurlCommand(f'-kv https://127.0.0.1:{self._ts.Variables.ssl_port}/acme-ssl')
+        tr2.MakeCurlCommand(f'-kv https://127.0.0.1:{self._ts.Variables.ssl_port}/acme-ssl', ts=self._ts)
         curl_acme_ssl = tr2.Processes.Default
         if not self._ts_started:
             curl_acme_ssl.StartBefore(self._ts)

--- a/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.test.py
@@ -145,7 +145,7 @@ class TestJA4Fingerprint:
                  'then a JA4 header should be attached.')
 def test1(params: TestParams) -> None:
     client = params['tr'].Processes.Default
-    params['tr'].MakeCurlCommand('-k -v "https://localhost:{0}/resource"'.format(params['port_one']))
+    params['tr'].MakeCurlCommand('-k -v "https://localhost:{0}/resource"'.format(params['port_one']), ts=params['ts'])
 
     client.ReturnCode = 0
     client.Streams.stdout += Testers.ContainsExpression(r'Yay!', 'We should receive the expected body.')

--- a/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
+++ b/tests/gold_tests/pluginTest/sslheaders/sslheaders.test.py
@@ -67,5 +67,6 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.MakeCurlCommand(
     '-H "SSL-Client-ID: My Fake Client ID" --verbose --ipv4 --insecure --header "Host: bar.com"' +
-    ' https://localhost:{}'.format(ts.Variables.ssl_port))
+    ' https://localhost:{}'.format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/stats_over_http/stats_over_http.test.py
+++ b/tests/gold_tests/pluginTest/stats_over_http/stats_over_http.test.py
@@ -78,7 +78,7 @@ class StatsOverHttpPluginTest:
     def __testCaseAcceptCSV(self):
         tr = Test.AddTestRun('Fetch stats over HTTP in CSV format')
         self.__checkProcessBefore(tr)
-        tr.MakeCurlCommand(f"-vs -H'Accept: text/csv' --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats")
+        tr.MakeCurlCommand(f"-vs -H'Accept: text/csv' --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats", ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             'proxy.process.http.delete_requests,0', 'Output should be CSV formatted.')
@@ -89,7 +89,8 @@ class StatsOverHttpPluginTest:
     def __testCaseAcceptPrometheus(self):
         tr = Test.AddTestRun('Fetch stats over HTTP in Prometheus format')
         self.__checkProcessBefore(tr)
-        tr.MakeCurlCommand(f"-vs -H'Accept: text/plain; version=0.0.4' --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats")
+        tr.MakeCurlCommand(
+            f"-vs -H'Accept: text/plain; version=0.0.4' --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats", ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             'proxy_process_http_delete_requests 0', 'Output should be Prometheus formatted.')
@@ -100,7 +101,7 @@ class StatsOverHttpPluginTest:
     def __testCasePathJSON(self):
         tr = Test.AddTestRun('Fetch stats over HTTP in JSON format via /_stats/json')
         self.__checkProcessBefore(tr)
-        tr.MakeCurlCommand(f"-vs --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/json")
+        tr.MakeCurlCommand(f"-vs --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/json", ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('{ "global": {', 'JSON header expected.')
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
@@ -112,7 +113,7 @@ class StatsOverHttpPluginTest:
     def __testCasePathCSV(self):
         tr = Test.AddTestRun('Fetch stats over HTTP in CSV format via /_stats/csv')
         self.__checkProcessBefore(tr)
-        tr.MakeCurlCommand(f"-vs --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/csv")
+        tr.MakeCurlCommand(f"-vs --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/csv", ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             'proxy.process.http.delete_requests,0', 'CSV output expected.')
@@ -123,7 +124,7 @@ class StatsOverHttpPluginTest:
     def __testCasePathPrometheus(self):
         tr = Test.AddTestRun('Fetch stats over HTTP in Prometheus format via /_stats/prometheus')
         self.__checkProcessBefore(tr)
-        tr.MakeCurlCommand(f"-vs --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/prometheus")
+        tr.MakeCurlCommand(f"-vs --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/prometheus", ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             'proxy_process_http_delete_requests 0', 'Prometheus output expected.')
@@ -134,7 +135,8 @@ class StatsOverHttpPluginTest:
     def __testCaseAcceptIgnoredIfPathExplicit(self):
         tr = Test.AddTestRun('Fetch stats over HTTP in Prometheus format with Accept csv header')
         self.__checkProcessBefore(tr)
-        tr.MakeCurlCommand(f"-vs -H'Accept: text/csv' --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/prometheus")
+        tr.MakeCurlCommand(
+            f"-vs -H'Accept: text/csv' --http1.1 http://127.0.0.1:{self.ts.Variables.port}/_stats/prometheus", ts=self.ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             'proxy_process_http_delete_requests 0', 'Prometheus output expected.')

--- a/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
+++ b/tests/gold_tests/pluginTest/test_hooks/test_hooks.test.py
@@ -71,12 +71,13 @@ tr.Processes.Default.ReturnCode = 0
 if not Condition.CurlUsingUnixDomainSocket():
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
-        '--verbose --ipv4 --http2 --insecure --header "Host: one" https://localhost:{0}/argh'.format(ts.Variables.ssl_port))
+        '--verbose --ipv4 --http2 --insecure --header "Host: one" https://localhost:{0}/argh'.format(ts.Variables.ssl_port), ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
-        '--verbose --ipv4 --http1.1 --insecure --header "Host: one" https://localhost:{0}/argh'.format(ts.Variables.ssl_port))
+        '--verbose --ipv4 --http1.1 --insecure --header "Host: one" https://localhost:{0}/argh'.format(ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
 # The probing of the ATS port to detect when ATS is ready may be seen by ATS as a VCONN start/close, so filter out these

--- a/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/tsapi.test.py
@@ -90,7 +90,8 @@ if not Condition.CurlUsingUnixDomainSocket():
     tr = Test.AddTestRun()
     tr.MakeCurlCommand(
         '--verbose --ipv4 --http2 --insecure --header ' +
-        '"Host: myhost.test:123" HttPs://LocalHost:{}/'.format(ts.Variables.ssl_port))
+        '"Host: myhost.test:123" HttPs://LocalHost:{}/'.format(ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun()

--- a/tests/gold_tests/post/post-continue.test.py
+++ b/tests/gold_tests/post/post-continue.test.py
@@ -76,7 +76,8 @@ test_run.Processes.Default.StartBefore(server)
 test_run.Processes.Default.StartBefore(ts)
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 continue", "Has Expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
@@ -87,7 +88,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 POST large body with Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 continue", "Has Expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
@@ -98,7 +100,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 POST small body w/o Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect:" -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 continue", "Does not have Expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect: 100-continue", "Does not have Expect header")
@@ -109,7 +112,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 POST large body w/o Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 continue", "Does not have Expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect: 100-continue", "Does not have Expect header")
@@ -120,7 +124,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST small body with Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
@@ -131,7 +136,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST large body with Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
@@ -142,7 +148,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST small body w/o Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: " -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
@@ -153,7 +160,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST large body w/o Expect header")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
@@ -166,7 +174,8 @@ test_run = Test.AddTestRun("http1.1 POST small body with Expect header, immediat
 test_run.Processes.Default.StartBefore(Test.Processes.ts2)
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 Continue", "Has Expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
@@ -177,7 +186,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 POST large body with Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 100 Continue", "Has Expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("Expect: 100-continue", "Has Expect header")
@@ -188,7 +198,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 POST small body w/o Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect:" -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 Continue", "Has Expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect 100-continue", "Has Expect header")
@@ -199,7 +210,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 POST large body w/o Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http1.1 -H "uuid: post" -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h1.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/1.1 100 Continue", "Has Expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("Expect 100-continue", "Has Expect header")
@@ -210,7 +222,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST small body with Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: 100-continue" -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
@@ -221,7 +234,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST large body with Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: 100-continue" -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/2 100", "Has Expect header")
@@ -232,7 +246,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST small body w/o Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: " -d "small body" -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")
@@ -243,7 +258,8 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http2 POST large body w/o Expect header, immediate")
 test_run.MakeCurlCommand(
     '-v -o /dev/null --http2 -H "uuid: post" -H "Expect: " -d @big_post_body -k https://127.0.0.1:{0}/post'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 test_run.Processes.Default.Streams.All = "gold/post-h2.gold"
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("xpect: 100-continue", "Has expect header")
 test_run.Processes.Default.Streams.All += Testers.ExcludesExpression("HTTP/2 100", "Has Expect header")

--- a/tests/gold_tests/post/post-early-return.test.py
+++ b/tests/gold_tests/post/post-early-return.test.py
@@ -84,7 +84,8 @@ big_post_body_file.close()
 test_run = Test.AddTestRun("http1.1 Post with small body early return")
 test_run.Processes.Default.StartBefore(Test.Processes.ts)
 test_run.Processes.Default.StartBefore(server1)
-test_run.MakeCurlCommand('-v -o /dev/null --http1.1 -d "small body" -k https://127.0.0.1:{}/one'.format(ts.Variables.ssl_port))
+test_run.MakeCurlCommand(
+    '-v -o /dev/null --http1.1 -d "small body" -k https://127.0.0.1:{}/one'.format(ts.Variables.ssl_port), ts=ts)
 test_run.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 420 Be Calm", "Receive the early response")
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
@@ -92,14 +93,15 @@ test_run.Processes.Default.ReturnCode = 0
 test_run = Test.AddTestRun("http1.1 Post with large body early return")
 test_run.Processes.Default.StartBefore(server2)
 test_run.MakeCurlCommand(
-    '-H "Expect:" -v -o /dev/null --http1.1 -d @big_post_body -k https://127.0.0.1:{}/two'.format(ts.Variables.ssl_port))
+    '-H "Expect:" -v -o /dev/null --http1.1 -d @big_post_body -k https://127.0.0.1:{}/two'.format(ts.Variables.ssl_port), ts=ts)
 test_run.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 420 Be Calm", "Receive the early response")
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0
 
 test_run = Test.AddTestRun("http2 Post with large body, small window and early return")
 test_run.Processes.Default.StartBefore(server3)
-test_run.MakeCurlCommand('-v -o /dev/null --http2 -d @big_post_body -k https://127.0.0.1:{}/three'.format(ts.Variables.ssl_port))
+test_run.MakeCurlCommand(
+    '-v -o /dev/null --http2 -d @big_post_body -k https://127.0.0.1:{}/three'.format(ts.Variables.ssl_port), ts=ts)
 test_run.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/2 420", "Receive the early response")
 test_run.StillRunningAfter = ts
 test_run.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
+++ b/tests/gold_tests/remap/basic_conf_remap_yaml.test.py
@@ -120,7 +120,8 @@ class conf_remap_yaml_load_test:
         else:
             tr.MakeCurlCommand(
                 '--proxy 127.0.0.1:{0} "http://www.testexample.com/test" -H "Host: www.testexample.com" --verbose'.format(
-                    self._ts.Variables.port))
+                    self._ts.Variables.port),
+                ts=self._ts)
         conf_remap_yaml_load_test.client_counter += 1
 
 

--- a/tests/gold_tests/remap/remap_https.test.py
+++ b/tests/gold_tests/remap/remap_https.test.py
@@ -61,7 +61,7 @@ ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key
 
 # call localhost straight
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr.Processes.Default.StartBefore(server)
@@ -73,43 +73,47 @@ tr.StillRunningAfter = ts
 
 # www.example.com host
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-https-200.gold"
 
 # www.example.com:80 host
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com:443" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com:443" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-https-200.gold"
 
 # www.example.com:8080 host
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com:{0}" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com:{0}" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-https-200.gold"
 
 # www.example3.com (match on receive port)
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example3.com" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example3.com" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-https-200_3.gold"
 
 # no rule for this
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.test.com" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.test.com" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-hitATS-404.gold"
 
 # bad port
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com:1234" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--http1.1 -k https://127.0.0.1:{0} -H "Host: www.example.com:1234" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-hitATS-404.gold"
 
 # map www.anotherexample.com to https://<IP of microserver>.com
 tr = Test.AddTestRun()
-tr.MakeCurlCommand('--http1.1 -k https://127.0.0.1:{0} -H "Host: www.anotherexample.com" --verbose'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    '--http1.1 -k https://127.0.0.1:{0} -H "Host: www.anotherexample.com" --verbose'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stderr = "gold/remap-https-200_2.gold"
 tr.StillRunningAfter = server2

--- a/tests/gold_tests/remap/remap_ws.test.py
+++ b/tests/gold_tests/remap/remap_ws.test.py
@@ -60,7 +60,8 @@ if not Condition.CurlUsingUnixDomainSocket():
     tr.Processes.Default.StartBefore(Test.Processes.ts, ready=1)
     tr.MakeCurlCommand(
         '--max-time 2 -v -s -q -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" -H "Sec-WebSocket-Version: 13" --http1.1 --resolve www.example.com:{0}:127.0.0.1 -k https://www.example.com:{0}/chat'
-        .format(ts.Variables.ssl_port))
+        .format(ts.Variables.ssl_port),
+        ts=ts)
     tr.Processes.Default.ReturnCode = 28
     tr.Processes.Default.Streams.stderr = "gold/remap-ws-upgrade.gold"
     tr.StillRunningAfter = server

--- a/tests/gold_tests/slow_post/server_abort.test.py
+++ b/tests/gold_tests/slow_post/server_abort.test.py
@@ -42,7 +42,7 @@ ts.Disk.records_config.update(
 tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
-tr.MakeCurlCommand("-v -k -H \")host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k -H \")host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/timeout/active_timeout.test.py
+++ b/tests/gold_tests/timeout/active_timeout.test.py
@@ -53,15 +53,15 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeo
 
 if not Condition.CurlUsingUnixDomainSocket():
     tr2 = Test.AddTestRun("tr")
-    tr2.MakeCurlCommand('-k -i --http1.1 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port))
+    tr2.MakeCurlCommand('-k -i --http1.1 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port), ts=ts)
     tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")
 
     tr3 = Test.AddTestRun("tr")
-    tr3.MakeCurlCommand('-k -i --http2 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port))
+    tr3.MakeCurlCommand('-k -i --http2 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port), ts=ts)
     tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Activity Timeout", "Request should fail with active timeout")
 
     if Condition.HasATSFeature('TS_HAS_QUICHE') and Condition.HasCurlFeature('http3'):
         tr4 = Test.AddTestRun("tr")
-        tr4.MakeCurlCommand('-k -i --http3 https://localhost:{0}/file'.format(ts.Variables.ssl_port))
+        tr4.MakeCurlCommand('-k -i --http3 https://localhost:{0}/file'.format(ts.Variables.ssl_port), ts=ts)
         tr4.Processes.Default.Streams.stdout = Testers.ContainsExpression(
             "Activity Timeout", "Request should fail with active timeout")

--- a/tests/gold_tests/timeout/conn_timeout.test.py
+++ b/tests/gold_tests/timeout/conn_timeout.test.py
@@ -67,13 +67,13 @@ tr.Processes.Default.Command = 'echo start; sudo sh -x ./setupnetns.sh {0} {1}'.
 # and the connect timeout should trigger with a 50x return.  If the SYN handshake occurs, the
 # no activity timeout would trigger, but not before the test timeout expires
 tr = Test.AddTestRun("tr-blocking")
-tr.MakeCurlCommand('-i http://127.0.0.1:{0}/blocked {0}'.format(ts.Variables.port))
+tr.MakeCurlCommand('-i http://127.0.0.1:{0}/blocked {0}'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.TimeOut = 4
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     "HTTP/1.1 502 internal error - server connection terminated", "Connect failed")
 
 tr = Test.AddTestRun("tr-blocking-post")
-tr.MakeCurlCommand('-d "stuff" -i http://127.0.0.1:{0}/blocked {0}'.format(ts.Variables.port))
+tr.MakeCurlCommand('-d "stuff" -i http://127.0.0.1:{0}/blocked {0}'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.TimeOut = 4
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     "HTTP/1.1 502 internal error - server connection terminated", "Connect failed")

--- a/tests/gold_tests/timeout/inactive_timeout.test.py
+++ b/tests/gold_tests/timeout/inactive_timeout.test.py
@@ -51,11 +51,11 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
 
 if not Condition.CurlUsingUnixDomainSocket():
     tr2 = Test.AddTestRun("tr")
-    tr2.MakeCurlCommand('-k -i --http1.1 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port))
+    tr2.MakeCurlCommand('-k -i --http1.1 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port), ts=ts)
     tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression(
         "Inactivity Timeout", "Request should fail with inactivity timeout")
 
     tr3 = Test.AddTestRun("tr")
-    tr3.MakeCurlCommand('-k -i --http2 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port))
+    tr3.MakeCurlCommand('-k -i --http2 https://127.0.0.1:{0}/file'.format(ts.Variables.ssl_port), ts=ts)
     tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression(
         "Inactivity Timeout", "Request should fail with inactivity timeout")

--- a/tests/gold_tests/timeout/tls_conn_timeout.test.py
+++ b/tests/gold_tests/timeout/tls_conn_timeout.test.py
@@ -67,7 +67,8 @@ tr = Test.AddTestRun("tr-blocking-post")
 tr.Setup.Copy(os.path.join(Test.Variables.AtsTestToolsDir, "ssl", "server.pem"))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(delay_post_connect, ready=When.PortOpen(Test.Variables.block_connect_port))
-tr.MakeCurlCommand('-H"Connection:close" -d "bob" -i http://127.0.0.1:{0}/connect_blocked --tlsv1.2'.format(ts.Variables.port))
+tr.MakeCurlCommand(
+    '-H"Connection:close" -d "bob" -i http://127.0.0.1:{0}/connect_blocked --tlsv1.2'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 502 Connection timed out", "Connect failed")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_post_connect
@@ -77,7 +78,7 @@ tr.StillRunningAfter = Test.Processes.ts
 #  Should not retry the connection
 tr = Test.AddTestRun("tr-delayed-post")
 tr.Processes.Default.StartBefore(delay_post_ttfb, ready=When.PortOpen(Test.Variables.block_ttfb_port))
-tr.MakeCurlCommand('-H"Connection:close" -d "bob" -i http://127.0.0.1:{0}/ttfb_blocked --tlsv1.2'.format(ts.Variables.port))
+tr.MakeCurlCommand('-H"Connection:close" -d "bob" -i http://127.0.0.1:{0}/ttfb_blocked --tlsv1.2'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("504 Connection Timed Out", "Connect timeout")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_post_ttfb
@@ -88,7 +89,7 @@ tr.StillRunningAfter = delay_post_ttfb
 # Should retry once
 tr = Test.AddTestRun("tr-blocking-get")
 tr.Processes.Default.StartBefore(delay_get_connect, ready=When.PortOpen(Test.Variables.get_block_connect_port))
-tr.MakeCurlCommand('-H"Connection:close" -i http://127.0.0.1:{0}/get_connect_blocked --tlsv1.2'.format(ts.Variables.port))
+tr.MakeCurlCommand('-H"Connection:close" -i http://127.0.0.1:{0}/get_connect_blocked --tlsv1.2'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("HTTP/1.1 502 Connection timed out", "Connect failed")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_get_connect
@@ -97,7 +98,7 @@ tr.StillRunningAfter = delay_get_connect
 #  Since get is idempotent, It will try to connect again even though the GET request had been sent
 tr = Test.AddTestRun("tr-delayed-get")
 tr.Processes.Default.StartBefore(delay_get_ttfb, ready=When.PortOpen(Test.Variables.get_block_ttfb_port))
-tr.MakeCurlCommand('-H"Connection:close" -i http://127.0.0.1:{0}/get_ttfb_blocked --tlsv1.2'.format(ts.Variables.port))
+tr.MakeCurlCommand('-H"Connection:close" -i http://127.0.0.1:{0}/get_ttfb_blocked --tlsv1.2'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("504 Connection Timed Out", "Connect timeout")
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = delay_get_ttfb

--- a/tests/gold_tests/tls/allow-plain.test.py
+++ b/tests/gold_tests/tls/allow-plain.test.py
@@ -69,7 +69,8 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 
 tr.MakeCurlCommand(
     '-o /dev/null -k --verbose -H "uuid: get" --ipv4 --http1.1 --resolve www.example.com:{}:127.0.0.1 https://www.example.com:{}/'
-    .format(ts.Variables.ssl_port, ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port, ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -79,7 +80,8 @@ tr.Processes.Default.Streams.all = Testers.ContainsExpression("TLS", "Should neg
 tr2 = Test.AddTestRun()
 tr2.MakeCurlCommand(
     '--verbose --ipv4 --http1.1 -H "uuid: get" --resolve www.example.com:{}:127.0.0.1 http://www.example.com:{}'.format(
-        ts.Variables.ssl_port, ts.Variables.ssl_port))
+        ts.Variables.ssl_port, ts.Variables.ssl_port),
+    ts=ts)
 tr2.Processes.Default.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -90,7 +92,8 @@ tr2.Processes.Default.Streams.all = Testers.ExcludesExpression("TLS", "Should no
 tr3 = Test.AddTestRun()
 tr3.MakeCurlCommand(
     '--verbose -d @big_post_body -H "uuid: post" --ipv4 --http1.1 --resolve www.example.com:{}:127.0.0.1 http://www.example.com:{}/post http://www.example.com:{}/post'
-    .format(ts.Variables.ssl_port, ts.Variables.ssl_port, ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port, ts.Variables.ssl_port, ts.Variables.ssl_port),
+    ts=ts)
 tr3.Processes.Default.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts

--- a/tests/gold_tests/tls/ssl_key_dialog.test.py
+++ b/tests/gold_tests/tls/ssl_key_dialog.test.py
@@ -50,8 +50,8 @@ server.addResponse("sessionlog.json", request_header, response_header)
 tr = Test.AddTestRun("use a key with passphrase")
 tr.Setup.Copy("ssl/signer.pem")
 tr.MakeCurlCommand(
-    f"-v --cacert ./signer.pem  --resolve 'passphrase:{ts.Variables.ssl_port}:127.0.0.1' https://passphrase:{ts.Variables.ssl_port}/"
-)
+    f"-v --cacert ./signer.pem  --resolve 'passphrase:{ts.Variables.ssl_port}:127.0.0.1' https://passphrase:{ts.Variables.ssl_port}/",
+    ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -86,8 +86,8 @@ tr2reload.Processes.Default.ReturnCode = 0
 tr3 = Test.AddTestRun("use a key with passphrase")
 tr3.Setup.Copy("ssl/signer.pem")
 tr3.MakeCurlCommand(
-    f"-v --cacert ./signer.pem  --resolve 'passphrase:{ts.Variables.ssl_port}:127.0.0.1' https://passphrase:{ts.Variables.ssl_port}/"
-)
+    f"-v --cacert ./signer.pem  --resolve 'passphrase:{ts.Variables.ssl_port}:127.0.0.1' https://passphrase:{ts.Variables.ssl_port}/",
+    ts=ts)
 tr3.ReturnCode = 0
 tr3.Processes.Default.Streams.stderr.Content = Testers.ContainsExpression("200", "expected 200 OK response")
 tr3.Processes.Default.Streams.stdout.Content = Testers.ContainsExpression("success!", "expected success")

--- a/tests/gold_tests/tls/ssl_multicert_loader.test.py
+++ b/tests/gold_tests/tls/ssl_multicert_loader.test.py
@@ -47,7 +47,7 @@ tr.Processes.Default.StartBefore(server)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    f"-q -s -v -k --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}")
+    f"-q -s -v -k --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}", ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 tr.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
@@ -84,7 +84,7 @@ tr3.Processes.Default.StartBefore(server2, ready=When.FileContains(ts.Disk.diags
 tr3.StillRunningAfter = ts
 tr3.StillRunningAfter = server
 tr3.MakeCurlCommand(
-    f"-q -s -v -k --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}")
+    f"-q -s -v -k --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}", ts=ts)
 tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 tr3.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")

--- a/tests/gold_tests/tls/tls_0rtt_server.test.py
+++ b/tests/gold_tests/tls/tls_0rtt_server.test.py
@@ -155,7 +155,7 @@ ts2.Disk.sni_yaml.AddLines([
 ])
 
 tr = Test.AddTestRun('Basic Curl Test')
-tr.MakeCurlCommand('-k --resolve example.com:{0}:127.0.0.1 https://example.com:{0}'.format(ts1.Variables.ssl_port))
+tr.MakeCurlCommand('-k --resolve example.com:{0}:127.0.0.1 https://example.com:{0}'.format(ts1.Variables.ssl_port), ts=ts1)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts1)

--- a/tests/gold_tests/tls/tls_bad_alpn.test.py
+++ b/tests/gold_tests/tls/tls_bad_alpn.test.py
@@ -68,7 +68,7 @@ tr.Processes.Default.Streams.All += Testers.IncludesExpression("No ALPN negotiat
 tr.Processes.Default.Streams.All += Testers.IncludesExpression("HTTP/1.1 400 Host Header Required", "Processed the request")
 
 tr = Test.AddTestRun("alpn h2")
-tr.MakeCurlCommand("-k --http2 -v -o /dev/null https://127.0.0.1:{}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-k --http2 -v -o /dev/null https://127.0.0.1:{}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.IncludesExpression("ALPN. server accepted.*h2", "negotiated h2")

--- a/tests/gold_tests/tls/tls_check_cert_select_plugin.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_select_plugin.test.py
@@ -77,7 +77,8 @@ dns.addRecords(records={"bar.com.": ["127.0.0.1"]})
 tr = Test.AddTestRun("bar.com cert")
 tr.Setup.Copy("ssl/signer.pem")
 tr.Setup.Copy("ssl/signer2.pem")
-tr.MakeCurlCommand("-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(dns)
@@ -91,7 +92,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 
 # Should receive a foo.com cert
 tr2 = Test.AddTestRun("foo.com cert")
-tr2.MakeCurlCommand("-v --cacert ./signer.pem --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand(
+    "-v --cacert ./signer.pem --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -102,7 +104,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 
 # Should receive random.server.com
 tr2 = Test.AddTestRun("random.server.com cert")
-tr2.MakeCurlCommand("-v -k --resolve 'random.server.com:{0}:127.0.0.1' https://random.server.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand(
+    "-v -k --resolve 'random.server.com:{0}:127.0.0.1' https://random.server.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -116,7 +119,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 # SNI name and returned cert name will not match, so must use -k to avoid cert verification
 tr2 = Test.AddTestRun("Bad SNI")
 tr2.MakeCurlCommand(
-    "-v -k --cacert ./signer.pem --resolve 'bad.sni.com:{0}:127.0.0.1' https://bad.sni.com:{0}".format(ts.Variables.ssl_port))
+    "-v -k --cacert ./signer.pem --resolve 'bad.sni.com:{0}:127.0.0.1' https://bad.sni.com:{0}".format(ts.Variables.ssl_port),
+    ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -144,7 +148,8 @@ trupdate.Processes.Default.ReturnCode = 0
 tr = Test.AddTestRun("Test new version of bar cert with good CA")
 tr.DelayStart = 4
 tr.MakeCurlCommandMulti(
-    "date; {{curl}} -v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+    "date; {{curl}} -v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -154,7 +159,8 @@ tr.Processes.Default.Streams.All += Testers.ExcludesExpression("CN=foo.com", "Ce
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should make an exchange")
 
 tr = Test.AddTestRun("Test new version of bar cert with bad CA")
-tr.MakeCurlCommand("-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 60
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_check_cert_selection.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection.test.py
@@ -68,7 +68,8 @@ dns.addRecords(records={"bar.com.": ["127.0.0.1"]})
 tr = Test.AddTestRun("bar.com cert")
 tr.Setup.Copy("ssl/signer.pem")
 tr.Setup.Copy("ssl/signer2.pem")
-tr.MakeCurlCommand("-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(dns)
@@ -82,7 +83,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 
 # Should receive a foo.com cert
 tr2 = Test.AddTestRun("foo.com cert")
-tr2.MakeCurlCommand("-v --cacert ./signer.pem --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand(
+    "-v --cacert ./signer.pem --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -93,7 +95,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 
 # Should receive random.server.com
 tr2 = Test.AddTestRun("random.server.com cert")
-tr2.MakeCurlCommand("-v -k --resolve 'random.server.com:{0}:127.0.0.1' https://random.server.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand(
+    "-v -k --resolve 'random.server.com:{0}:127.0.0.1' https://random.server.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -107,7 +110,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 # SNI name and returned cert name will not match, so must use -k to avoid cert verification
 tr2 = Test.AddTestRun("Bad SNI")
 tr2.MakeCurlCommand(
-    "-v -k --cacert ./signer.pem --resolve 'bad.sni.com:{0}:127.0.0.1' https://bad.sni.com:{0}".format(ts.Variables.ssl_port))
+    "-v -k --cacert ./signer.pem --resolve 'bad.sni.com:{0}:127.0.0.1' https://bad.sni.com:{0}".format(ts.Variables.ssl_port),
+    ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
+++ b/tests/gold_tests/tls/tls_check_cert_selection_reload.test.py
@@ -63,7 +63,7 @@ tr = Test.AddTestRun("bar.com cert signer1")
 tr.Setup.Copy("ssl/signer.pem")
 tr.Setup.Copy("ssl/signer2.pem")
 tr.MakeCurlCommand(
-    "-v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port))
+    "-v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -76,7 +76,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("404", "Should ma
 
 tr = Test.AddTestRun("bar.com cert signer2")
 tr.MakeCurlCommand(
-    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port))
+    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 60
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -111,14 +111,14 @@ tr.Processes.Default.StartBefore(
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "-v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port))
+    "-v --cacert ./signer.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 60
 tr.Processes.Default.Streams.All = Testers.ContainsExpression(
     "unable to get local issuer certificate", "Server certificate not issued by expected signer")
 
 tr = Test.AddTestRun("Try with signer 2 again")
 tr.MakeCurlCommand(
-    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port))
+    "-v --cacert ./signer2.pem  --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/random".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_client_cert.test.py
+++ b/tests/gold_tests/tls/tls_client_cert.test.py
@@ -121,7 +121,7 @@ tr.Processes.Default.StartBefore(server2)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -130,7 +130,7 @@ trfail = Test.AddTestRun("Connect with first client cert to second server")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -139,7 +139,7 @@ trbar = Test.AddTestRun("Connect with signed2 bar to second server")
 trbar.StillRunningAfter = ts
 trbar.StillRunningAfter = server
 trbar.StillRunningAfter = server2
-trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 trbar.Processes.Default.ReturnCode = 0
 trbar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -148,7 +148,7 @@ trbarfail = Test.AddTestRun("Connect with signed2 bar cert to first server")
 trbarfail.StillRunningAfter = ts
 trbarfail.StillRunningAfter = server
 trbarfail.StillRunningAfter = server2
-trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 trbarfail.Processes.Default.ReturnCode = 0
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -198,7 +198,7 @@ tr3bar.Processes.Default.StartBefore(server3, ready=When.FileContains(ts.Disk.di
 tr3bar.StillRunningAfter = ts
 tr3bar.StillRunningAfter = server
 tr3bar.StillRunningAfter = server2
-tr3bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr3bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr3bar.Processes.Default.ReturnCode = 0
 tr3bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -207,7 +207,7 @@ tr3barfail = Test.AddTestRun("Make request with other bar cert to second server"
 tr3barfail.StillRunningAfter = ts
 tr3barfail.StillRunningAfter = server
 tr3barfail.StillRunningAfter = server2
-tr3barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr3barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr3barfail.Processes.Default.ReturnCode = 0
 tr3barfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -217,7 +217,7 @@ tr3 = Test.AddTestRun("Make request with other cert to second server")
 tr3.StillRunningAfter = ts
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = server2
-tr3.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr3.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -226,7 +226,7 @@ tr3fail = Test.AddTestRun("Make request with other cert to first server")
 tr3fail.StillRunningAfter = ts
 tr3fail.StillRunningAfter = server
 tr3fail.StillRunningAfter = server2
-tr3fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr3fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr3fail.Processes.Default.ReturnCode = 0
 tr3fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -260,7 +260,7 @@ tr4bar.DelayStart = 10
 tr4bar.StillRunningAfter = ts
 tr4bar.StillRunningAfter = server
 tr4bar.StillRunningAfter = server2
-tr4bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr4bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr4bar.Processes.Default.ReturnCode = 0
 tr4bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -269,7 +269,7 @@ tr4barfail = Test.AddTestRun("Make request with renamed bar cert to first server
 tr4barfail.StillRunningAfter = ts
 tr4barfail.StillRunningAfter = server
 tr4barfail.StillRunningAfter = server2
-tr4barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr4barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr4barfail.Processes.Default.ReturnCode = 0
 tr4barfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -278,7 +278,7 @@ tr4 = Test.AddTestRun("Make request with renamed foo cert to first server")
 tr4.StillRunningAfter = ts
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = server2
-tr4.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr4.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr4.Processes.Default.ReturnCode = 0
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -287,7 +287,7 @@ tr4fail = Test.AddTestRun("Make request with renamed foo cert to second server")
 tr4fail.StillRunningAfter = ts
 tr4fail.StillRunningAfter = server
 tr4fail.StillRunningAfter = server2
-tr4fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr4fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr4fail.Processes.Default.ReturnCode = 0
 tr4fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 

--- a/tests/gold_tests/tls/tls_client_cert2.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2.test.py
@@ -127,7 +127,7 @@ tr.Processes.Default.StartBefore(server2)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:bob.bar.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:bob.bar.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -136,7 +136,7 @@ trfail = Test.AddTestRun("bob.bar.com to server 2")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:bob.bar.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:bob.bar.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -145,7 +145,7 @@ tr = Test.AddTestRun("bob.foo.com to server 1")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:bob.foo.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:bob.foo.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -154,7 +154,7 @@ trfail = Test.AddTestRun("bob.foo.com to server 2")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:bob.foo.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:bob.foo.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -163,7 +163,7 @@ tr = Test.AddTestRun("random.bar.com to server 2")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:random.bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:random.bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -172,7 +172,7 @@ trfail = Test.AddTestRun("random.bar.com to server 1")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:random.bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:random.bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -181,7 +181,7 @@ tr = Test.AddTestRun("random.foo.com to server 2")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:random.foo.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:random.foo.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -190,7 +190,7 @@ trfail = Test.AddTestRun("random.foo.com to server 1")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:random.foo.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:random.foo.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 

--- a/tests/gold_tests/tls/tls_client_cert2_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert2_plugin.test.py
@@ -124,7 +124,7 @@ tr.Processes.Default.StartBefore(server2)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:bob.bar.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:bob.bar.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -133,7 +133,7 @@ trfail = Test.AddTestRun("bob.bar.com to server 2")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:bob.bar.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:bob.bar.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -142,7 +142,7 @@ tr = Test.AddTestRun("bob.foo.com to server 1")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:bob.foo.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:bob.foo.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -151,7 +151,7 @@ trfail = Test.AddTestRun("bob.foo.com to server 2")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:bob.foo.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:bob.foo.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -160,7 +160,7 @@ tr = Test.AddTestRun("random.bar.com to server 2")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:random.bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:random.bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -169,7 +169,7 @@ trfail = Test.AddTestRun("random.bar.com to server 1")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:random.bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:random.bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -178,7 +178,7 @@ tr = Test.AddTestRun("random.foo.com to server 2")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:random.foo.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:random.foo.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -187,6 +187,6 @@ trfail = Test.AddTestRun("random.foo.com to server 1")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:random.foo.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:random.foo.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")

--- a/tests/gold_tests/tls/tls_client_cert_override.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override.test.py
@@ -111,7 +111,7 @@ tr.Processes.Default.StartBefore(server2)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -120,7 +120,7 @@ trfail = Test.AddTestRun("Connect with bad client cert to first server")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -129,7 +129,7 @@ trbar = Test.AddTestRun("Connect with correct client cert to second server")
 trbar.StillRunningAfter = ts
 trbar.StillRunningAfter = server
 trbar.StillRunningAfter = server2
-trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 trbar.Processes.Default.ReturnCode = 0
 trbar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -138,6 +138,6 @@ trbarfail = Test.AddTestRun("Connect with bad client cert to second server")
 trbarfail.StillRunningAfter = ts
 trbarfail.StillRunningAfter = server
 trbarfail.StillRunningAfter = server2
-trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/badcase2'.format(ts.Variables.port))
+trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/badcase2'.format(ts.Variables.port), ts=ts)
 trbarfail.Processes.Default.ReturnCode = 0
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")

--- a/tests/gold_tests/tls/tls_client_cert_override_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_override_plugin.test.py
@@ -130,7 +130,7 @@ tr.Processes.Default.StartBefore(server2)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -139,7 +139,7 @@ trfail = Test.AddTestRun("Connect with bad client cert to first server")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -148,7 +148,7 @@ trbar = Test.AddTestRun("Connect with correct client cert to second server")
 trbar.StillRunningAfter = ts
 trbar.StillRunningAfter = server
 trbar.StillRunningAfter = server2
-trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 trbar.Processes.Default.ReturnCode = 0
 trbar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -157,7 +157,7 @@ trbarfail = Test.AddTestRun("Connect with bad client cert to second server")
 trbarfail.StillRunningAfter = ts
 trbarfail.StillRunningAfter = server
 trbarfail.StillRunningAfter = server2
-trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/badcase2'.format(ts.Variables.port))
+trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/badcase2'.format(ts.Variables.port), ts=ts)
 trbarfail.Processes.Default.ReturnCode = 0
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -189,7 +189,7 @@ tr3bar.Processes.Default.StartBefore(server3, ready=When.FileContains(ts.Disk.di
 tr3bar.StillRunningAfter = ts
 tr3bar.StillRunningAfter = server
 tr3bar.StillRunningAfter = server2
-tr3bar.MakeCurlCommand(' -H host:foo.com http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port))
+tr3bar.MakeCurlCommand(' -H host:foo.com http://127.0.0.1:{0}/badcase1'.format(ts.Variables.port), ts=ts)
 tr3bar.Processes.Default.ReturnCode = 0
 tr3bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -213,7 +213,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.StillRunningAfter = ts
-tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -222,6 +222,6 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
 tr.StillRunningAfter = ts
-tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/badcase1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/badcase1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")

--- a/tests/gold_tests/tls/tls_client_cert_plugin.test.py
+++ b/tests/gold_tests/tls/tls_client_cert_plugin.test.py
@@ -116,7 +116,7 @@ tr.Processes.Default.StartBefore(server2)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.StillRunningAfter = server2
-tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port))
+tr.MakeCurlCommand("-H host:example.com  http://127.0.0.1:{0}/case1".format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -125,7 +125,7 @@ trfail = Test.AddTestRun("Connect with first client cert to second server")
 trfail.StillRunningAfter = ts
 trfail.StillRunningAfter = server
 trfail.StillRunningAfter = server2
-trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+trfail.MakeCurlCommand('-H host:example.com  http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 trfail.Processes.Default.ReturnCode = 0
 trfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -134,7 +134,7 @@ trbar = Test.AddTestRun("Connect with signed2 bar to second server")
 trbar.StillRunningAfter = ts
 trbar.StillRunningAfter = server
 trbar.StillRunningAfter = server2
-trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+trbar.MakeCurlCommand("-H host:bar.com  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 trbar.Processes.Default.ReturnCode = 0
 trbar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -143,7 +143,7 @@ trbarfail = Test.AddTestRun("Connect with signed2 bar cert to first server")
 trbarfail.StillRunningAfter = ts
 trbarfail.StillRunningAfter = server
 trbarfail.StillRunningAfter = server2
-trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+trbarfail.MakeCurlCommand('-H host:bar.com  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 trbarfail.Processes.Default.ReturnCode = 0
 trbarfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -195,7 +195,7 @@ tr3bar.Processes.Default.StartBefore(server3, ready=When.FileContains(ts.Disk.di
 tr3bar.StillRunningAfter = ts
 tr3bar.StillRunningAfter = server
 tr3bar.StillRunningAfter = server2
-tr3bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr3bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr3bar.Processes.Default.ReturnCode = 0
 tr3bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -204,7 +204,7 @@ tr3barfail = Test.AddTestRun("Make request with other bar cert to second server"
 tr3barfail.StillRunningAfter = ts
 tr3barfail.StillRunningAfter = server
 tr3barfail.StillRunningAfter = server2
-tr3barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr3barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr3barfail.Processes.Default.ReturnCode = 0
 tr3barfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -214,7 +214,7 @@ tr3 = Test.AddTestRun("Make request with other cert to second server")
 tr3.StillRunningAfter = ts
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = server2
-tr3.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr3.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -223,7 +223,7 @@ tr3fail = Test.AddTestRun("Make request with other cert to first server")
 tr3fail.StillRunningAfter = ts
 tr3fail.StillRunningAfter = server
 tr3fail.StillRunningAfter = server2
-tr3fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr3fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr3fail.Processes.Default.ReturnCode = 0
 tr3fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -257,7 +257,7 @@ tr4bar.DelayStart = 10
 tr4bar.StillRunningAfter = ts
 tr4bar.StillRunningAfter = server
 tr4bar.StillRunningAfter = server2
-tr4bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr4bar.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr4bar.Processes.Default.ReturnCode = 0
 tr4bar.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -266,7 +266,7 @@ tr4barfail = Test.AddTestRun("Make request with renamed bar cert to first server
 tr4barfail.StillRunningAfter = ts
 tr4barfail.StillRunningAfter = server
 tr4barfail.StillRunningAfter = server2
-tr4barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr4barfail.MakeCurlCommand(' -H host:bar.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr4barfail.Processes.Default.ReturnCode = 0
 tr4barfail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")
 
@@ -275,7 +275,7 @@ tr4 = Test.AddTestRun("Make request with renamed foo cert to first server")
 tr4.StillRunningAfter = ts
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = server2
-tr4.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr4.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr4.Processes.Default.ReturnCode = 0
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 
@@ -284,6 +284,6 @@ tr4fail = Test.AddTestRun("Make request with renamed foo cert to second server")
 tr4fail.StillRunningAfter = ts
 tr4fail.StillRunningAfter = server
 tr4fail.StillRunningAfter = server2
-tr4fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port))
+tr4fail.MakeCurlCommand(' -H host:example.com http://127.0.0.1:{0}/case2'.format(ts.Variables.port), ts=ts)
 tr4fail.Processes.Default.ReturnCode = 0
 tr4fail.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Check response")

--- a/tests/gold_tests/tls/tls_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_client_verify.test.py
@@ -86,7 +86,8 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(server)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand("--tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "--tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to foo.com with bad cert")
@@ -96,7 +97,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case2".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 # Should fail with badly signed certs
 tr.Processes.Default.ReturnCode = 35
 
@@ -107,7 +109,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case3"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -115,7 +118,7 @@ tr = Test.AddTestRun("Connect to bob.bar.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "--tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case4".format(ts.Variables.ssl_port))
+    "--tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case4".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
@@ -126,7 +129,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bob-bar.pem --key ./signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case5"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -137,7 +141,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case6"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -145,7 +150,7 @@ tr = Test.AddTestRun("Connect to bob.foo.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "--tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case7".format(ts.Variables.ssl_port))
+    "--tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case7".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
@@ -156,7 +161,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bob-foo.pem --key ./signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case8"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -167,14 +173,16 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case9"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
 tr = Test.AddTestRun("Connect to bar.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand("--tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case10".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "--tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case10".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bar.com with cert")
@@ -184,7 +192,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bar.pem --key ./signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case11"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
@@ -195,21 +204,23 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case12".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 # Test that the fqdn's match completely.  bob.com should require client certificate. bob.com.com should not
 tr = Test.AddTestRun("Connect to bob.com without cert, should fail")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand("--tls-max 1.2 -k --resolve 'bob.com:{0}:127.0.0.1' https://bob.com:{0}/case13".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "--tls-max 1.2 -k --resolve 'bob.com:{0}:127.0.0.1' https://bob.com:{0}/case13".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.foo.com without cert, should succeed")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "--tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case14".format(ts.Variables.ssl_port))
+    "--tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case14".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("Wait for the access log to write out")

--- a/tests/gold_tests/tls/tls_client_verify2.test.py
+++ b/tests/gold_tests/tls/tls_client_verify2.test.py
@@ -71,7 +71,8 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(server)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand("--tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "--tls-max 1.2 -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -82,7 +83,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -90,7 +92,7 @@ tr = Test.AddTestRun("Connect to bob.bar.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "--tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port))
+    "--tls-max 1.2 -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.bar.com with cert")
@@ -100,7 +102,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bob-bar.pem --key ./signed-bar.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
@@ -111,14 +114,15 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.foo.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "--tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port))
+    "--tls-max 1.2 -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bob.foo.com with cert")
@@ -128,7 +132,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bob-foo.pem --key ./signed-foo.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "TLS handshake should succeed")
 
@@ -139,13 +144,15 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 tr = Test.AddTestRun("Connect to bar.com without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand("--tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "--tls-max 1.2 -k --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert", "TLS handshake should succeed")
 
@@ -156,7 +163,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bar.pem --key ./signed-bar.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("error", "Check response")
 
@@ -167,6 +175,7 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'bar.com:{0}:127.0.0.1' https://bar.com:{0}/case1".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("alert unknown ca", "TLS handshake should succeed")

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -78,7 +78,8 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 # https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
@@ -86,7 +87,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("foo.com TLSv1")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 
@@ -94,7 +96,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("bar.com TLSv1")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
@@ -102,6 +105,7 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("bar.com TLSv1_2")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_client_versions_minmax.test.py
+++ b/tests/gold_tests/tls/tls_client_versions_minmax.test.py
@@ -83,7 +83,8 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 # https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_security_level.html
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
@@ -91,7 +92,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("foo.com TLSv1")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 
@@ -99,7 +101,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("foo.com TLSv1_1")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.1 --tlsv1.1 --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 
@@ -107,7 +110,8 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("bar.com TLSv1")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.0 --tlsv1 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
 
@@ -115,6 +119,7 @@ tr.StillRunningAfter = ts
 tr = Test.AddTestRun("bar.com TLSv1_2")
 tr.MakeCurlCommand(
     "-v --ciphers DEFAULT@SECLEVEL=0 --tls-max 1.2 --tlsv1.2 --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_engine.test.py
+++ b/tests/gold_tests/tls/tls_engine.test.py
@@ -92,7 +92,7 @@ ts.Disk.MakeConfigFile('load_engine.cnf').AddLines(
 
 # Make a basic request.  Hopefully it goes through
 tr = Test.AddTestRun("Run-Test")
-tr.MakeCurlCommand("-k -v -H uuid:basic -H host:example.com  https://127.0.0.1:{0}/".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-k -v -H uuid:basic -H host:example.com  https://127.0.0.1:{0}/".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))

--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -78,7 +78,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.all = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
@@ -87,7 +88,8 @@ tr2.StillRunningAfter = ts
 tr2.StillRunningAfter = server
 tr2.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-bar.pem --key ./signed-bar.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr2.Processes.Default.ReturnCode = 35
 tr2.Processes.Default.Streams.all = Testers.ContainsExpression("error", "Curl attempt should have failed")
 
@@ -98,7 +100,8 @@ tr3.StillRunningAfter = ts
 tr3.StillRunningAfter = server
 tr3.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./server.pem --key ./server.key --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}/case1".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr3.Processes.Default.ReturnCode = 35
 tr3.Processes.Default.Streams.all = Testers.ContainsExpression("error", "Curl attempt should have failed")
 

--- a/tests/gold_tests/tls/tls_hooks_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_verify.test.py
@@ -65,21 +65,21 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand("--resolve \"foo.com:{0}:127.0.0.1\" -k  https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("--resolve \"foo.com:{0}:127.0.0.1\" -k  https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have failed")
 
 tr2 = Test.AddTestRun("request bad name")
 tr2.StillRunningAfter = ts
 tr2.StillRunningAfter = server
-tr2.MakeCurlCommand("--resolve \"random.com:{0}:127.0.0.1\" -k  https://random.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("--resolve \"random.com:{0}:127.0.0.1\" -k  https://random.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.Processes.Default.ReturnCode = 0
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 
 tr3 = Test.AddTestRun("request bad name permissive")
 tr3.StillRunningAfter = ts
 tr3.StillRunningAfter = server
-tr3.MakeCurlCommand("--resolve \"bar.com:{0}:127.0.0.1\" -k  https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand("--resolve \"bar.com:{0}:127.0.0.1\" -k  https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have failed")
 

--- a/tests/gold_tests/tls/tls_keepalive.test.py
+++ b/tests/gold_tests/tls/tls_keepalive.test.py
@@ -69,7 +69,7 @@ tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    '-k -v --http1.1  -H \'host:example.com:{0}\' https://127.0.0.1:{0} https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+    '-k -v --http1.1  -H \'host:example.com:{0}\' https://127.0.0.1:{0} https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("Test two HTTP/1.1 requests over two TLS connections")
@@ -77,14 +77,16 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommandMulti(
     '{{curl}} -k -v --http1.1  -H \'host:example.com:{0}\' https://127.0.0.1:{0}; {{curl}} -k -v --http1.1 -H \'host:example.com:{0}\'  https://127.0.0.1:{0}'
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("Test two HTTP/2 requests over one TLS connection")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommandMulti(
-    '{{curl}} -k -v --http2  -H \'host:example.com:{0}\' https://127.0.0.1:{0} https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+    '{{curl}} -k -v --http2  -H \'host:example.com:{0}\' https://127.0.0.1:{0} https://127.0.0.1:{0}'.format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 tr = Test.AddTestRun("Test two HTTP/2 requests over two TLS connections")
@@ -92,7 +94,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommandMulti(
     '{{curl}} -k -v --http2  -H \'host:example.com:{0}\' https://127.0.0.1:{0}; {{curl}} -k -v --http1.1 -H \'host:example.com:{0}\'  https://127.0.0.1:{0}'
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 # Just a check to flush out the traffic log until we have a clean shutdown for traffic_server

--- a/tests/gold_tests/tls/tls_ocsp.test.py
+++ b/tests/gold_tests/tls/tls_ocsp.test.py
@@ -67,5 +67,6 @@ tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.MakeCurlCommand(
     "-v --cacert {0} --cert-status -H \")host:example.com\" https://127.0.0.1:{1}".format(
-        os.path.join(ts.Variables.SSLDir, "ca.ocsp.pem"), ts.Variables.ssl_port))
+        os.path.join(ts.Variables.SSLDir, "ca.ocsp.pem"), ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0

--- a/tests/gold_tests/tls/tls_origin_session_reuse.test.py
+++ b/tests/gold_tests/tls/tls_origin_session_reuse.test.py
@@ -134,7 +134,8 @@ ts4.Disk.records_config.update(
 tr = Test.AddTestRun('new session then reuse')
 tr.MakeCurlCommandMulti(
     '{{curl}} https://127.0.0.1:{0}/reuse_session -k && {{curl}} https://127.0.0.1:{0}/reuse_session -k'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts1)
@@ -149,7 +150,8 @@ tr.StillRunningAfter += ts2
 tr = Test.AddTestRun('remove oldest session, new session then reuse')
 tr.MakeCurlCommandMulti(
     '{{curl}} https://127.0.0.1:{0}/remove_oldest -k && {{curl}} https://127.0.0.1:{0}/remove_oldest -k'.format(
-        ts2.Variables.ssl_port))
+        ts2.Variables.ssl_port),
+    ts=ts2)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression('curl test', 'Making sure the basics still work')
 ts2.Disk.traffic_out.Content = Testers.ContainsExpression('remove oldest session', '')
@@ -158,7 +160,8 @@ ts2.Disk.traffic_out.Content += Testers.ContainsExpression('reused session to or
 tr.StillRunningAfter = server
 
 tr = Test.AddTestRun('disable origin session reuse, reuse should fail')
-tr.MakeCurlCommandMulti('{{curl}} https://127.0.0.1:{0} -k && {{curl}} https://127.0.0.1:{0} -k'.format(ts4.Variables.ssl_port))
+tr.MakeCurlCommandMulti(
+    '{{curl}} https://127.0.0.1:{0} -k && {{curl}} https://127.0.0.1:{0} -k'.format(ts4.Variables.ssl_port), ts=ts4)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(ts3)
 tr.Processes.Default.StartBefore(ts4)

--- a/tests/gold_tests/tls/tls_partial_blind_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_partial_blind_tunnel.test.py
@@ -61,7 +61,7 @@ ts.Disk.sni_yaml.AddLines(
     ])
 
 tr = Test.AddTestRun("Partial Blind Route")
-tr.MakeCurlCommand("--http1.1 -v --resolve 'foo.com:{0}:127.0.0.1' -k https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("--http1.1 -v --resolve 'foo.com:{0}:127.0.0.1' -k https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_bar)
 tr.Processes.Default.StartBefore(nameserver)

--- a/tests/gold_tests/tls/tls_sni_groups.test.py
+++ b/tests/gold_tests/tls/tls_sni_groups.test.py
@@ -70,7 +70,8 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.MakeCurlCommand(
     "-v --ciphers ECDHE-RSA-AES256-GCM-SHA384 --resolve 'bbb.com:{0}:127.0.0.1' -k  https://bbb.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
@@ -81,7 +82,8 @@ tr.Processes.Default.Streams.all = Testers.IncludesExpression(
 tr = Test.AddTestRun("Test 1: fail")
 tr.MakeCurlCommand(
     "-v --ciphers ECDHE-RSA-AES256-GCM-SHA384 --resolve 'ccc.com:{0}:127.0.0.1' -k  https://ccc.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 # The error code is 35, which indicates there was a ssl connection error
 tr.ReturnCode = 35
 tr.StillRunningAfter = ts
@@ -94,7 +96,8 @@ if Condition.HasOpenSSLVersion("3.5.0"):
     tr = Test.AddTestRun("Test 2: X25519MLKEM768")
     tr.MakeCurlCommand(
         "-v --tls13-ciphers TLS_AES_256_GCM_SHA384 --resolve 'aaa.com:{0}:127.0.0.1' -k  https://aaa.com:{0}".format(
-            ts.Variables.ssl_port))
+            ts.Variables.ssl_port),
+        ts=ts)
     tr.ReturnCode = 0
     tr.StillRunningAfter = ts
     ts.Disk.traffic_out.Content += Testers.ContainsExpression(

--- a/tests/gold_tests/tls/tls_sni_host_policy.test.py
+++ b/tests/gold_tests/tls/tls_sni_host_policy.test.py
@@ -79,7 +79,7 @@ tr.Processes.Default.StartBefore(server)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "-v --tls-max 1.2 -k -H 'host:dave' --resolve 'Bob:{0}:127.0.0.1' https://Bob:{0}/case1".format(ts.Variables.ssl_port))
+    "-v --tls-max 1.2 -k -H 'host:dave' --resolve 'Bob:{0}:127.0.0.1' https://Bob:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 35
 
 # case 2
@@ -92,7 +92,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "-v --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:dave' --resolve 'Bob:{0}:127.0.0.1' https://Bob:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 # case 3
@@ -102,7 +103,7 @@ tr = Test.AddTestRun("Connect to dave without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "-v --tls-max 1.2 -k -H 'host:Bob' --resolve 'dave:{0}:127.0.0.1' https://dave:{0}/case1".format(ts.Variables.ssl_port))
+    "-v --tls-max 1.2 -k -H 'host:Bob' --resolve 'dave:{0}:127.0.0.1' https://dave:{0}/case1".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("Access Denied", "Check response")
 
@@ -114,7 +115,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "-v --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:bob' --resolve 'dave:{0}:127.0.0.1' https://dave:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ContainsExpression("Access Denied", "Check response")
 
@@ -125,7 +127,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "--tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:boB' --resolve 'Bob:{0}:127.0.0.1' https://bob:{0}/case1"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
 
@@ -137,7 +140,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "-v --tls-max 1.2 -k -H 'host:Boblite' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
 
@@ -149,7 +153,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "-v --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:Boblite' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
 
@@ -159,7 +164,8 @@ tr = Test.AddTestRun("Connect to ellen without cert")
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    "-v --tls-max 1.2 -k -H 'host:fran' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(ts.Variables.ssl_port))
+    "-v --tls-max 1.2 -k -H 'host:fran' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly".format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
 
@@ -170,7 +176,8 @@ tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
     "-v --tls-max 1.2 -k --cert ./signed-foo.pem --key ./signed-foo.key -H 'host:fran' --resolve 'ellen:{0}:127.0.0.1' https://ellen:{0}/warnonly"
-    .format(ts.Variables.ssl_port))
+    .format(ts.Variables.ssl_port),
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Access Denied", "Check response")
 

--- a/tests/gold_tests/tls/tls_sni_yaml_reload.test.py
+++ b/tests/gold_tests/tls/tls_sni_yaml_reload.test.py
@@ -67,8 +67,8 @@ tr.Processes.Default.StartBefore(server)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 tr.MakeCurlCommand(
-    f"-q --tls-max 1.2 -s -v -k  --cert ./signed-foo.pem --key ./signed-foo.key --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}"
-)
+    f"-q --tls-max 1.2 -s -v -k  --cert ./signed-foo.pem --key ./signed-foo.key --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}",
+    ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Verify curl could successfully connect")
 tr.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", f"Verify curl used the {sni_domain} SNI")

--- a/tests/gold_tests/tls/tls_sni_yaml_reload.test.py
+++ b/tests/gold_tests/tls/tls_sni_yaml_reload.test.py
@@ -113,8 +113,8 @@ tr3.Processes.Default.StartBefore(server2, ready=When.FileContains(ts.Disk.diags
 tr3.StillRunningAfter = ts
 tr3.StillRunningAfter = server
 tr3.MakeCurlCommand(
-    f"-q --tls-max 1.2 -s -v -k  --cert ./signed-bar.pem --key ./signed-bar.key --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}"
-)
+    f"-q --tls-max 1.2 -s -v -k  --cert ./signed-bar.pem --key ./signed-bar.key --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' https://{sni_domain}:{ts.Variables.ssl_port}",
+    ts=ts)
 tr3.Processes.Default.ReturnCode = 0
 # since the 2nd config with http2 turned on should have failed and used the prior config, verify http2 was not used
 tr3.Processes.Default.Streams.stderr = Testers.ExcludesExpression("GET / HTTP/2", "Confirm that HTTP2 is still not used")

--- a/tests/gold_tests/tls/tls_tunnel.test.py
+++ b/tests/gold_tests/tls/tls_tunnel.test.py
@@ -126,7 +126,7 @@ ts.Disk.sni_yaml.AddLines(
 
 tr = Test.AddTestRun("foo.com Tunnel-test")
 tr.TimeOut = 5
-tr.MakeCurlCommand("-v --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
@@ -146,7 +146,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("foo ok", "Should
 
 tr = Test.AddTestRun("bob.bar.com Tunnel-test")
 tr.TimeOut = 5
-tr.MakeCurlCommand("-v --resolve 'bob.bar.com:{0}:127.0.0.1' -k  https://bob.bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v --resolve 'bob.bar.com:{0}:127.0.0.1' -k  https://bob.bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -159,7 +159,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("foo ok", "Should
 
 tr = Test.AddTestRun("bar.com no Tunnel-test")
 tr.TimeOut = 5
-tr.MakeCurlCommand("-v --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -168,7 +168,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("ATS", "Terminate
 
 tr = Test.AddTestRun("no SNI Tunnel-test")
 tr.TimeOut = 5
-tr.MakeCurlCommand("-v -k  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -180,7 +180,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("bar ok", "Should
 
 tr = Test.AddTestRun("one.match.com Tunnel-test")
 tr.TimeOut = 5
-tr.MakeCurlCommand("-vvv --resolve 'one.match.com:{0}:127.0.0.1' -k  https://one.match.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-vvv --resolve 'one.match.com:{0}:127.0.0.1' -k  https://one.match.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -193,7 +194,8 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("foo ok", "Should
 
 tr = Test.AddTestRun("one.ok.two.com Tunnel-test")
 tr.TimeOut = 5
-tr.MakeCurlCommand("-vvv --resolve 'one.ok.two.com:{0}:127.0.0.1' -k  https://one.ok.two.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-vvv --resolve 'one.ok.two.com:{0}:127.0.0.1' -k  https://one.ok.two.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
@@ -207,7 +209,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("foo ok", "Should
 tr = Test.AddTestRun("test {inbound_local_port}")
 tr.TimeOut = 5
 tr.MakeCurlCommand(
-    "-vvv --resolve 'incoming.port.com:{0}:127.0.0.1' -k  https://incoming.port.com:{0}".format(ts.Variables.ssl_port))
+    "-vvv --resolve 'incoming.port.com:{0}:127.0.0.1' -k  https://incoming.port.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 # The tunnel connecting to the outgoing port which is the same as the incoming
 # port (per the `inbound_local_port` configuration) will result in ATS
 # connecting back to itself. This will result in a connection close and a
@@ -255,7 +257,8 @@ tr = Test.AddTestRun("test wildcard with inbound_local_port")
 tr.TimeOut = 5
 tr.MakeCurlCommand(
     "-vvv --resolve 'wildcard.with.incoming.port.com:{0}:127.0.0.1' -k  https://wildcard.with.incoming.port.com:{0}".format(
-        ts.Variables.ssl_port))
+        ts.Variables.ssl_port),
+    ts=ts)
 
 # See the inbound_local_port test above for the explanation of the return code.
 tr.ReturnCode = 35
@@ -345,14 +348,14 @@ tr.TimeOut = 30
 tr.StillRunningAfter = ts
 # Wait for the reload to complete by running the sni_reload_done test
 tr.Processes.Default.StartBefore(server2, ready=When.FileContains(ts.Disk.diags_log.Name, 'sni.yaml finished loading', 2))
-tr.MakeCurlCommand("-v --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("Not Found on Accelerato", "Terminates on on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("ATS", "Terminate on Traffic Server")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 # Should tunnel to server_bar
 tr = Test.AddTestRun("bar.com  Tunnel-test")
-tr.MakeCurlCommand("-v --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v --resolve 'bar.com:{0}:127.0.0.1' -k  https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")

--- a/tests/gold_tests/tls/tls_tunnel_forward.test.py
+++ b/tests/gold_tests/tls/tls_tunnel_forward.test.py
@@ -87,7 +87,7 @@ ts.Disk.sni_yaml.AddLines(
     ])
 
 tr = Test.AddTestRun("Tunnel-test")
-tr.MakeCurlCommand("-v  --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v  --resolve 'foo.com:{0}:127.0.0.1' -k  https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
@@ -104,7 +104,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("ok foo", "Body i
 
 tr2 = Test.AddTestRun("Forward-test")
 tr2.MakeCurlCommand(
-    "-v --http1.1  -H 'host:bar.com' --resolve 'bar.com:{0}:127.0.0.1' -k https://bar.com:{0}".format(ts.Variables.ssl_port))
+    "-v --http1.1  -H 'host:bar.com' --resolve 'bar.com:{0}:127.0.0.1' -k https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server_bar
 tr2.StillRunningAfter = ts
@@ -116,7 +116,7 @@ tr2.Processes.Default.Streams.All += Testers.ContainsExpression("HTTP/1.1 200 OK
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression("ok bar", "Body is expected")
 
 tr3 = Test.AddTestRun("no-sni-forward-test")
-tr3.MakeCurlCommand("--http1.1 -v -k -H 'host:random.com' https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand("--http1.1 -v -k -H 'host:random.com' https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server_random
 tr3.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_verify.test.py
+++ b/tests/gold_tests/tls/tls_verify.test.py
@@ -114,7 +114,7 @@ tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
 tr.Setup.Copy("ssl/signed-wild.pem")
 tr.Setup.Copy("ssl/signed-wild.key")
-tr.MakeCurlCommand("-v -k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
@@ -126,28 +126,28 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("Override-enforcing-Test")
-tr2.MakeCurlCommand("-v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("Override-enforcing-Test-fail-name-check")
-tr3.MakeCurlCommand("-v -k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand("-v -k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
 
 tr4 = Test.AddTestRun("Exercise-wildcard-cert-name-check")
-tr4.MakeCurlCommand("-v -k -H \"host: foo.wild.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr4.MakeCurlCommand("-v -k -H \"host: foo.wild.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr4.ReturnCode = 0
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
 
 tr5 = Test.AddTestRun("Exercise-wildcard-cert-underscore-name-check")
-tr5.MakeCurlCommand("-v -k -H \"host: foo_bar.wild.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr5.MakeCurlCommand("-v -k -H \"host: foo_bar.wild.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr5.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr5.ReturnCode = 0
 tr5.StillRunningAfter = server

--- a/tests/gold_tests/tls/tls_verify2.test.py
+++ b/tests/gold_tests/tls/tls_verify2.test.py
@@ -96,7 +96,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand("-k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
@@ -107,35 +107,35 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("override-disabled")
-tr2.MakeCurlCommand("-k -H \"host: random.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-k -H \"host: random.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("override-permissive")
-tr3.MakeCurlCommand("-k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand("-k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr4 = Test.AddTestRun("override-permissive-bad-name")
-tr4.MakeCurlCommand("-k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr4.MakeCurlCommand("-k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr4.ReturnCode = 0
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr5 = Test.AddTestRun("default-enforce-bad-sig")
-tr5.MakeCurlCommand("-k -H \"host: random2.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr5.MakeCurlCommand("-k -H \"host: random2.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr5.ReturnCode = 0
 tr5.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr5.StillRunningAfter = server
 tr5.StillRunningAfter = ts
 
 tr6 = Test.AddTestRun("default-enforce-fail")
-tr6.MakeCurlCommand("-k -H \"host: bad_foo.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr6.MakeCurlCommand("-k -H \"host: bad_foo.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr6.ReturnCode = 0
 tr6.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr6.StillRunningAfter = server

--- a/tests/gold_tests/tls/tls_verify3.test.py
+++ b/tests/gold_tests/tls/tls_verify3.test.py
@@ -103,7 +103,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.StartBefore(server_foo)
@@ -114,28 +114,29 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr = Test.AddTestRun("my.random.com Permissive-Test log failure")
-tr.MakeCurlCommand("-v -k --resolve 'my.random.com:{0}:127.0.0.1' https://my.random.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k --resolve 'my.random.com:{0}:127.0.0.1' https://my.random.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("bob.bar.com Override-enforcing-Test")
-tr2.MakeCurlCommand("-v -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'bob.bar.com:{0}:127.0.0.1' https://bob.bar.com:{0}/".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("bob.foo.com override-enforcing-name-test")
-tr3.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand("-v -k --resolve 'bob.foo.com:{0}:127.0.0.1' https://bob.foo.com:{0}/".format(ts.Variables.ssl_port), ts=ts)
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should not fail")
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
 
 tr3 = Test.AddTestRun("random.bar.com override-no-test")
-tr3.MakeCurlCommand("-v -k --resolve 'random.bar.com:{0}:127.0.0.1' https://random.bar.com:{0}".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand(
+    "-v -k --resolve 'random.bar.com:{0}:127.0.0.1' https://random.bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should not fail")
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server

--- a/tests/gold_tests/tls/tls_verify4.test.py
+++ b/tests/gold_tests/tls/tls_verify4.test.py
@@ -91,7 +91,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand("-k -H \"host: random2.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-k -H \"host: random2.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
@@ -139,7 +139,7 @@ trreload.Processes.Default.Env = ts.Env
 trreload.Processes.Default.ReturnCode = 0
 
 tragain = Test.AddTestRun("permissive-after-update")
-tragain.MakeCurlCommand("-k -H \"host: random3.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tragain.MakeCurlCommand("-k -H \"host: random3.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tragain.ReturnCode = 0
 tragain.StillRunningAfter = server
 tragain.StillRunningAfter = ts
@@ -182,7 +182,7 @@ trreload.Processes.Default.Env = ts.Env
 trreload.Processes.Default.ReturnCode = 0
 
 tragain = Test.AddTestRun("enforced-after-update")
-tragain.MakeCurlCommand("-k -H \"host: random4.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tragain.MakeCurlCommand("-k -H \"host: random4.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tragain.ReturnCode = 0
 tragain.StillRunningAfter = server
 tragain.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_verify_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_base.test.py
@@ -96,7 +96,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand("-v -k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k -H \"host: foo.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(server_bar)
@@ -107,21 +107,21 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr = Test.AddTestRun("Permissive-Test with logged failure")
-tr.MakeCurlCommand("-v -k -H \"host: random.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v -k -H \"host: random.com\" https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("Override-enforcing-Test")
-tr2.MakeCurlCommand("-v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k -H \"host: bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("Override-enforcing-Test-fail-name-check")
-tr3.MakeCurlCommand("-v -k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port))
+tr3.MakeCurlCommand("-v -k -H \"host: bad_bar.com\"  https://127.0.0.1:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr3.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server

--- a/tests/gold_tests/tls/tls_verify_ca_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_ca_override.test.py
@@ -90,7 +90,7 @@ ts.Disk.records_config.update(
 
 # Should succeed
 tr = Test.AddTestRun("Use correct ca bundle for server 1")
-tr.MakeCurlCommand('-k -H \"host: foo.com\"  http://127.0.0.1:{0}/case1'.format(ts.Variables.port))
+tr.MakeCurlCommand('-k -H \"host: foo.com\"  http://127.0.0.1:{0}/case1'.format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
@@ -104,7 +104,7 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("Use incorrect ca  bundle for server 1")
-tr2.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/badcase1".format(ts.Variables.port))
+tr2.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/badcase1".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server1
 tr2.StillRunningAfter = ts
@@ -112,7 +112,7 @@ tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("Use correct ca bundle for server 2")
-tr2.MakeCurlCommand("-k -H \"host: random.com\"  http://127.0.0.1:{0}/case2".format(ts.Variables.port))
+tr2.MakeCurlCommand("-k -H \"host: random.com\"  http://127.0.0.1:{0}/case2".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server2
 tr2.StillRunningAfter = ts
@@ -120,7 +120,7 @@ tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("User incorrect ca bundle for server 2")
-tr3.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/badcase2".format(ts.Variables.port))
+tr3.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/badcase2".format(ts.Variables.port), ts=ts)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server2
 tr3.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_verify_not_pristine.test.py
+++ b/tests/gold_tests/tls/tls_verify_not_pristine.test.py
@@ -81,7 +81,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand("-v --resolve 'bar.com:{0}:127.0.0.1' -k https://bar.com:{0}".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand("-v --resolve 'bar.com:{0}:127.0.0.1' -k https://bar.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(server_foo)
 tr.Processes.Default.StartBefore(dns)
@@ -92,7 +92,7 @@ tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Conn
 
 # foo.com in.  bar.com out.  Should not verify
 tr2 = Test.AddTestRun("Enforced-bad-test")
-tr2.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port))
+tr2.MakeCurlCommand("-v -k --resolve 'foo.com:{0}:127.0.0.1' https://foo.com:{0}".format(ts.Variables.ssl_port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_verify_override.test.py
+++ b/tests/gold_tests/tls/tls_verify_override.test.py
@@ -133,7 +133,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand('-v -k -H \"host: foo.com\"  http://127.0.0.1:{0}/basic'.format(ts.Variables.port))
+tr.MakeCurlCommand('-v -k -H \"host: foo.com\"  http://127.0.0.1:{0}/basic'.format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(server_foo)
@@ -147,7 +147,7 @@ tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("default-permissive-fail")
-tr2.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port))
+tr2.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -156,7 +156,7 @@ tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connec
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("default-permissive-fail2")
-tr2.MakeCurlCommand("-v -k -H \"host: random.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port))
+tr2.MakeCurlCommand("-v -k -H \"host: random.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -165,7 +165,7 @@ tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connec
 tr2.Processes.Default.Streams.All += Testers.ContainsExpression("404 Not Found", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("default-foo-to-bar")
-tr3.MakeCurlCommand("-k -v -H \"host: foo.com\"  http://127.0.0.1:{0}/basictobar".format(ts.Variables.port))
+tr3.MakeCurlCommand("-k -v -H \"host: foo.com\"  http://127.0.0.1:{0}/basictobar".format(ts.Variables.port), ts=ts)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
@@ -174,7 +174,7 @@ tr3.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connec
 tr3.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("override-foo")
-tr3.MakeCurlCommand("-k -v -H \"host: foo.com\"  http://127.0.0.1:{0}/override".format(ts.Variables.port))
+tr3.MakeCurlCommand("-k -v -H \"host: foo.com\"  http://127.0.0.1:{0}/override".format(ts.Variables.port), ts=ts)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
@@ -183,7 +183,7 @@ tr3.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connec
 tr3.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
 
 tr4 = Test.AddTestRun("override-bar-disabled")
-tr4.MakeCurlCommand("-k -v -H \"host: bad_bar.com\"  http://127.0.0.1:{0}/overridedisabled".format(ts.Variables.port))
+tr4.MakeCurlCommand("-k -v -H \"host: bad_bar.com\"  http://127.0.0.1:{0}/overridedisabled".format(ts.Variables.port), ts=ts)
 tr4.ReturnCode = 0
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
@@ -192,7 +192,7 @@ tr4.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connec
 tr4.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
 
 tr5 = Test.AddTestRun("override-bar-signature-enforced")
-tr5.MakeCurlCommand("-k -v -H \"host: bar.com\"  http://127.0.0.1:{0}/overridesignature".format(ts.Variables.port))
+tr5.MakeCurlCommand("-k -v -H \"host: bar.com\"  http://127.0.0.1:{0}/overridesignature".format(ts.Variables.port), ts=ts)
 tr5.ReturnCode = 0
 tr5.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr5.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
@@ -200,7 +200,7 @@ tr5.StillRunningAfter = server
 tr5.StillRunningAfter = ts
 
 tr5a = Test.AddTestRun("override-bar-none-permissive")
-tr5a.MakeCurlCommand("-k -v -H \"host: bar.com\"  http://127.0.0.1:{0}/overridenone".format(ts.Variables.port))
+tr5a.MakeCurlCommand("-k -v -H \"host: bar.com\"  http://127.0.0.1:{0}/overridenone".format(ts.Variables.port), ts=ts)
 tr5a.ReturnCode = 0
 tr5a.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr5a.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl attempt should have succeeded")
@@ -208,7 +208,7 @@ tr5a.StillRunningAfter = server
 tr5a.StillRunningAfter = ts
 
 tr6 = Test.AddTestRun("override-bar-enforced")
-tr6.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/overrideenforced".format(ts.Variables.port))
+tr6.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/overrideenforced".format(ts.Variables.port), ts=ts)
 tr6.ReturnCode = 0
 # Should fail
 tr6.Processes.Default.Streams.All = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
@@ -217,7 +217,7 @@ tr6.StillRunningAfter = ts
 
 # Should succeed
 tr = Test.AddTestRun("foo-to-bar-sni-policy-remap")
-tr.MakeCurlCommand("-v -k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarremap".format(ts.Variables.port))
+tr.MakeCurlCommand("-v -k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarremap".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -226,7 +226,7 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression("200 OK", "Curl a
 
 # Should fail
 tr = Test.AddTestRun("foo-to-bar-sni-policy-host")
-tr.MakeCurlCommand("-v -k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarhost".format(ts.Variables.port))
+tr.MakeCurlCommand("-v -k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarhost".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -234,7 +234,7 @@ tr.Processes.Default.Streams.All = Testers.ContainsExpression("Could not connect
 
 # Should fail
 tr = Test.AddTestRun("bar-to-foo-sni-policy-remap")
-tr.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfooremap".format(ts.Variables.port))
+tr.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfooremap".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -242,7 +242,7 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not conn
 
 # Should succeed
 tr = Test.AddTestRun("bar-to-foo-sni-policy-host")
-tr.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfoohost".format(ts.Variables.port))
+tr.MakeCurlCommand("-v -k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfoohost".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_verify_override_base.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_base.test.py
@@ -129,7 +129,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand('-k -H \"host: foo.com\"  http://127.0.0.1:{0}/basic'.format(ts.Variables.port))
+tr.MakeCurlCommand('-k -H \"host: foo.com\"  http://127.0.0.1:{0}/basic'.format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(server_foo)
@@ -142,7 +142,7 @@ tr.StillRunningAfter = ts
 tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("default-permissive-fail")
-tr2.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port))
+tr2.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -150,7 +150,7 @@ tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("default-permissive-fail2")
-tr2.MakeCurlCommand("-k -H \"host: random.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port))
+tr2.MakeCurlCommand("-k -H \"host: random.com\"  http://127.0.0.1:{0}/basic".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
@@ -158,7 +158,7 @@ tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr3 = Test.AddTestRun("override-foo")
-tr3.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/override".format(ts.Variables.port))
+tr3.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/override".format(ts.Variables.port), ts=ts)
 tr3.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
@@ -166,7 +166,7 @@ tr3.StillRunningAfter = ts
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr4 = Test.AddTestRun("override-bar-disabled")
-tr4.MakeCurlCommand("-k -H \"host: bad_bar.com\"  http://127.0.0.1:{0}/overridedisabled".format(ts.Variables.port))
+tr4.MakeCurlCommand("-k -H \"host: bad_bar.com\"  http://127.0.0.1:{0}/overridedisabled".format(ts.Variables.port), ts=ts)
 tr4.ReturnCode = 0
 tr4.StillRunningAfter = server
 tr4.StillRunningAfter = ts
@@ -174,14 +174,14 @@ tr4.StillRunningAfter = ts
 tr4.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr5 = Test.AddTestRun("override-bar-signature-enforced")
-tr5.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/overridesignature".format(ts.Variables.port))
+tr5.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/overridesignature".format(ts.Variables.port), ts=ts)
 tr5.ReturnCode = 0
 tr5.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 tr5.StillRunningAfter = server
 tr5.StillRunningAfter = ts
 
 tr6 = Test.AddTestRun("override-bar-enforced")
-tr6.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/overrideenforced".format(ts.Variables.port))
+tr6.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/overrideenforced".format(ts.Variables.port), ts=ts)
 tr6.ReturnCode = 0
 # Should fail
 tr6.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should have failed")
@@ -190,7 +190,7 @@ tr6.StillRunningAfter = ts
 
 # Should succeed
 tr = Test.AddTestRun("foo-to-bar-sni-policy-remap")
-tr.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarremap".format(ts.Variables.port))
+tr.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarremap".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -198,7 +198,7 @@ tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could not conn
 
 # Should fail
 tr = Test.AddTestRun("foo-to-bar-sni-policy-host")
-tr.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarhost".format(ts.Variables.port))
+tr.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/snipolicybarhost".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -206,7 +206,8 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not conn
 
 # Should fail
 tr = Test.AddTestRun("foo-to-bar-sni-policy-servername")
-tr.MakeCurlCommand("-k --resolve foo.com:{0}:127.0.0.1 https://foo.com:{0}/snipolicybarservername".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-k --resolve foo.com:{0}:127.0.0.1 https://foo.com:{0}/snipolicybarservername".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -214,7 +215,7 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not conn
 
 # Should fail
 tr = Test.AddTestRun("bar-to-foo-sni-policy-remap")
-tr.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfooremap".format(ts.Variables.port))
+tr.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfooremap".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -222,7 +223,7 @@ tr.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could not conn
 
 # Should succeed
 tr = Test.AddTestRun("bar-to-foo-sni-policy-host")
-tr.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfoohost".format(ts.Variables.port))
+tr.MakeCurlCommand("-k -H \"host: bar.com\"  http://127.0.0.1:{0}/snipolicyfoohost".format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
@@ -230,7 +231,8 @@ tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could not conn
 
 # Should succeed
 tr = Test.AddTestRun("bar-to-foo-sni-policy-servername")
-tr.MakeCurlCommand("-k --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}/snipolicyfooservername".format(ts.Variables.ssl_port))
+tr.MakeCurlCommand(
+    "-k --resolve bar.com:{0}:127.0.0.1 https://bar.com:{0}/snipolicyfooservername".format(ts.Variables.ssl_port), ts=ts)
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts

--- a/tests/gold_tests/tls/tls_verify_override_sni.test.py
+++ b/tests/gold_tests/tls/tls_verify_override_sni.test.py
@@ -123,7 +123,7 @@ tr.Setup.Copy("ssl/signed-foo.key")
 tr.Setup.Copy("ssl/signed-foo.pem")
 tr.Setup.Copy("ssl/signed-bar.key")
 tr.Setup.Copy("ssl/signed-bar.pem")
-tr.MakeCurlCommand('-k -H \"host: foo.com\"  http://127.0.0.1:{0}/defaultbar'.format(ts.Variables.port))
+tr.MakeCurlCommand('-k -H \"host: foo.com\"  http://127.0.0.1:{0}/defaultbar'.format(ts.Variables.port), ts=ts)
 tr.ReturnCode = 0
 tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(server_foo)
@@ -134,14 +134,14 @@ tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Conn
 
 # should fail.  Exercise the override
 tr2 = Test.AddTestRun("policy-override-fail")
-tr2.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/overridepolicy".format(ts.Variables.port))
+tr2.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/overridepolicy".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ContainsExpression("Could Not Connect", "Curl attempt should fail")
 
 # should succeed with an error message
 tr2 = Test.AddTestRun("properties-override-permissive")
-tr2.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/overrideproperties".format(ts.Variables.port))
+tr2.MakeCurlCommand("-k -H \"host: foo.com\"  http://127.0.0.1:{0}/overrideproperties".format(ts.Variables.port), ts=ts)
 tr2.ReturnCode = 0
 tr2.StillRunningAfter = ts
 tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")

--- a/tests/gold_tests/tls_hooks/tls_hooks.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks.test.py
@@ -55,7 +55,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-v -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-v -k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 tr.Processes.Default.Streams.All = Testers.ExcludesExpression(

--- a/tests/gold_tests/tls_hooks/tls_hooks10.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks10.test.py
@@ -53,7 +53,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.traffic_out.Content = "gold/ts-cert-1-im-2.gold"

--- a/tests/gold_tests/tls_hooks/tls_hooks11.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks11.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks12.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks12.test.py
@@ -53,7 +53,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.traffic_out.Content = "gold/ts-preaccept-delayed-1-immdate-2.gold"

--- a/tests/gold_tests/tls_hooks/tls_hooks13.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks13.test.py
@@ -53,7 +53,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.traffic_out.Content = "gold/ts-out-start-close-2.gold"

--- a/tests/gold_tests/tls_hooks/tls_hooks14.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks14.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.traffic_out.Content = "gold/ts-out-delay-start-2.gold"

--- a/tests/gold_tests/tls_hooks/tls_hooks15.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks15.test.py
@@ -53,7 +53,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 
 ts.Disk.traffic_out.Content = "gold/ts-close-out-close.gold"

--- a/tests/gold_tests/tls_hooks/tls_hooks16.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks16.test.py
@@ -56,7 +56,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/client-hello-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks17.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks17.test.py
@@ -56,7 +56,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/client-hello-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks18.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks18.test.py
@@ -56,7 +56,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks2.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks2.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks3.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks3.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks4.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks4.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks6.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks6.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks7.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks7.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks8.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks8.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tls_hooks/tls_hooks9.test.py
+++ b/tests/gold_tests/tls_hooks/tls_hooks9.test.py
@@ -54,7 +54,7 @@ tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
-tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port))
+tr.MakeCurlCommand('-k -H \'host:example.com:{0}\' https://127.0.0.1:{0}'.format(ts.Variables.ssl_port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/preaccept-1.gold"
 

--- a/tests/gold_tests/tunnel/tunnel_transform.test.py
+++ b/tests/gold_tests/tunnel/tunnel_transform.test.py
@@ -85,7 +85,7 @@ cmd_tunnel = '-k --http1.1 -H "Connection: close" -vs --resolve "tunnel-test:{0}
 
 # Send the tunnel request
 tr.Processes.Default.Env = ts.Env
-tr.MakeCurlCommand(cmd_tunnel)
+tr.MakeCurlCommand(cmd_tunnel, ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.TimeOut = 10
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.SSL_Port))

--- a/tests/gold_tests/tunnel/txn_type.test.py
+++ b/tests/gold_tests/tunnel/txn_type.test.py
@@ -85,7 +85,7 @@ cmd_connect = '-k --http1.1 -H "Connection: close" -vs --resolve "connect-proxy:
 # Send the http request
 tr = Test.AddTestRun("send http request")
 tr.Processes.Default.Env = ts.Env
-tr.MakeCurlCommand(cmd_http)
+tr.MakeCurlCommand(cmd_http, ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.SSL_Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
@@ -95,7 +95,7 @@ tr.StillRunningAfter = server
 # Send the tunnel request
 tr = Test.AddTestRun("send tunnel request")
 tr.Processes.Default.Env = ts.Env
-tr.MakeCurlCommand(cmd_tunnel)
+tr.MakeCurlCommand(cmd_tunnel, ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
@@ -106,7 +106,7 @@ tr.StillRunningAfter = server
 # method to determine whether a connect tunnel will be set up
 tr = Test.AddTestRun("send connect request")
 tr.Processes.Default.Env = ts.Env
-tr.MakeCurlCommand(cmd_connect)
+tr.MakeCurlCommand(cmd_connect, ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server


### PR DESCRIPTION
- Have parameters with default at the end to force ts to be included with `CurlCommand`
- Instead of copying test files to filter, temporary mv unnecessary test dir when running autest
    - maintains one dir for test files 