### PR TITLE
Add range request support to cache fill + global plugin support

### DIFF
--- a/doc/admin-guide/plugins/cache_fill.en.rst
+++ b/doc/admin-guide/plugins/cache_fill.en.rst
@@ -24,9 +24,8 @@ The initial version of this plugin relays the initial request to the origin serv
 This plugin doesn't provide any improvement for smaller objects but could also degrade the performance as two outgoing requests for every cache update.
 
 
-Using the plugin
-----------------
-
+Configuration
+-------------
 This plugin functions as either a global or per remap plugin, and it takes an optional argument for
 specifying a config file with inclusion or exclusion criteria. The config file can be specified both
 via an absolute path or via a relative path to the install dir
@@ -39,6 +38,39 @@ To activate the plugin in per remap mode, in :file:`remap.config`, simply append
 below to the specific remap line::
 
    @plugin=cache_fill.so @pparam=<config-file>
+
+include/exclude
+---------------
+The plugin supports a config file that can specify exclusion or inclusion of background fetch
+based on any arbitrary header or client-ip::
+
+The contents of the config-file could be as below::
+
+   include User-Agent ABCDEF
+   exclude User-Agent *
+   exclude Content-Type text
+   exclude X-Foo-Bar text
+   exclude Content-Length <1000
+   exclude Client-IP 127.0.0.1
+   include Client-IP 10.0.0.0/16
+
+The ``include`` configuration directive is only used when there is a corresponding ``exclude`` to exempt.
+For example, a single line directive, ``include Host example.com`` would not make the plugin
+*only* act on example.com. To achieve classic allow (only) lists, one would need to have a broad
+exclude line, such as::
+
+   exclude Host *
+   include Host example.com
+
+range-request-only
+------------------
+When set to ``true``, this plugin will only trigger a background fetch if a range header is present.
+Range headers include ``Range``, ``If-Match``, ``If-Modified-Since``, ``If-None-Match``, ``If-Range``
+and ``If-Unmodified-Since``
+
+This would look like::
+    
+    @plugin=cache_fill.so @pparam=--range-request-only
 
 Functionality
 -------------

--- a/doc/admin-guide/plugins/cache_fill.en.rst
+++ b/doc/admin-guide/plugins/cache_fill.en.rst
@@ -27,9 +27,15 @@ This plugin doesn't provide any improvement for smaller objects but could also d
 Using the plugin
 ----------------
 
-This plugin functions as a per remap plugin.
+This plugin functions as either a global or per remap plugin, and it takes an optional argument for
+specifying a config file with inclusion or exclusion criteria. The config file can be specified both
+via an absolute path or via a relative path to the install dir
 
-To activate the plugin, in :file:`remap.config`, simply append the
+To activate the plugin in global mode, in :file:`plugin.config`, simply add::
+
+    @plugin=cache_fill.so @pparam=<config-file>
+
+To activate the plugin in per remap mode, in :file:`remap.config`, simply append the
 below to the specific remap line::
 
    @plugin=cache_fill.so @pparam=<config-file>
@@ -38,6 +44,7 @@ Functionality
 -------------
 
 Plugin decides to trigger a background fetch of the original (Client) request if the request/response is cacheable and cache status is TS_CACHE_LOOKUP_MISS/TS_CACHE_LOOKUP_HIT_STALE.
+This will work for range requests by making a background fetch and removing the range header.
 
 Future additions
 ----------------

--- a/doc/admin-guide/plugins/cache_fill.en.rst
+++ b/doc/admin-guide/plugins/cache_fill.en.rst
@@ -32,7 +32,7 @@ via an absolute path or via a relative path to the install dir
 
 To activate the plugin in global mode, in :file:`plugin.config`, simply add::
 
-    @plugin=cache_fill.so @pparam=<config-file>
+   cache_fill.so --config <config-file>
 
 To activate the plugin in per remap mode, in :file:`remap.config`, simply append the
 below to the specific remap line::
@@ -42,7 +42,7 @@ below to the specific remap line::
 include/exclude
 ---------------
 The plugin supports a config file that can specify exclusion or inclusion of background fetch
-based on any arbitrary header or client-ip::
+based on any arbitrary header or client-ip
 
 The contents of the config-file could be as below::
 
