### PR TITLE
Fix HostDB sync issue by preserving expiry_time on load

### DIFF
--- a/iocore/hostdb/P_RefCountCache.h
+++ b/iocore/hostdb/P_RefCountCache.h
@@ -611,7 +611,7 @@ LoadRefCountCacheFromPath(RefCountCache<CacheEntryType> &cache, const std::strin
 
     CacheEntryType *newItem = load_func((char *)&buf, tmpValue.size);
     if (newItem != nullptr) {
-      cache.put(tmpValue.key, newItem, tmpValue.size - sizeof(CacheEntryType));
+      cache.put(tmpValue.key, newItem, tmpValue.size - sizeof(CacheEntryType), tmpValue.expiry_time);
     }
   };
 


### PR DESCRIPTION
# Problem
Although PR #12395 addresses an issue related to loading host.db, a new issue has been identified concerning the synchronization to host.db after the fix.
In short, the cache loaded from host.db is not being synced back to host.db.

Since synchronization to host.db is handled by `HostDBSync`, I investigated the behavior and found that the `write_partition` method in `HostDBSync` was skipping the write operation.
Specifically, the following `if` statement was triggered, and according to a gdb inspection, `entry->meta.expiry_time` was set to -1:
https://github.com/apache/trafficserver/blob/9f6ababfed6c9d0266ee1d7e1703a09413ca48cb/iocore/hostdb/P_RefCountCacheSerializer.h#L167-L170

```
(gdb) p entry->meta.expiry_time
$1 = -1
(gdb) p curr_time
$2 = 1754462975
```

# Cause
The cause of `entry->meta.expiry_time` being -1 lies in the load process of host.db, specifically in the `LoadRefCountCacheFromPath` function:
https://github.com/apache/trafficserver/blob/9f6ababfed6c9d0266ee1d7e1703a09413ca48cb/iocore/hostdb/P_RefCountCache.h#L612-L615

The cache is registered via a call to `cache.put` (`RefCountCache<HostDBInfo>::put`), but since the 4th argument (`expiry_time`) is omitted, the default value -1 is used:
https://github.com/apache/trafficserver/blob/9f6ababfed6c9d0266ee1d7e1703a09413ca48cb/iocore/hostdb/P_RefCountCache.h#L405

# Fix
The correct value to pass for the 4th argument of `RefCountCache<HostDBInfo>::put` is stored in `tmpValue.expiry_time`.
This patch updates the call to explicitly pass `tmpValue.expiry_time` as the `expiry_time` argument.