### PR TITLE
test_SnowflakeID: Avoid sequence number continuation

### DIFF
--- a/src/tscore/unit_tests/test_SnowflakeID.cc
+++ b/src/tscore/unit_tests/test_SnowflakeID.cc
@@ -117,6 +117,9 @@ TEST_CASE("SnowflakeID", "[libts][SnowflakeID]")
       // Something is seriously wrong...don't infinite loop.
       FAIL("Failed to generate two snowflake IDs in the same millisecond.");
     }
+    // Sleep to ensure we generate IDs in a fresh millisecond, avoiding
+    // sequence number continuation from previous attempts.
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
     ms_since_unix_epoch_before = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
     v1                         = SnowflakeID::get_next_value();
     v2                         = SnowflakeID::get_next_value();


### PR DESCRIPTION
I noticed the following test failure in a recent CI run:

```
SnowflakeID
-------------------------------------------------------------------------------
../src/tscore/unit_tests/test_SnowflakeID.cc:94
...............................................................................

../src/tscore/unit_tests/test_SnowflakeID.cc:169: FAILED:
  REQUIRE( u1.sequence == 0u )
with expansion:
  1 == 0
```

I realized this can happen if we re-attempt to grab new snowflake IDs in what happens to be the same millisecond as the previous attempt. Thus the u1 from the new attempt will likely be in the same millisecond as the u2 in the previous attempt. Thus u1.squence will then be 1 instead of 0. This adds a 2ms sleep in the loop to avoid this situation.

Note this is a timing bug in the test. The production code correctly assigned in this situation a sequence of 1 since the ID was in the same millisecond as the previous one.