@@ -66,17 +66,27 @@ range-request-only
 ------------------
 When set to ``true``, this plugin will only trigger a background fetch if a range header is present.
 Range headers include ``Range``, ``If-Match``, ``If-Modified-Since``, ``If-None-Match``, ``If-Range``
-and ``If-Unmodified-Since``
+and ``If-Unmodified-Since``. By default, this is set to false.
 
 This would look like::
-    
+
     @plugin=cache_fill.so @pparam=--range-request-only
+
+cache-range-req
+---------------
+When set to ``false``. this plugin will not trigger a background fetch for range requests. By default,
+this is set to true.
+Note: you cannot set this to false and ``range-request-only`` to true.
+
+This would look like::
+
+    @plugin=cache_fill.so @pparam=--cache-range-req=false
 
 Functionality
 -------------
 
 Plugin decides to trigger a background fetch of the original (Client) request if the request/response is cacheable and cache status is TS_CACHE_LOOKUP_MISS/TS_CACHE_LOOKUP_HIT_STALE.
-This will work for range requests by making a background fetch and removing the range header.
+This will work for range requests by making a background fetch and removing the range header. To disable this feature, set ``--cache-range-req=false``
 
 Future additions
 ----------------

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -45,17 +45,6 @@ namespace cache_fill_ns
 DbgCtl dbg_ctl{PLUGIN_NAME};
 }
 
-// This is the list of all headers that must be removed when we make the actual background
-// fetch request for range requests.
-static const std::array<const std::string_view, 6> FILTER_HEADERS{
-  {{TS_MIME_FIELD_RANGE, static_cast<size_t>(TS_MIME_LEN_RANGE)},
-   {TS_MIME_FIELD_IF_MATCH, static_cast<size_t>(TS_MIME_LEN_IF_MATCH)},
-   {TS_MIME_FIELD_IF_MODIFIED_SINCE, static_cast<size_t>(TS_MIME_LEN_IF_MODIFIED_SINCE)},
-   {TS_MIME_FIELD_IF_NONE_MATCH, static_cast<size_t>(TS_MIME_LEN_IF_NONE_MATCH)},
-   {TS_MIME_FIELD_IF_RANGE, static_cast<size_t>(TS_MIME_LEN_IF_RANGE)},
-   {TS_MIME_FIELD_IF_UNMODIFIED_SINCE, static_cast<size_t>(TS_MIME_LEN_IF_UNMODIFIED_SINCE)}}
-};
-
 ///////////////////////////////////////////////////////////////////////////
 // Remove a header (fully) from an TSMLoc / TSMBuffer. Return the number
 // of fields (header values) we removed.

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -45,6 +45,38 @@ namespace cache_fill_ns
 DbgCtl dbg_ctl{PLUGIN_NAME};
 }
 
+// This is the list of all headers that must be removed when we make the actual background
+// fetch request for range requests.
+static const std::array<const std::string_view, 6> FILTER_HEADERS{
+  {{TS_MIME_FIELD_RANGE, static_cast<size_t>(TS_MIME_LEN_RANGE)},
+   {TS_MIME_FIELD_IF_MATCH, static_cast<size_t>(TS_MIME_LEN_IF_MATCH)},
+   {TS_MIME_FIELD_IF_MODIFIED_SINCE, static_cast<size_t>(TS_MIME_LEN_IF_MODIFIED_SINCE)},
+   {TS_MIME_FIELD_IF_NONE_MATCH, static_cast<size_t>(TS_MIME_LEN_IF_NONE_MATCH)},
+   {TS_MIME_FIELD_IF_RANGE, static_cast<size_t>(TS_MIME_LEN_IF_RANGE)},
+   {TS_MIME_FIELD_IF_UNMODIFIED_SINCE, static_cast<size_t>(TS_MIME_LEN_IF_UNMODIFIED_SINCE)}}
+};
+
+///////////////////////////////////////////////////////////////////////////
+// Remove a header (fully) from an TSMLoc / TSMBuffer. Return the number
+// of fields (header values) we removed.
+int
+remove_header(TSMBuffer bufp, TSMLoc hdr_loc, const char *header, int len)
+{
+  TSMLoc field = TSMimeHdrFieldFind(bufp, hdr_loc, header, len);
+  int    cnt   = 0;
+
+  while (field) {
+    TSMLoc tmp = TSMimeHdrFieldNextDup(bufp, hdr_loc, field);
+
+    ++cnt;
+    TSMimeHdrFieldDestroy(bufp, hdr_loc, field);
+    TSHandleMLocRelease(bufp, hdr_loc, field);
+    field = tmp;
+  }
+
+  return cnt;
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Set a header to a specific value. This will avoid going to through a
 // remove / add sequence in case of an existing header.
@@ -175,6 +207,12 @@ BgFetchData::initialize(TSMBuffer request, TSMLoc req_hdr, TSHttpTxn txnp)
 
             if (set_header(mbuf, hdr_loc, TS_MIME_FIELD_HOST, TS_MIME_LEN_HOST, hostp, len)) {
               Dbg(dbg_ctl, "Set header Host: %.*s", len, hostp);
+            }
+            // Next, remove the Range headers and IMS (conditional) headers from the request
+            for (auto const &header : FILTER_HEADERS) {
+              if (remove_header(mbuf, hdr_loc, header.data(), header.size()) > 0) {
+                Dbg(dbg_ctl, "Removed the %s header from request", header.data());
+              }
             }
             ret = true;
           }

