### PR TITLE
Fix: [ATS 200 response after 302 not cached] (#12369)

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2062,7 +2062,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
     t_state.api_next_action       = HttpTransact::StateMachineAction_t::API_READ_RESPONSE_HDR;
 
     // if exceeded limit deallocate postdata buffers and disable redirection
-    if (!(enable_redirection && (redirection_tries < t_state.txn_conf->number_of_redirections))) {
+    if (!(enable_redirection && (redirection_tries <= t_state.txn_conf->number_of_redirections))) {
       this->disable_redirect();
     }
 


### PR DESCRIPTION
Fix: [ATS 9.2.x: 200 response after 302 not cached]

With backport markers:
- Project: 9.2.x
- Project: 10.x