### PR TITLE
AuTest: reduce port usage in the Remap ACL test

### DIFF
--- a/tests/gold_tests/remap/remap_acl.test.py
+++ b/tests/gold_tests/remap/remap_acl.test.py
@@ -59,7 +59,7 @@ class Test_remap_acl:
 
         tr = Test.AddTestRun(name)
         self._configure_server(tr)
-        self._configure_traffic_server(tr)
+        self._configure_traffic_server(tr, proxy_protocol)
         self._configure_client(tr, proxy_protocol)
 
     def _configure_server(self, tr: 'TestRun') -> None:
@@ -72,14 +72,14 @@ class Test_remap_acl:
         Test_remap_acl._server_counter += 1
         self._server = server
 
-    def _configure_traffic_server(self, tr: 'TestRun') -> None:
+    def _configure_traffic_server(self, tr: 'TestRun', proxy_protocol: bool) -> None:
         """Configure Traffic Server.
 
         :param tr: The TestRun object to associate the Traffic Server process with.
         """
 
         name = f"ts-{Test_remap_acl._ts_counter}"
-        ts = tr.MakeATSProcess(name, enable_cache=False, enable_tls=True, enable_proxy_protocol=True)
+        ts = tr.MakeATSProcess(name, enable_cache=False, enable_proxy_protocol=proxy_protocol, enable_uds=False)
         Test_remap_acl._ts_counter += 1
         self._ts = ts
 
@@ -159,7 +159,7 @@ class Test_old_action:
         '''
         name = f"ts-old-action-{Test_old_action._ts_counter}"
         Test_old_action._ts_counter += 1
-        ts = tr.MakeATSProcess(name)
+        ts = tr.MakeATSProcess(name, enable_uds=False)
         self._ts = ts
 
         ts.Disk.records_config.update(


### PR DESCRIPTION
Mitigation of https://github.com/apache/trafficserver/issues/12401. It looks like every Remap ACL test uses 6 listening ports. However, it looks like ssl and pp are not necessary in many tests.

Before
```
$ grep "server_ports" /tmp/sandbox/remap_acl/ts-*/config/records.yaml 
/tmp/sandbox/remap_acl/ts-0/config/records.yaml:    server_ports: 61015 61016:ipv6 61017:ssl 61018:ssl:ipv6 61019:pp 61020:pp:ipv6
/tmp/sandbox/remap_acl/ts-1/config/records.yaml:    server_ports: 61028 61029:ipv6 61030:ssl 61031:ssl:ipv6 61032:pp 61033:pp:ipv6
/tmp/sandbox/remap_acl/ts-10/config/records.yaml:    server_ports: 61155 61156:ipv6 61157:ssl 61158:ssl:ipv6 61159:pp 61160:pp:ipv6
...
```

After
```
$ grep "server_ports" /tmp/sandbox/remap_acl/ts-*/config/records.yaml 
/tmp/sandbox/remap_acl/ts-0/config/records.yaml:    server_ports: 61015 61016:ipv6
/tmp/sandbox/remap_acl/ts-1/config/records.yaml:    server_ports: 61022 61023:ipv6 61024:pp 61025:pp:ipv6
/tmp/sandbox/remap_acl/ts-10/config/records.yaml:    server_ports: 61097 61098:ipv6
...
```