--- a/plugins/experimental/cache_fill/background_fetch.h
+++ b/plugins/experimental/cache_fill/background_fetch.h
@@ -43,6 +43,17 @@
 using OutstandingRequests = std::unordered_map<std::string, bool>;
 const char PLUGIN_NAME[]  = "cache_fill";
 
+// This is the list of all headers that must be removed when we make the actual background
+// fetch request for range requests.
+static const std::array<const std::string_view, 6> FILTER_HEADERS{
+  {{TS_MIME_FIELD_RANGE, static_cast<size_t>(TS_MIME_LEN_RANGE)},
+   {TS_MIME_FIELD_IF_MATCH, static_cast<size_t>(TS_MIME_LEN_IF_MATCH)},
+   {TS_MIME_FIELD_IF_MODIFIED_SINCE, static_cast<size_t>(TS_MIME_LEN_IF_MODIFIED_SINCE)},
+   {TS_MIME_FIELD_IF_NONE_MATCH, static_cast<size_t>(TS_MIME_LEN_IF_NONE_MATCH)},
+   {TS_MIME_FIELD_IF_RANGE, static_cast<size_t>(TS_MIME_LEN_IF_RANGE)},
+   {TS_MIME_FIELD_IF_UNMODIFIED_SINCE, static_cast<size_t>(TS_MIME_LEN_IF_UNMODIFIED_SINCE)}}
+};
+
 namespace cache_fill_ns
 {
 extern DbgCtl dbg_ctl;

--- a/plugins/experimental/cache_fill/configs.cc
+++ b/plugins/experimental/cache_fill/configs.cc
@@ -44,7 +44,6 @@ BgFetchConfig::parseOptions(int argc, const char *argv[])
   static const struct option longopt[] = {
     {const_cast<char *>("log"),            required_argument, nullptr, 'l' },
     {const_cast<char *>("config"),         required_argument, nullptr, 'c' },
-    {const_cast<char *>("allow-304"),      no_argument,       nullptr, 'a' },
     {const_cast<char *>("range-req-only"), no_argument,       nullptr, 'r' },
     {nullptr,                              no_argument,       nullptr, '\0'},
   };
@@ -66,10 +65,6 @@ BgFetchConfig::parseOptions(int argc, const char *argv[])
         // Error messages are written in the parser
         return false;
       }
-      break;
-    case 'a':
-      Dbg(dbg_ctl, "option: --allow-304 set");
-      _allow_304 = true;
       break;
     case 'r':
       Dbg(dbg_ctl, "option: --range-req-only set");

--- a/plugins/experimental/cache_fill/configs.h
+++ b/plugins/experimental/cache_fill/configs.h
@@ -84,6 +84,7 @@ public:
 private:
   TSCont      _cont = nullptr;
   list_type   _rules;
-  bool        _allow_304 = false;
+  bool        _allow_304      = false;
+  bool        _range_req_only = false;
   std::string _log_file;
 };

--- a/plugins/experimental/cache_fill/configs.h
+++ b/plugins/experimental/cache_fill/configs.h
@@ -70,12 +70,6 @@ public:
     return _log_file;
   }
 
