### PR TITLE
Cripts: Refactor the cache key / URL APIs

### DIFF
--- a/doc/developer-guide/cripts/cripts-convenience.en.rst
+++ b/doc/developer-guide/cripts/cripts-convenience.en.rst
@@ -72,9 +72,10 @@ Object                        Traditional API equivalent
 ``server.request``            ``borrow cripts::Server::Request::Get()``
 ``server.response``           ``borrow cripts::Server::Response::Get()``
 ``server.connection``         ``borrow cripts::Server::Connection::Get()``
+``cached.url``                ``borrow cripts::Cache::URL::Get()``
+``cached.response``           ``borrow cripts::Cache::Response::Get()``
 ``urls.request``              ``borrow cripts::Client::URL::Get()``
 ``urls.pristine``             ``borrow cripts::Pristine::URL::Get()``
-``urls.cache``                ``borrow cripts::Cache::URL::Get()``
 ``urls.parent``               ``borrow cripts::Parent::URL::Get()``
 ``urls.remap.to``             ``borrow cripts::Remap::To::URL::Get()``
 ``urls.remap.from``           ``borrow cripts::Remap::From::URL::Get()``

--- a/doc/developer-guide/cripts/cripts-misc.en.rst
+++ b/doc/developer-guide/cripts/cripts-misc.en.rst
@@ -88,7 +88,6 @@ Function                    Description
 =========================   =======================================================================
 ``DisableCallback()``       Disables a future callback in this Cript, for this transaction.
 ``Aborted()``               Has the transaction been aborted.
-``LookupStatus()``          Returns the cache lookup status for the transaction.
 =========================   =======================================================================
 
 When disabling a callback, use the following names:
@@ -182,9 +181,9 @@ Example usage:
 Time
 ====
 
-Cripts has encapsulated some common time-related functions in the core.  At the
-moment only the localtime is available, via the ``cripts::Time::Local`` object and its
-``Now()`` method. The ``Now()`` method returns the current time as an object
+Cripts has encapsulated some common time-related functions in the core.  Two different time objects
+are available, ``cripts::Time::Local`` and ``cripts::Time::UTC`` objects and their respective
+``::Now()`` methods. The ``Now()`` method returns the current time as an object
 with the following functions:
 
 =====================   ===========================================================================
@@ -199,10 +198,11 @@ Function                Description
 ``Second()``            Returns the second (0-59).
 ``WeekDay()``           Returns the day of the week (0-6, Sunday is 0).
 ``YearDay()``           Returns the day of the year (0-365).
+``ToDate()``            Returns a string for the Date in HTTP header format
 =====================   ===========================================================================
 
 The time as returned by ``Now()`` can also be used directly in comparisons with previous or future
-times, and can be cast to an integer to get the epoch time.
+times. In addition, the ``Now()`` constructor can take an optional ``cripts::Time::Point`` argument.
 
 Example usage:
 
@@ -212,12 +212,8 @@ Example usage:
    {
      auto now = cripts::Time::Local::Now();
 
-     CDebug("Current time: year={}, month={}, day={}",
-            now.Year(), now.Month(), now.Day());
+     CDebug("Current time: year={}, month={}, day={}", now.Year(), now.Month(), now.Day());
      CDebug("Epoch time: {}", now.Epoch());
-
-     // Can also be used directly as integer
-     integer epoch_time = now;
    }
 
 .. _cripts-misc-plugins:

