### PR TITLE
Fix cripts build issue

### DIFF
--- a/src/cripts/Certs.cc
+++ b/src/cripts/Certs.cc
@@ -190,7 +190,7 @@ CertBase::SAN::SANBase::_load() const
   auto bio = BIO_new(BIO_s_mem());
 
   if (bio) {
-    for (int i = 0; i < sk_GENERAL_NAME_num(san_names); ++i) {
+    for (int i = 0; i < static_cast<int>(sk_GENERAL_NAME_num(san_names)); ++i) {
       const GENERAL_NAME *name = sk_GENERAL_NAME_value(san_names, i);
 
       if (static_cast<cripts::Certs::SAN>(name->type) == _san_id) {


### PR DESCRIPTION
`sk_GENERAL_NAME_num` from BoringSSL returns `size_t`.

Same as this place:
https://github.com/apache/trafficserver/blob/636772a5c5ad89d19d4fcdc9a1a797228c243237/src/tscore/X509HostnameValidator.cc#L242

The line was added by #12320. If the change is going to be back ported 10.1.x, this one should be ported too.