-  bool
-  allow304() const
-  {
-    return _allow_304;
-  }
-
   // This parses and populates the BgFetchRule linked list (_rules).
   bool readConfig(const char *file_name);
 
@@ -84,7 +78,6 @@ public:
 private:
   TSCont      _cont = nullptr;
   list_type   _rules;
-  bool        _allow_304      = false;
   bool        _range_req_only = false;
   std::string _log_file;
 };

--- a/plugins/experimental/cache_fill/configs.h
+++ b/plugins/experimental/cache_fill/configs.h
@@ -70,6 +70,12 @@ public:
     return _log_file;
   }
 
+  static bool
+  isTrue(const char *arg)
+  {
+    return (nullptr == arg || 0 == strncasecmp("true", arg, 4) || 0 == strncasecmp("1", arg, 1) || 0 == strncasecmp("yes", arg, 3));
+  }
+
   // This parses and populates the BgFetchRule linked list (_rules).
   bool readConfig(const char *file_name);
 
@@ -78,6 +84,7 @@ public:
 private:
   TSCont      _cont = nullptr;
   list_type   _rules;
-  bool        _range_req_only = false;
+  bool        _range_req_only  = false;
+  bool        _cache_range_req = true;
   std::string _log_file;
 };

--- a/tests/gold_tests/pluginTest/cache_fill/cache_fill.test.py
+++ b/tests/gold_tests/pluginTest/cache_fill/cache_fill.test.py
@@ -1,0 +1,214 @@
+import os
+import time
+from collections import namedtuple
+from typing import Tuple
+
+Test.Summary = '''
+Basic cache_fill plugin test
+'''
+
+Test.SkipUnless(
+    Condition.PluginExists('cache_fill.so'),
+    Condition.PluginExists('xdebug.so'),
+)
+Test.ContinueOnFail = True
+Test.testName = "cache_fill"
+
+
+class CacheFillTest:
+
+    def __init__(self):
+        self.setUpOriginServer()
+        self.setUpTS()
+        self.curl_and_args = '-s -D /dev/stdout -v -x localhost:{} -H "x-debug: x-cache,x-cache-key"'.format(self.ts.Variables.port)
+
+    def setUpOriginServer(self):
+        # Define and configure origin server
+        self.server = Test.MakeOriginServer("server")
+
+        req = {
+            "headers": "GET /nostore HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*" + "Range: bytes=0-4\r\n" + "\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
+
+        res = {
+            "headers":
+                "HTTP/1.1 200 OK\r\n" + "Cache-Control: nostore\r\n" + "Connection: close\r\n" + 'Etag: 994324f6-78f6bc3e8d639\r\n',
+            "timestamp": "1469733493.993",
+            "body": "hello hello"
+        }
+
+        self.server.addResponse("sessionlog.json", req, res)
+
+        req = {"headers": "GET /200 HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n", "timestamp": "1469733493.993", "body": ""}
+
+        res = {
+            "headers":
+                "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" +
+                'Etag: 772102f4-56f4bc1e6d417\r\n',
+            "timestamp": "1469733493.993",
+            "body": "hello hello"
+        }
+
+        self.server.addResponse("sessionlog.json", req, res)
+
+        req = {
+            "headers": "GET /range HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*" + "Range: bytes=0-4\r\n" + "\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
+        res = {
+            "headers":
+                "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" +
+                'Etag: 883213f5-67f5bc2e7d528\r\n',
+            "timestamp": "1469733493.993",
+            "body": "hello hello"
+        }
+
+        self.server.addResponse("sessionlog.json", req, res)
+
+    def setUpTS(self):
+        # Define and configure ATS
+        self.ts = Test.MakeATSProcess("ts")
+
+        self.ts.Disk.remap_config.AddLines(
+            [
+                'map http://www.example.com/200 http://127.0.0.1:{}/200 @plugin=cache_fill.so'.format(self.server.Variables.Port),
+                'map http://www.example.com/range http://127.0.0.1:{}/range @plugin=cache_fill.so'.format(
+                    self.server.Variables.Port),
+                'map http://www.example.com/nostore http://127.0.0.1:{}/nostore @plugin=cache_fill.so'.format(
+                    self.server.Variables.Port),
+                'map http://www.example.com/304 http://127.0.0.1:{}/range @plugin=cache_fill.so'.format(self.server.Variables.Port),
+            ])
+
+        self.ts.Disk.plugin_config.AddLine('xdebug.so --enable=x-cache,x-cache-key')
+
+        self.ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'cache_fill|.*cache.*',
+            })
+
+    def test_cacheMiss(self):
+        # Cache miss; background fetch should fill cache
+        tr = Test.AddTestRun("Cache miss")
+        ps = tr.Processes.Default
+        ps.StartBefore(self.server, ready=When.PortOpen(self.server.Variables.Port))
+        ps.StartBefore(Test.Processes.ts)
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/200', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 OK status")
+        tr.StillRunningAfter = self.ts
+
+    def test_cacheHit(self):
+        # Cache hit-fresh from background fill
+        tr = Test.AddTestRun("Cache hit-fresh")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/200', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 OK status")
+        tr.StillRunningAfter = self.ts
+
+    def test_rangeReq_CacheMiss(self):
+        # Cache miss; background fetch should fill cache
+        tr = Test.AddTestRun("Range cache miss")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/range -r 0-4', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
+
+    def test_rangeReq_CacheHit(self):
+        # Cache hit-fresh from background fill
+        tr = Test.AddTestRun("Range cache hit-fresh")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/range -r 0-4', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("206 Partial Content", "Expected 206 status")
+        ps.Streams.stdout.Content += Testers.ContainsExpression(
+            "Content-Range: bytes 0-4/11", "Expected Content-Range: bytes 0-4/11")
+        tr.StillRunningAfter = self.ts
+
+    def test_noStore_noFill(self):
+        # Background fetch should NOT fill cache
+        tr = Test.AddTestRun("nostore cache miss")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/nostore -r 0-4', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
+
+    def test_nostore_cacheMiss(self):
+        # Cache hit miss because background fill was not triggered
+        tr = Test.AddTestRun("nostore cache hit-fresh")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/nostore -r 0-4', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
+
+    def setUpGlobalPlugin(self):
+        ## Check global plugin ##
+        self.ts.Disk.plugin_config.AddLine('cache_fill.so')
+
+        self.ts.Disk.remap_config.AddLines(
+            ['map http://www.example.com/global http://127.0.0.1:{}/global'.format(self.server.Variables.Port)])
+
+        req = {
+            "headers": "GET /global HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
+        res = {
+            "headers":
+                "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" +
+                'Etag: 661091f3-45f3bc0e5d306\r\n',
+            "timestamp": "1469733493.993",
+            "body": "hello hello"
+        }
+
+        self.server.addResponse("sessionlog.json", req, res)
+
+    def test_global_cacheMiss(self):
+        # Global implementation: Cache miss; background fetch should fill cache
+        tr = Test.AddTestRun("Cache miss - global implementation")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/global', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
+
+    def test_global_cacheHit(self):
+        # Global implementation: Cache hit-fresh from background fill
+        tr = Test.AddTestRun("Cache hit-fresh - global implementation")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/global', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
+
+    def runTraffic(self):
+        self.test_cacheMiss()
+        self.test_cacheHit()
+        self.test_rangeReq_CacheMiss()
+        self.test_rangeReq_CacheHit()
+        self.test_noStore_noFill()
+        self.test_nostore_cacheMiss()
+        self.setUpGlobalPlugin()
+        self.test_global_cacheMiss()
+        self.test_global_cacheHit()
+
+    def run(self):
+        self.runTraffic()
+
+
+CacheFillTest().run()

--- a/tests/gold_tests/pluginTest/cache_fill/cache_fill.test.py
+++ b/tests/gold_tests/pluginTest/cache_fill/cache_fill.test.py
@@ -1,7 +1,21 @@
-import os
-import time
-from collections import namedtuple
-from typing import Tuple
+'''
+Test cache_fill plugin
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 Test.Summary = '''
 Basic cache_fill plugin test

--- a/tests/gold_tests/pluginTest/cache_fill/cache_fill.test.py
+++ b/tests/gold_tests/pluginTest/cache_fill/cache_fill.test.py
@@ -170,10 +170,13 @@ class CacheFillTest:
 
     def setUpGlobalPlugin(self):
         ## Check global plugin ##
-        self.ts.Disk.plugin_config.AddLine('cache_fill.so')
+        self.ts.Disk.plugin_config.AddLine('cache_fill.so --range-req-only')
 
         self.ts.Disk.remap_config.AddLines(
-            ['map http://www.example.com/global http://127.0.0.1:{}/global'.format(self.server.Variables.Port)])
+            [
+                'map http://www.example.com/global http://127.0.0.1:{}/global'.format(self.server.Variables.Port),
+                'map http://www.example.com/globalRange http://127.0.0.1:{}/globalRange'.format(self.server.Variables.Port)
+            ])
 
         req = {
             "headers": "GET /global HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "\r\n",
@@ -189,6 +192,45 @@ class CacheFillTest:
         }
 
         self.server.addResponse("sessionlog.json", req, res)