--- a/example/cripts/example1.cc
+++ b/example/cripts/example1.cc
@@ -79,16 +79,17 @@ do_read_response()
 
 do_send_response()
 {
-  borrow resp = cripts::Client::Response::Get();
-  borrow conn = cripts::Client::Connection::Get();
-  string msg  = "Eliminate TSCPP";
+  borrow resp   = cripts::Client::Response::Get();
+  borrow conn   = cripts::Client::Connection::Get();
+  borrow cached = cripts::Cache::Response::Get();
+  string msg    = "Eliminate TSCPP";
 
   resp["Server"]         = "";        // Deletes the Server header
   resp["X-AMC"]          = msg;       // New header
   resp["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
   resp["X-UUID"]         = cripts::UUID::Unique::Get();
   resp["X-tcpinfo"]      = conn.tcpinfo.Log();
-  resp["X-Cache-Status"] = resp.cache;
+  resp["X-Cache-Status"] = cached.lookupstatus.GetSV();
   resp["X-Integer"]      = 666;
   resp["X-Data"]         = AsString(txn_data[2]);
 

--- a/example/cripts/example2.cc
+++ b/example/cripts/example2.cc
@@ -57,8 +57,8 @@ do_txn_close()
 
 do_cache_lookup()
 {
-  CDebug("Cache URL: {}", urls.cache);
-  CDebug("Cache Host: {}", urls.cache.host);
+  CDebug("Cache URL: {}", cached.url);
+  CDebug("Cache Host: {}", cached.url.host);
 }
 
 do_send_request()
@@ -80,7 +80,7 @@ do_send_response()
   client.response["Cache-Control"]  = "Private"; // Deletes old CC values, and sets a new one
   client.response["X-UUID"]         = UniqueUUID();
   client.response["X-tcpinfo"]      = client.connection.tcpinfo.Log();
-  client.response["X-Cache-Status"] = client.response.cache;
+  client.response["X-Cache-Status"] = cached.response.lookupstatus.GetSV();
   client.response["X-Integer"]      = 666;
   client.response["X-Data"]         = AsString(txn_data[2]);
 
@@ -118,7 +118,7 @@ do_send_response()
 do_remap()
 {
   auto ip  = client.connection.IP();
-  auto now = TimeNow();
+  auto now = LocalTimeNow();
 
   if (CRIPT_ALLOW.Match(ip)) {
     CDebug("Client IP allowed: {}", ip.string(24, 64));

--- a/include/cripts/Context.hpp
+++ b/include/cripts/Context.hpp
@@ -44,7 +44,7 @@ public:
 
   // This will, and should, only be called via the ProxyAllocator as used in the factory.
   Context(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_ptr, cripts::Instance &inst)
-    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _urls(this, _client.url)
+    : rri(rri_ptr), p_instance(inst), _client(this), _server(this), _cache(this), _urls(this, _client.url)
   {
     state.txnp    = txn_ptr;
     state.ssnp    = ssn_ptr;
@@ -76,8 +76,10 @@ public:
   friend class Server::Request;
   friend class Server::Response;
   friend class Server::Connection;
-  friend class Pristine::URL;
+  friend class Server::Response;
+  friend class Cache::Response;
   friend class Cache::URL;
+  friend class Pristine::URL;
   friend class Parent::URL;
   friend class Plugin::Remap;
 
@@ -111,10 +113,21 @@ public:
 
   } _server;
 
+  struct _CacheBlock {
+    cripts::Cache::Response response;
+    cripts::Cache::URL      url;
+
+    _CacheBlock(Context *ctx)
+    {
+      response.set_state(&ctx->state);
+      url.set_context(ctx);
+    }
+
+  } _cache;
+
   struct _UrlBlock {
     cripts::Client::URL  &request;
     cripts::Pristine::URL pristine;
-    cripts::Cache::URL    cache;
     cripts::Parent::URL   parent;
 
     struct {
@@ -126,7 +139,6 @@ public:
     {
       request.set_context(ctx);
       pristine.set_context(ctx);
-      cache.set_context(ctx);
       parent.set_context(ctx);
       remap.from.set_context(ctx);
       remap.to.set_context(ctx);

--- a/include/cripts/Epilogue.hpp
+++ b/include/cripts/Epilogue.hpp
@@ -581,8 +581,8 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     if (!context->state.error.Failed()) {
-      if (context->_urls.cache.Modified()) {
-        context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+      if (context->_cache.url.Modified()) {
+        context->_cache.url._update(); // Make sure the cache-key gets updated, if modified
       }
       if (context->_urls.request.Modified()) {
         context->_urls.request._update(); // Make sure any changes to the request URL is updated
@@ -612,8 +612,8 @@ http_txn_cont(TSCont contp, TSEvent event, void *edata)
     }
 
     if (!context->state.error.Failed()) {
-      if (context->_urls.cache.Modified()) {
-        context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+      if (context->_cache.url.Modified()) {
+        context->_cache.url._update(); // Make sure the cache-key gets updated, if modified
       }
       if (context->_urls.request.Modified()) {
         context->_urls.request._update(); // Make sure any changes to the request URL is updated
@@ -899,8 +899,8 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
 
   // Don't do the callbacks when we are in a failure state.
   if (!context->state.error.Failed()) {
-    if (context->_urls.cache.Modified()) {
-      context->_urls.cache._update(); // Make sure the cache-key gets updated, if modified
+    if (context->_cache.url.Modified()) {
+      context->_cache.url._update(); // Make sure the cache-key gets updated, if modified
     }
     if (context->_urls.request.Modified()) {
       context->_urls.request._update(); // Make sure any changes to the request URL is updated

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -142,42 +142,6 @@ public:
 
   }; // End class cripts::Header::Method
 
-  class CacheStatus
-  {
-    using self_type = CacheStatus;
-
-  public:
-    CacheStatus() = delete;
-    CacheStatus(Header *owner) : _owner(owner) {}
-
-    cripts::string_view GetSV();
-
-    operator cripts::string_view() { return GetSV(); }
-
-    cripts::string_view::const_pointer
-    Data()
-    {
-      return GetSV().data();
-    }
-
-    cripts::string_view::size_type
-    Size()
-    {
-      return GetSV().size();
-    }
-
-    cripts::string_view::size_type
-    Length()
-    {
-      return GetSV().size();
-    }
-
-  private:
-    Header             *_owner = nullptr;
-    cripts::string_view _cache;
-
-  }; // Class cripts::Header::CacheStatus
-
   class String : public cripts::StringViewMixin<String>
   {
     using super_type = cripts::StringViewMixin<String>;
@@ -199,21 +163,17 @@ public:
     self_type &operator+=(const cripts::string_view str);
 
     // These specialized assignment operators all use the above
-    template <size_t N>
-    self_type &
-    operator=(const char (&str)[N])
-    {
-      return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
-    }
+    // template <size_t N>
+    // self_type &
+    // operator=(const char (&str)[N])
+    //{
+    //  return operator=(cripts::string_view(str, str[N - 1] ? N : N - 1));
+    //}
+
+    self_type &operator=(std::nullptr_t) = delete;
 
     self_type &
-    operator=(char *&str)
-    {
-      return operator=(cripts::string_view(str, strlen(str)));
-    }
-
-    self_type &
-    operator=(char const *&str)
+    operator=(char const *str)
     {
       return operator=(cripts::string_view(str, strlen(str)));
     }
@@ -331,11 +291,11 @@ public:
     static const Iterator _end;
   }; // Class cripts::Header::iterator
 
-  Header() : status(this), reason(this), body(this), cache(this) {}
+  Header() : status(this), reason(this), body(this) {}
 
   ~Header() { Reset(); }
 
-  // Clear anything "cached" in the Url, this is rather draconian, but it's
+  // Clear anything "cached" in the Header, this is rather draconian, but it's
   // safe...
   void
   Reset()
@@ -363,6 +323,7 @@ public:
   }
 
   String operator[](const cripts::string_view str);
+  time_t AsDate(const cripts::string_view str);
 
   [[nodiscard]] bool
   Initialized() const
@@ -393,10 +354,9 @@ public:
     _state = state;
   }
 
-  Status      status;
-  Reason      reason;
-  Body        body;
-  CacheStatus cache;
+  Status status;
+  Reason reason;
+  Body   body;
 
 protected:
   static void
@@ -513,6 +473,48 @@ namespace Server
 
 } // namespace Server
 
+namespace Cache
+{
+  class Response : public ResponseHeader
+  {
+    using super_type = ResponseHeader;
+    using self_type  = Response;
+
+    class LookupStatus
+    {
+      using self_type = LookupStatus;
+
+    public:
+      LookupStatus() = delete;
+      LookupStatus(Response *owner) : _owner(owner) {}
+
+      cripts::string_view GetSV();
+      self_type          &operator=(int status);
+
+      operator integer();
+
+    private:
+      Response *_owner  = nullptr;
+      int       _lookup = -1; // Note set yet
+
+    }; // Class cripts::Cache::LookupStatus
+
+  public:
+    Response() : ResponseHeader(), lookupstatus(this){};
+
+    Response(const self_type &)       = delete;
+    void operator=(const self_type &) = delete;
+
+    // Implemented later, because needs the context.
+    static self_type &_get(cripts::Context *context);
+    void              _initialize() override;
+
+    LookupStatus lookupstatus;
+
+  }; // End class Cache::Response
+
+} // namespace Cache
+
 // Some static methods for the Method class
 namespace Method
 {
@@ -529,6 +531,16 @@ namespace Method
   // This is a special feature of ATS
   extern const cripts::Header::Method PURGE;
 } // namespace Method
+
+// Lookup status constants, these are used in the Cache::Response::lookupstatus
+namespace LookupStatus
+{
+  inline constexpr int NONE      = -1;
+  inline constexpr int MISS      = TS_CACHE_LOOKUP_MISS;
+  inline constexpr int HIT_STALE = TS_CACHE_LOOKUP_HIT_STALE;
+  inline constexpr int HIT_FRESH = TS_CACHE_LOOKUP_HIT_FRESH;
+  inline constexpr int SKIPPED   = TS_CACHE_LOOKUP_SKIPPED;
+} // namespace LookupStatus
 
 class Context;
 } // namespace cripts

--- a/include/cripts/Headers.hpp
+++ b/include/cripts/Headers.hpp
@@ -162,7 +162,8 @@ public:
     self_type &operator=(integer val);
     self_type &operator+=(const cripts::string_view str);
 
-    // These specialized assignment operators all use the above
+    // ToDo: This was useful at some point, but was breaking other useful uses. Leaving
+    // it here for now for maybe future work.
     // template <size_t N>
     // self_type &
     // operator=(const char (&str)[N])

--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -112,7 +112,7 @@ public:
     }
   }
 
-  std::array<DataType, 32>                       data;
+  std::array<DataType, 16>                       data;
   cripts::string                                 to_url;
   cripts::string                                 from_url;
   cripts::string                                 plugin_debug_tag;

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <charconv>
 #include <type_traits>
+#include <chrono>
 
 #include <fmt/core.h>
 
@@ -101,6 +102,12 @@ public:
   ToBool() const
   {
     return bool(*this);
+  }
+
+  [[nodiscard]] time_t
+  ToDate() const
+  {
+    return TSMimeParseDate(_value.data(), _value.size());
   }
 
   std::vector<mixin_type>

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <vector>
 #include <tuple>
-#include <algorithm>
 
 #include "cripts/Headers.hpp"
 #include "cripts/Lulu.hpp"

--- a/include/cripts/Matcher.hpp
+++ b/include/cripts/Matcher.hpp
@@ -20,8 +20,10 @@
 // Setup for PCRE2
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
+#include <algorithm>
 #include <vector>
 #include <tuple>
+#include <algorithm>
 
 #include "cripts/Headers.hpp"
 #include "cripts/Lulu.hpp"
@@ -151,7 +153,8 @@ namespace List
     {
       auto data = method.Data();
 
-      return end() != std::find_if(begin(), end(), [&](const cripts::Header::Method &header) { return header.Data() == data; });
+      return end() !=
+             std::ranges::find_if(begin(), end(), [&](const cripts::Header::Method &header) { return header.Data() == data; });
     }
 
     [[nodiscard]] bool

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -115,12 +115,14 @@ extern cripts::Versions version; // Access to the ATS version information
 #define client                      context->_client
 #define server                      context->_server
 #define urls                        context->_urls
+#define cached                      context->_cache
 #define Regex(_name_, ...)          static cripts::Matcher::PCRE _name_(__VA_ARGS__);
 #define ACL(_name_, ...)            static cripts::Matcher::Range::IP _name_(__VA_ARGS__);
 #define StatusCode(_name_, ...)     cripts::Error::Status::Set(_name_, __VA_ARGS__);
 #define CreateCounter(_id_, _name_) instance.metrics[_id_] = cripts::Metrics::Counter::Create(_name_);
 #define CreateGauge(_id_, _name_)   instance.metrics[_id_] = cripts::Metrics::Gauge::Create(_name_);
 #define FilePath(_name_, _path_)    static const cripts::File::Path _name_(_path_);
-#define UniqueUUID()                cripts::UUID::Unique::Get();
-#define TimeNow()                   cripts::Time::Local::Now();
+#define UniqueUUID()                cripts::UUID::Unique::Get()
+#define LocalTimeNow()              cripts::Time::Local::Now()
+#define UTCTimeNow()                cripts::Time::UTC::Now()
 #endif

--- a/include/cripts/Time.hpp
+++ b/include/cripts/Time.hpp
@@ -28,6 +28,12 @@
 // std::chrono :-/ Todo: Rewrite this with std::chrono when it has things like
 // std::chrono::year_month_day
 
+namespace cripts::Time
+{
+using Clock = std::chrono::system_clock;
+using Point = Clock::time_point;
+} // namespace cripts::Time
+
 namespace detail
 {
 class BaseTime
@@ -95,16 +101,24 @@ public:
     return static_cast<integer>(_result.tm_yday) + 1;
   }
 
+  [[nodiscard]] const cripts::string_view
+  ToDate()
+  {
+    int len = sizeof(_buffer);
+
+    TSMimeFormatDate(_now, _buffer, &len);
+    return {_buffer, len};
+  }
+
 protected:
-  std::time_t _now    = std::time(nullptr);
-  std::tm     _result = {};
+  char        _buffer[64] = {};
+  std::time_t _now        = std::time(nullptr);
+  std::tm     _result     = {};
 };
 } // namespace detail
 
 namespace cripts::Time
 {
-// ToDo: Right now, we only have localtime, but we should support e.g. UTC and
-// other time zone instances.
 class Local : public detail::BaseTime
 {
   using super_type = detail::BaseTime;
@@ -123,7 +137,37 @@ public:
     return {};
   }
 
+  explicit Local(Time::Point tp)
+  {
+    _now = Time::Clock::to_time_t(tp);
+    localtime_r(&_now, static_cast<struct tm *>(&_result));
+  }
+
 }; // End class Time::Local
+
+class UTC : public detail::BaseTime
+{
+  using super_type = detail::BaseTime;
+  using self_type  = UTC;
+
+public:
+  UTC(const self_type &)            = delete;
+  void operator=(const self_type &) = delete;
+
+  UTC() { gmtime_r(&_now, static_cast<struct tm *>(&_result)); }
+
+  explicit UTC(Time::Point tp)
+  {
+    _now = Time::Clock::to_time_t(tp);
+    gmtime_r(&_now, static_cast<struct tm *>(&_result));
+  }
+
+  static UTC
+  Now()
+  {
+    return {};
+  }
+};
 
 } // namespace cripts::Time
 
@@ -139,9 +183,25 @@ template <> struct formatter<cripts::Time::Local> {
 
   template <typename FormatContext>
   auto
-  format(cripts::Time::Local &time, FormatContext &ctx) const -> decltype(ctx.out())
+  format(const cripts::Time::Local &time, FormatContext &ctx) const -> decltype(ctx.out())
   {
     return fmt::format_to(ctx.out(), "{}", time.Epoch());
   }
 };
+
+template <> struct formatter<cripts::Time::UTC> {
+  constexpr auto
+  parse(const format_parse_context &ctx) -> decltype(ctx.begin())
+  {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto
+  format(const cripts::Time::UTC &time, FormatContext &ctx) const -> decltype(ctx.out())
+  {
+    return fmt::format_to(ctx.out(), "{}", time.Epoch());
+  }
+};
+
 } // namespace fmt

--- a/include/cripts/Transaction.hpp
+++ b/include/cripts/Transaction.hpp
@@ -81,18 +81,6 @@ public:
     return false;
   }
 
-  [[nodiscard]] int
-  LookupStatus() const
-  {
-    int status = 0;
-
-    if (TSHttpTxnCacheLookupStatusGet(txnp, &status) != TS_SUCCESS) {
-      return -1;
-    }
-
-    return status;
-  }
-
 }; // class Transaction
 
 } // namespace cripts

--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -17,10 +17,12 @@
 */
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+#include <concepts>
 
 #include "ts/ts.h"
 #include "ts/remap.h"
@@ -500,7 +502,7 @@ public:
       // Make sure the hash and vector are populated
       _parser();
 
-      std::sort(_ordered.begin(), _ordered.end());
+      std::ranges::sort(_ordered);
       _modified = true;
     }
 

--- a/src/cripts/Bundles/LogsMetrics.cc
+++ b/src/cripts/Bundles/LogsMetrics.cc
@@ -113,7 +113,7 @@ LogsMetrics::doTxnClose(cripts::Context *context)
     resp["@TCPInfo"] += fmt::format(",TC; {}", conn.tcpinfo.Log());
   }
 
