### PR TITLE
Revert "Address HttpSM::attach_server_session crash (#12325)"

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2779,9 +2779,6 @@ HttpSM::tunnel_handler_post(int event, void *data)
       default:
         break;
       }
-    } else if (p->handler_state == HTTP_SM_POST_SERVER_FAIL) {
-      handle_post_failure();
-      break;
     }
     break;
   case VC_EVENT_WRITE_READY: // iocore may callback first before send.


### PR DESCRIPTION
This reverts commit d9ed9841cb9d667780bf8a8bcf30a9a00468ea2e.

This was leading to a crash in tunnel_handler_post_or_put