### PR TITLE
stats_over_http: Add HINT and TYPE Prometheus annotations

### DIFF
--- a/plugins/stats_over_http/stats_over_http.cc
+++ b/plugins/stats_over_http/stats_over_http.cc
@@ -496,14 +496,25 @@ prometheus_out_stat(TSRecordType /* rec_type ATS_UNUSED */, void *edata, int /* 
 {
   stats_state *my_state       = static_cast<stats_state *>(edata);
   std::string  sanitized_name = sanitize_metric_name_for_prometheus(name);
+  char         type_buffer[256];
+  char         help_buffer[256];
+
+  snprintf(help_buffer, sizeof(help_buffer), "# HELP %s %s\n", sanitized_name.c_str(), name);
   switch (data_type) {
   case TS_RECORDDATATYPE_COUNTER:
+    APPEND(help_buffer);
+    snprintf(type_buffer, sizeof(type_buffer), "# TYPE %s counter\n", sanitized_name.c_str());
+    APPEND(type_buffer);
     APPEND_STAT_PROMETHEUS_NUMERIC(sanitized_name.c_str(), "%" PRIu64, wrap_unsigned_counter(datum->rec_counter));
     break;
   case TS_RECORDDATATYPE_INT:
+    APPEND(help_buffer);
+    snprintf(type_buffer, sizeof(type_buffer), "# TYPE %s gauge\n", sanitized_name.c_str());
+    APPEND(type_buffer);
     APPEND_STAT_PROMETHEUS_NUMERIC(sanitized_name.c_str(), "%" PRIu64, wrap_unsigned_counter(datum->rec_int));
     break;
   case TS_RECORDDATATYPE_FLOAT:
+    APPEND(help_buffer);
     APPEND_STAT_PROMETHEUS_NUMERIC(sanitized_name.c_str(), "%f", datum->rec_float);
     break;
   case TS_RECORDDATATYPE_STRING:


### PR DESCRIPTION
This makes use of #12392 to add TYPE annotations to stats_over_http Prometheus formatted output. While we're at it, it also adds a HINT string to indicate what the original ATS metric name was that the Prometheus metric is for since Prometheus forces us to modify the metric pretty signifantly from its original form (periods replaced with underscores, etc.).