### PR TITLE
Error messages when server closes connection

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -1033,7 +1033,6 @@ HttpSM::state_read_push_response_header(int event, void *data)
 
   switch (event) {
   case VC_EVENT_EOS:
-    log_server_close_with_origin(t_state, "Server closed connection while reading PUSH response header.");
     _ua.get_entry()->eos = true;
     // Fall through
 
@@ -1971,7 +1970,7 @@ HttpSM::state_read_server_response_header(int event, void *data)
 
   switch (event) {
   case VC_EVENT_EOS:
-    log_server_close_with_origin(t_state, "Server closed connection while reading response header");
+    log_server_close_with_origin(t_state, "Server closed connection while reading response header.");
     server_entry->eos = true;
     // If we have received any bytes for this transaction do not retry
     if (server_response_hdr_bytes > 0) {


### PR DESCRIPTION
A server can close a connection while we're expecting a response.  For example, the server may close the connection due to a keep-alive timeout.  This results in a 502 response to the client.  Log an error in this case, so that the administrator has a chance to adjust the keep-alive timeout on the ATS side to avoid this situation.