+        req = {
+            "headers":
+                "GET /globalRange HTTP/1.1\r\n" + "Host: www.example.com\r\n" + "Accept: */*" + "Range: bytes=0-4\r\n" + "\r\n",
+            "timestamp": "1469733493.993",
+            "body": ""
+        }
+        res = {
+            "headers":
+                "HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=1\r\n" + "Connection: close\r\n" +
+                'Etag: 883213f5-67f5bc2e7d528\r\n',
+            "timestamp": "1469733493.993",
+            "body": "hello hello"
+        }
+
+        self.server.addResponse("sessionlog.json", req, res)
+
+    def test_global_rangeReqOnly_CacheMiss(self):
+        # Cache miss; background fetch should fill cache
+        tr = Test.AddTestRun("Range cache miss")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/globalRange -r 0-4', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
+        self.ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
+            "_range_req_only=true; This transaction is not a range request", "expected background fetch to not trigger")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
+
+    def test_global_rangeReqOnly_cacheHit(self):
+        # Global implementation: Cache hit-fresh from background fill
+        tr = Test.AddTestRun("Cache hit-fresh - global implementation")
+        ps = tr.Processes.Default
+        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/globalRange', ts=self.ts)
+        ps.ReturnCode = 0
+        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit")
+        self.ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
+            "_range_req_only=true; This transaction is not a range request", "expected background fetch to not trigger")
+        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
+        tr.StillRunningAfter = self.ts
 
     def test_global_cacheMiss(self):
         # Global implementation: Cache miss; background fetch should fill cache
