### PR TITLE
Add USDT tracepoints for connection fd tracking

### DIFF
--- a/src/iocore/net/ReadWriteEventIO.cc
+++ b/src/iocore/net/ReadWriteEventIO.cc
@@ -24,7 +24,7 @@
 
 #include "iocore/net/ReadWriteEventIO.h"
 #include "iocore/net/NetHandler.h"
-
+#include "ts/ats_probe.h"
 namespace
 {
 DbgCtl dbg_ctl_iocore_net_main{"iocore_net_main"};
@@ -52,6 +52,7 @@ ReadWriteEventIO::process_event(int flags)
 {
   // Remove triggered NetEvent from cop_list because it won't be timeout before
   // next InactivityCop runs.
+  ATS_PROBE2(eventio_rw_process_event, _ne->get_fd(), flags);
   if (_nh->cop_list.in(_ne)) {
     _nh->cop_list.remove(_ne);
   }

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -392,6 +392,7 @@ HttpSM::attach_client_session(ProxyTransaction *txn)
   if (!netvc) {
     return;
   }
+  ATS_PROBE2(http_attach_client_session, sm_id, netvc->get_socket());
   _ua.set_txn(txn, milestones);
 
   // Collect log & stats information. We've already verified that the netvc is !nullptr above,
@@ -6627,6 +6628,7 @@ HttpSM::attach_server_session()
   // Propagate the per client IP debugging
   if (_ua.get_txn()) {
     server_txn->get_netvc()->control_flags.set_flags(get_cont_flags().get_flags());
+    ATS_PROBE2(http_attach_server_session, this->sm_id, server_txn->get_netvc()->get_socket());
   } else { // If there is no _ua.get_txn() no sense in continuing to attach the server session
     return;
   }


### PR DESCRIPTION
* Origin connection pool - track acquisition and release
* Session attachment - correlate connections with state machines
* Readiness polling - track ready and error events