### PR TITLE
server.honor_cipher_order: Clarify documentation

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -3721,8 +3721,10 @@ SSL Termination
 
 .. ts:cv:: CONFIG proxy.config.ssl.server.honor_cipher_order INT 1
 
-   By default (``1``) |TS| will use the server's cipher suites preferences instead of the client preferences.
-   By disabling it (``0``) |TS| will use client's cipher suites preferences.
+   By default (``1``) |TS| will use the server's preferences for cipher suites, supported groups, and
+   signature algorithms instead of the client preferences. By disabling it (``0``) |TS| will use the
+   client's preferences. Note that despite the configuration name mentioning "cipher_order", this
+   setting controls server preference for multiple aspects of TLS negotiation, not just cipher suites.
 
 .. ts:cv:: CONFIG proxy.config.ssl.server.prioritize_chacha INT 0
 

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -373,12 +373,17 @@ SSLConfigParams::initialize()
     ats_free(clientALPNProtocols);
   }
 
-#ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
+#if defined(SSL_OP_SERVER_PREFERENCE) || defined(SSL_OP_CIPHER_SERVER_PREFERENCE)
   option = RecGetRecordInt("proxy.config.ssl.server.honor_cipher_order").value_or(0);
   if (option) {
+    // Prefer the newer, more accurately named flag when available.
+#ifdef SSL_OP_SERVER_PREFERENCE
+    ssl_ctx_options |= SSL_OP_SERVER_PREFERENCE;
+#else
     ssl_ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
-  }
 #endif
+  }
+#endif // defined(SSL_OP_SERVER_PREFERENCE) || defined(SSL_OP_CIPHER_SERVER_PREFERENCE)
 
 #ifdef SSL_OP_PRIORITIZE_CHACHA
   option = RecGetRecordInt("proxy.config.ssl.server.prioritize_chacha").value_or(0);


### PR DESCRIPTION
Clarify in records.yaml.en.rst that server.honor_cipher_order controls TLS server preference for TLS groups and signature algorithms in addition to ciphers.

This also makes use of the SSL_OP_SERVER_PREFERENCE instead of the misleading SSL_OP_CIPHER_SERVER_PREFERENCE when available.

Fixes: #12382

---

# For review

The updated doc can be seen, albeit temporarilly until jenkins cleans up the archive, here:
https://ci.trafficserver.apache.org/view/Github/job/Github_Builds/job/docs/7246/artifact/output/12416/docbuild/html/admin-guide/files/records.yaml.en.html#proxy-config-ssl-server-honor-cipher-order