### PR TITLE
Fix nightly OS build issue - null stringview

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2026,7 +2026,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   {
     auto rec_str{RecGetRecordStringAlloc("proxy.config.log.hostname")};
     auto hostname{ats_as_c_str(rec_str)};
-    if (hostname != nullptr || std::string_view(hostname) == "localhost"sv) {
+    if (hostname != nullptr && std::string_view(hostname) == "localhost"sv) {
       // The default value was used. Let Machine::init derive the hostname.
       hostname = nullptr;
     }


### PR DESCRIPTION
At some point this line changed from && to ||, so now both are evaluated and this is undefined when hostname is null.