### PR TITLE
cache_promote: Bugfix, don't repurpose policies without labels

### DIFF
--- a/plugins/cache_promote/cache_promote.cc
+++ b/plugins/cache_promote/cache_promote.cc
@@ -77,13 +77,13 @@ cont_handle_policy(TSCont contp, TSEvent event, void *edata)
           // Do nothing, just let it handle the lookup.
           DBG("cache-status is %d (hit), nothing to do", obj_status);
 
-          if (config->getPolicy()->_stats_enabled) {
+          if (!config->getPolicy()->_stats_id.empty()) {
             TSStatIntIncrement(config->getPolicy()->_cache_hits_id, 1);
           }
           break;
         }
       }
-      if (config->getPolicy()->_stats_enabled) {
+      if (!config->getPolicy()->_stats_id.empty()) {
         TSStatIntIncrement(config->getPolicy()->_total_requests_id, 1);
       }
     } else {

--- a/plugins/cache_promote/configs.cc
+++ b/plugins/cache_promote/configs.cc
@@ -74,7 +74,7 @@ PromotionConfig::factory(int argc, char *argv[])
         return false;
       } else {
         if (_policy && _policy->stats_add(optarg)) {
-          _policy->_stats_enabled = true;
+          _policy->_stats_id = optarg;
           DBG("stats collection is enabled");
         }
       }

--- a/plugins/cache_promote/lru_policy.h
+++ b/plugins/cache_promote/lru_policy.h
@@ -120,8 +120,12 @@ public:
   const std::string
   id() const override
   {
+    if (_label.empty()) {
+      return ""; // This will prevent the policy factory from coalescing this policy
+    }
+
     return _label + ";LRU=b:" + std::to_string(_buckets) + ",h:" + std::to_string(_hits) + ",B:" + std::to_string(_bytes) +
-           ",i:" + std::to_string(_internal_enabled);
+           ",i:" + std::to_string(_internal_enabled) + ",e:" + _stats_id;
   }
 
   void

--- a/plugins/cache_promote/policy.h
+++ b/plugins/cache_promote/policy.h
@@ -63,7 +63,7 @@ public:
   void
   decrementStat(const int stat, const int amount)
   {
-    if (_stats_enabled) {
+    if (!_stats_id.empty()) {
       TSStatIntDecrement(stat, amount);
     }
   }
@@ -71,7 +71,7 @@ public:
   void
   incrementStat(const int stat, const int amount)
   {
-    if (_stats_enabled) {
+    if (!_stats_id.empty()) {
       TSStatIntIncrement(stat, amount);
     }
   }
@@ -127,12 +127,11 @@ public:
   virtual void        usage() const                   = 0;
   virtual bool        stats_add(const char *remap_id) = 0;
 
-  // when true stats are incremented.
-  bool _stats_enabled     = false;
-  bool _internal_enabled  = false;
-  int  _cache_hits_id     = -1;
-  int  _promoted_id       = -1;
-  int  _total_requests_id = -1;
+  bool        _internal_enabled  = false;
+  int         _cache_hits_id     = -1;
+  int         _promoted_id       = -1;
+  int         _total_requests_id = -1;
+  std::string _stats_id          = "";
 
 private:
   float _sample = 0.0;


### PR DESCRIPTION
Leaving it up to the RMs for back ports, this has been a bug since v8.1... :/ It's generally not an issue unless you have two identical LRUs / settings, at which point you can get an accidental share.

This fixes #12368.

(there are actually two bugs here, but the stats-id one is less serious than the label issue).