### PR TITLE
Add log messages about QUIC cert loading for consistency

### DIFF
--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -800,9 +800,9 @@ SSLCertificateConfig::reconfigure()
   }
 
   if (retStatus) {
-    Note("%s finished loading%s", params->configFilePath, ts::bw_dbg.c_str());
+    Note("(ssl) %s finished loading%s", params->configFilePath, ts::bw_dbg.c_str());
   } else {
-    Error("%s failed to load%s", params->configFilePath, ts::bw_dbg.c_str());
+    Error("(ssl) %s failed to load%s", params->configFilePath, ts::bw_dbg.c_str());
   }
 
   return retStatus;


### PR DESCRIPTION
There are "loading" message with quic/ssl label, but there's only "finished" message for ssl.

The added code is almost just a copy and paste from the one for SSL.