### PR TITLE
10.1.x: server.honor_cipher_order: Clarify documentation (#12416)

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -3709,8 +3709,10 @@ SSL Termination
 
 .. ts:cv:: CONFIG proxy.config.ssl.server.honor_cipher_order INT 1
 
-   By default (``1``) |TS| will use the server's cipher suites preferences instead of the client preferences.
-   By disabling it (``0``) |TS| will use client's cipher suites preferences.
+   By default (``1``) |TS| will use the server's preferences for cipher suites, supported groups, and
+   signature algorithms instead of the client preferences. By disabling it (``0``) |TS| will use the
+   client's preferences. Note that despite the configuration name mentioning "cipher_order", this
+   setting controls server preference for multiple aspects of TLS negotiation, not just cipher suites.
 
 .. ts:cv:: CONFIG proxy.config.ssl.server.prioritize_chacha INT 0
 

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -375,12 +375,17 @@ SSLConfigParams::initialize()
     ats_free(clientALPNProtocols);
   }
 
-#ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
+#if defined(SSL_OP_SERVER_PREFERENCE) || defined(SSL_OP_CIPHER_SERVER_PREFERENCE)
   REC_ReadConfigInteger(option, "proxy.config.ssl.server.honor_cipher_order");
   if (option) {
+    // Prefer the newer, more accurately named flag when available.
+#ifdef SSL_OP_SERVER_PREFERENCE
+    ssl_ctx_options |= SSL_OP_SERVER_PREFERENCE;
+#else
     ssl_ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
-  }
 #endif
+  }
+#endif // defined(SSL_OP_SERVER_PREFERENCE) || defined(SSL_OP_CIPHER_SERVER_PREFERENCE)
 
 #ifdef SSL_OP_PRIORITIZE_CHACHA
   REC_ReadConfigInteger(option, "proxy.config.ssl.server.prioritize_chacha");


### PR DESCRIPTION
Clarify in records.yaml.en.rst that server.honor_cipher_order controls TLS server preference for TLS groups and signature algorithms in addition to ciphers.

This also makes use of the SSL_OP_SERVER_PREFERENCE instead of the misleading SSL_OP_CIPHER_SERVER_PREFERENCE when available.

Fixes: #12382
(cherry picked from commit a5beffc4f108362a33c928f15e55d770e9031521)