### PR TITLE
HRW: Fix parser when conditions are values

### DIFF
--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -53,7 +53,7 @@ Value::set_value(const std::string &val)
         if ((tcond_val = condition_factory(cond_token))) {
           Parser parser;
 
-          if (parser.parse_line(_value)) {
+          if (parser.parse_line(cond_token)) {
             tcond_val->initialize(parser);
           } else {
             // TODO: should we produce error here?


### PR DESCRIPTION
The improvements to stricter parsing of int types in #12218 introduces a subtle bug when conditions are used in string values (like "Random is %{RANDOM:100}".