### PR TITLE
Revert "Address HttpSM::attach_server_session crash (#12325)"

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2784,9 +2784,6 @@ HttpSM::tunnel_handler_post(int event, void *data)
       default:
         break;
       }
-    } else if (static_cast<HttpSmPost_t>(p->handler_state) == HttpSmPost_t::SERVER_FAIL) {
-      handle_post_failure();
-      break;
     }
     break;
   case VC_EVENT_WRITE_READY: // iocore may callback first before send.


### PR DESCRIPTION
This reverts commit e5e3da8973cac5b94d64f491fa4941e7fe5fb5a6.

This was leading to a crash in tunnel_handler_post_or_put