### PR TITLE
traffic_ctl: get all host statuses by empty arg

### DIFF
--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -131,7 +131,7 @@ main([[maybe_unused]] int argc, const char **argv)
   config_command.add_command("registry", "Show configuration file registry", [&]() { command->execute(); })
     .add_example_usage("traffic_ctl config registry");
   // host commands
-  host_command.add_command("status", "Get one or more host statuses", "", MORE_THAN_ONE_ARG_N, [&]() { command->execute(); })
+  host_command.add_command("status", "Get one or more host statuses", "", MORE_THAN_ZERO_ARG_N, [&]() { command->execute(); })
     .add_example_usage("traffic_ctl host status HOST  [HOST  ...]");
   host_command.add_command("down", "Set down one or more host(s)", "", MORE_THAN_ONE_ARG_N, [&]() { command->execute(); })
     .add_example_usage("traffic_ctl host down HOST [OPTIONS]")


### PR DESCRIPTION
`server_get_status` returns all host statuses if given param is empty, but `traffic_ctl` requires one argument. This relaxes the restriction.
https://github.com/apache/trafficserver/blob/636772a5c5ad89d19d4fcdc9a1a797228c243237/src/proxy/HostStatus.cc#L458-L468