### PR TITLE
Skip autest for PROXY protocol if the version of curl is old

### DIFF
--- a/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py
@@ -22,7 +22,10 @@ Test.Summary = '''
 Test TS API to get PROXY protocol info
 '''
 
-Test.SkipUnless(Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),)
+Test.SkipUnless(
+    Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
+    Condition.HasCurlVersion("8.2.0"),
+)
 Test.ContinueOnFail = True
 
 # ----


### PR DESCRIPTION
`--haproxy-clientip` is available only on curl 8.2.0 or later.