### PR TITLE
Update cache metrics after initialized

### DIFF
--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -131,6 +131,10 @@ CacheProcessor::start(int, size_t)
 void
 CachePeriodicMetricsUpdate()
 {
+  if (cacheProcessor.initialized != CacheInitState::INITIALIZED) {
+    return;
+  }
+
   int64_t total_sum = 0;
 
   // Make sure the bytes_used per volume is always reset to zero, this can update the
@@ -140,21 +144,19 @@ CachePeriodicMetricsUpdate()
     ts::Metrics::Gauge::store(gstripes[i]->cache_vol->vol_rsb.bytes_used, 0);
   }
 
-  if (cacheProcessor.initialized == CacheInitState::INITIALIZED) {
-    for (int i = 0; i < gnstripes; ++i) {
-      StripeSM *v    = gstripes[i];
-      int64_t   used = cache_bytes_used(i);
+  for (int i = 0; i < gnstripes; ++i) {
+    StripeSM *v    = gstripes[i];
+    int64_t   used = cache_bytes_used(i);
 
-      ts::Metrics::Gauge::increment(v->cache_vol->vol_rsb.bytes_used, used); // This assumes they start at zero
-      total_sum += used;
-    }
-
-    // Also update the global (not per volume) metrics
-    int64_t total = ts::Metrics::Gauge::load(cache_rsb.bytes_total);
-
-    ts::Metrics::Gauge::store(cache_rsb.bytes_used, total_sum);
-    ts::Metrics::Gauge::store(cache_rsb.percent_full, total ? (total_sum * 100) / total : 0);
+    ts::Metrics::Gauge::increment(v->cache_vol->vol_rsb.bytes_used, used); // This assumes they start at zero
+    total_sum += used;
   }
+
+  // Also update the global (not per volume) metrics
+  int64_t total = ts::Metrics::Gauge::load(cache_rsb.bytes_total);
+
+  ts::Metrics::Gauge::store(cache_rsb.bytes_used, total_sum);
+  ts::Metrics::Gauge::store(cache_rsb.percent_full, total ? (total_sum * 100) / total : 0);
 }
 
 // ToDo: This gets called as part of librecords collection continuation, probably change this later.


### PR DESCRIPTION
When cache initialization takes time but `CachePeriodicMetricsUpdate` is fired, it'll be crashed because stripes are not set yet.
```
Thread 53 "[ET_TASK 1]" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffdd4fe640 (LWP 1082960)]
0x000055555592e5a7 in CachePeriodicMetricsUpdate () at /src/iocore/cache/Cache.cc:228
228	    Metrics::Gauge::store(gstripes[i]->cache_vol->vol_rsb.bytes_used, 0);
(gdb) bt
#0  0x000055555592e5a7 in CachePeriodicMetricsUpdate () at /src/iocore/cache/Cache.cc:228
#1  0x0000555555a7f593 in std::__1::__function::__value_func<void ()>::operator()[abi:v160006]() const (this=0x7fffd1c931d0) at  /include/c++/v1/__functional/function.h:510
#2  std::__1::function<void ()>::operator()() const (this=0x7fffd1c931d0) at  /include/c++/v1/__functional/function.h:1156
#3  RecExecRawStatSyncCbs () at /src/records/RecRawStats.cc:380
#4  0x0000555555a8df19 in raw_stat_sync_cont::exec_callbacks (this=0x7fffd1c931d0) at /src/iocore/eventsystem/RecProcess.cc:91
#5  0x0000555555a865a5 in Continuation::handleEvent (this=<optimized out>, event=2, data=0x7ffff6c35ce0) at /include/iocore/eventsystem/Continuation.h:236
#6  EThread::process_event (this=0x7ffff12c9840, e=0x7ffff6c35ce0, calling_code=2) at /src/iocore/eventsystem/UnixEThread.cc:162
#7  0x0000555555a86e9d in EThread::execute_regular (this=0x7ffff12c9840) at /src/iocore/eventsystem/UnixEThread.cc:269
#8  0x0000555555a87664 in EThread::execute (this=0x7ffff12c9840) at /src/iocore/eventsystem/UnixEThread.cc:348
#9  0x0000555555a854d7 in spawn_thread_internal (a=0x7ffff6dfb120) at /src/iocore/eventsystem/Thread.cc:75
#10 0x00007ffff7089d22 in start_thread () from /lib64/libc.so.6
#11 0x00007ffff710ed40 in clone3 () from /lib64/libc.so.6
(gdb) p gstripes
$1 = (Stripe **) 0x7fffe74fb500
(gdb) p i
$2 = 0
(gdb) p gstripes[0]
$3 = (Stripe *) 0x0
(gdb) p CacheProcessor::initialized
$4 = 0
```

For reviewer, "Hide whitespace" is recommended.