-  // .label(str)
+  // .propstats(str)
   if (_label.length() > 0) {
     instance.metrics[Bundle::PROPSTAT_CLIENT_BYTES_IN]->Increment(TSHttpTxnClientReqHdrBytesGet(transaction.txnp) +
                                                                   TSHttpTxnClientReqBodyBytesGet(transaction.txnp));
@@ -170,12 +170,12 @@ LogsMetrics::doSendResponse(cripts::Context *context)
 void
 LogsMetrics::doCacheLookup(cripts::Context *context)
 {
-  auto status = transaction.LookupStatus();
+  borrow cached = cripts::Cache::Response::Get();
 
-  // .label(str)
+  // .propstats(str)
   if (_label.length() > 0) {
-    if (status >= 0 && status <= 3) {
-      instance.metrics[status]->Increment(); // This assumes the 4 cache stats are first
+    if (cached.lookupstatus >= LookupStatus::MISS && cached.lookupstatus <= LookupStatus::SKIPPED) {
+      instance.metrics[cached.lookupstatus]->Increment(); // This assumes the 4 cache stats are first
     }
   }
 }
@@ -196,8 +196,9 @@ LogsMetrics::doRemap(cripts::Context *context)
 
   // .tcpinfo(bool)
   if (_tcpinfo && sampled) {
-    borrow req      = cripts::Client::Request::Get();
-    borrow conn     = cripts::Client::Connection::Get();
+    borrow req  = cripts::Client::Request::Get();
+    borrow conn = cripts::Client::Connection::Get();
+
     req["@TCPInfo"] = fmt::format("TS; {}", conn.tcpinfo.Log());
   }
 }

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -52,11 +52,11 @@ Context::reset()
   if (_urls.pristine.Initialized()) {
     _urls.pristine.Reset();
   }
-  if (_urls.cache.Initialized()) {
-    _urls.cache.Reset();
-  }
   if (_urls.parent.Initialized()) {
     _urls.parent.Reset();
+  }
+  if (_cache.url.Initialized()) {
+    _cache.url.Reset();
   }
 }
 

