### PR TITLE
cqssrt log field for TLS resumption type

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -618,6 +618,7 @@ SSL / Encryption
 .. _cscert:
 .. _cqssl:
 .. _cqssr:
+.. _cqssrt:
 .. _cqssv:
 .. _cqssc:
 .. _cqssu:
@@ -639,9 +640,15 @@ cscert Client Request 1 if |TS| requested certificate from client during TLS
                       handshake. 0 otherwise.
 cqssl  Client Request SSL client request status indicates if this client
                       connection is over SSL.
-cqssr  Client Request SSL session ticket reused status; indicates if the current
-                      request hit the SSL session ticket and avoided a full SSL
-                      handshake.
+cqssr  Client Request SSL session resumption status; indicates whether the
+                      current request was resumed from a previous SSL session
+                      and avoided a full TLS handshake. Resumption may have
+                      been via a server side session cache or via a TLS session
+                      ticket, see cqssrt_ for the resumption type.
+cqssrt Client Request SSL resumption type; indicates the type of TLS session
+                      resumption used for this request. 0 for no resumption,
+                      1 for server session cache resumption, 2 for TLS session
+                      ticket resumption.
 cqssv  Client Request SSL version used to communicate with the client.
 cqssc  Client Request SSL Cipher used by |TS| to communicate with the client.
 cqssu  Client Request SSL Elliptic Curve used by |TS| to communicate with the

--- a/include/proxy/logging/LogAccess.h
+++ b/include/proxy/logging/LogAccess.h
@@ -147,6 +147,7 @@ public:
   int marshal_client_req_tcp_reused(char *);         // INT
   int marshal_client_req_is_ssl(char *);             // INT
   int marshal_client_req_ssl_reused(char *);         // INT
+  int marshal_client_ssl_resumption_type(char *);    // INT
   int marshal_client_req_is_internal(char *);        // INT
   int marshal_client_req_mptcp_state(char *);        // INT
   int marshal_client_security_protocol(char *);      // STR

--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -535,6 +535,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqssr", field);
 
+  field = new LogField("client_req_ssl_resumption_type", "cqssrt", LogField::dINT, &LogAccess::marshal_client_ssl_resumption_type,
+                       &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("cqssrt", field);
+
   field = new LogField("client_req_is_internal", "cqint", LogField::sINT, &LogAccess::marshal_client_req_is_internal,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -2127,6 +2127,15 @@ LogAccess::marshal_client_req_ssl_reused(char *buf)
 }
 
 int
+LogAccess::marshal_client_ssl_resumption_type(char *buf)
+{
+  if (buf) {
+    marshal_int(buf, m_http_sm->get_user_agent().get_client_ssl_resumption_type());
+  }
+  return INK_MIN_ALIGN;
+}
+
+int
 LogAccess::marshal_client_req_is_internal(char *buf)
 {
   if (buf) {


### PR DESCRIPTION
This adds the cqssrt log field that indicates the TLS resumption type:

0: no resumption
1: server session cache resumption
2: TLS ticket resumption