@@ -197,16 +239,8 @@ class CacheFillTest:
         tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/global', ts=self.ts)
         ps.ReturnCode = 0
         ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: miss", "expected cache miss")
-        ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
-        tr.StillRunningAfter = self.ts
-
-    def test_global_cacheHit(self):
-        # Global implementation: Cache hit-fresh from background fill
-        tr = Test.AddTestRun("Cache hit-fresh - global implementation")
-        ps = tr.Processes.Default
-        tr.MakeCurlCommand(self.curl_and_args + ' http://www.example.com/global', ts=self.ts)
-        ps.ReturnCode = 0
-        ps.Streams.stdout.Content = Testers.ContainsExpression("X-Cache: hit-fresh", "expected cache hit")
+        self.ts.Disk.traffic_out.Content = Testers.ContainsExpression(
+            "_range_req_only=true; This transaction is not a range request", "expected background fetch to not trigger")
         ps.Streams.stdout.Content += Testers.ContainsExpression("200 OK", "Expected 200 status")
         tr.StillRunningAfter = self.ts
 
@@ -218,8 +252,9 @@ class CacheFillTest:
         self.test_noStore_noFill()
         self.test_nostore_cacheMiss()
         self.setUpGlobalPlugin()
+        self.test_global_rangeReqOnly_CacheMiss()
+        self.test_global_rangeReqOnly_cacheHit()
         self.test_global_cacheMiss()
-        self.test_global_cacheHit()
 
     def run(self):
         self.runTraffic()


### PR DESCRIPTION
Currently, cache_fill will do a background fetch for a range request but only for that range. These changes remove the range header from the request before making the background fetch so we fetch the whole body and store that into cache.
The config variable --allow-304 has been removed as we do not check the status of the transaction. The background fetch will be triggered without considering the status.
Added two new configs
--range-req-only -> only trigger a background fetch for range requests
--cache-range-req -> turn on/off background fetch for range requests