--- a/src/cripts/Headers.cc
+++ b/src/cripts/Headers.cc
@@ -110,30 +110,6 @@ Header::Method::GetSV()
   return _method;
 }
 
-cripts::string_view
-Header::CacheStatus::GetSV()
-{
-  static std::array<cripts::string_view, 4> names{
-    "miss",      // TS_CACHE_LOOKUP_MISS,
-    "hit-stale", // TS_CACHE_LOOKUP_HIT_STALE,
-    "hit-fresh", // TS_CACHE_LOOKUP_HIT_FRESH,
-    "skipped"    // TS_CACHE_LOOKUP_SKIPPED
-  };
-  int status;
-
-  _ensure_initialized(_owner);
-  if (_cache.size() == 0) {
-    TSAssert(_owner->_state->txnp);
-    if (TSHttpTxnCacheLookupStatusGet(_owner->_state->txnp, &status) == TS_ERROR || status < 0 || status >= 4) {
-      _cache = "none";
-    } else {
-      _cache = names[status];
-    }
-  }
-
-  return _cache;
-}
-
 Header::String &
 Header::String::operator=(const cripts::string_view str)
 {
@@ -264,6 +240,24 @@ Header::operator[](const cripts::string_view str)
     ret._initialize(str, cripts::string_view(value, len), this, field_loc);
   } else {
     ret._initialize(str, {}, this, nullptr);
+  }
+
+  return ret;
+}
+
+time_t
+Header::AsDate(const cripts::string_view str)
+{
+  _ensure_initialized(this);
+  TSAssert(_bufp && _hdr_loc);
+
+  time_t ret       = 0;
+  TSMLoc field_loc = TSMimeHdrFieldFind(_bufp, _hdr_loc, str.data(), str.size());
+
+  if (field_loc) {
+    ret = TSMimeHdrFieldValueDateGet(_bufp, _hdr_loc, field_loc);
+    // Since this is not owned by a Header::String, we have to release it now
+    TSHandleMLocRelease(_bufp, _hdr_loc, field_loc);
   }
 
   return ret;
@@ -403,6 +397,74 @@ Server::Response::_initialize()
   } else {
     super_type::_initialize(); // Don't initialize unless properly setup
   }
+}
+
+Cache::Response &
+Cache::Response::_get(cripts::Context *context)
+{
+  _ensure_initialized(&context->_cache.response);
+  return context->_cache.response;
+}
+
+void
+Cache::Response::_initialize()
+{
+  CAssert(_state->hook != TS_HTTP_READ_REQUEST_HDR_HOOK);
+  CAssert(_state->hook != TS_HTTP_POST_REMAP_HOOK);
+  CAssert(_state->hook != TS_HTTP_SEND_REQUEST_HDR_HOOK);
+
+  TSAssert(_state->txnp);
+
+  if (TSHttpTxnCachedRespGet(_state->txnp, &_bufp, &_hdr_loc) != TS_SUCCESS) {
+    _state->error.Fail();
+  } else {
+    super_type::_initialize(); // Don't initialize unless properly setup
+  }
+}
+
+Cache::Response::LookupStatus::operator integer()
+{
+  if (_lookup == -1) {
+    TSAssert(_owner->_state->txnp);
+
+    if (TSHttpTxnCacheLookupStatusGet(_owner->_state->txnp, &_lookup) == TS_ERROR || _lookup < 0 || _lookup >= 4) {
+      _lookup = -1;
+    }
+  }
+
+  return _lookup;
+}
+
+cripts::string_view
+Cache::Response::LookupStatus::GetSV()
+{
+  static std::array<cripts::string_view, 4> names{
+    "miss",      // TS_CACHE_LOOKUP_MISS,
+    "hit-stale", // TS_CACHE_LOOKUP_HIT_STALE,
+    "hit-fresh", // TS_CACHE_LOOKUP_HIT_FRESH,
+    "skipped"    // TS_CACHE_LOOKUP_SKIPPED
+  };
+
+  int status = operator integer();
+
+  if (status == -1) {
+    return "none";
+  } else {
+    return names[status];
+  }
+}
+
+Cache::Response::LookupStatus &
+Cache::Response::LookupStatus::operator=(int lookup)
+{
+  if (TSHttpTxnCacheLookupStatusSet(_owner->_state->txnp, lookup) == TS_SUCCESS) {
+    _owner->_state->context->p_instance.debug("Setting LookupStatus = {}", lookup);
+  } else {
+    // ToDo: Should we fail here?
+    // _owner->_state->error.Fail();
+  }
+
+  return *this;
 }
 
 } // namespace cripts


### PR DESCRIPTION
- cleans up the notion around cached URLs and headers, and cache keys.
- cleans up the Now / time functionality, allowing for UTC etc.
- adds APIs to set the lookup status as well

Note: This was split out of the Cache Groups PR, since this is universally useful / need in Cripts.