### PR TITLE
escalate plugin: --get-method-only

### DIFF
--- a/doc/admin-guide/plugins/escalate.en.rst
+++ b/doc/admin-guide/plugins/escalate.en.rst
@@ -43,6 +43,10 @@ when the origin server in the remap rule returns a 401,
   This option sends the "pristine" Host: header (eg, the Host: header
   that the client sent) to the escalated request.
 
+@pparam=--get-method-only
+  This option restricts escalation to only GET requests. POST, PUT, HEAD,
+  and other methods will not be escalated.
+
 Installation
 ------------
 
@@ -61,3 +65,8 @@ Traffic Server would accept a request for ``cdn.example.com`` and, on a cache mi
 request to ``origin.example.com``. If the response code from that server is a 401, 404, 410,
 or 502, then Traffic Server would proxy the request to ``second-origin.example.com``, using a
 Host: header of ``cdn.example.com``.
+
+To only escalate GET requests, you can use::
+
+    map cdn.example.com origin.example.com \
+      @plugin=escalate.so @pparam=401,404,410,502:second-origin.example.com @pparam=--get-method-only

--- a/plugins/escalate/escalate.cc
+++ b/plugins/escalate/escalate.cc
@@ -20,13 +20,16 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
+#include "ts/apidefs.h"
 #include <ts/ts.h>
 #include <ts/remap.h>
+
 #include <cstdlib>
 #include <cstdio>
 #include <getopt.h>
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <iterator>
 #include <map>
 
@@ -67,7 +70,8 @@ struct EscalationState {
   ~EscalationState() { TSContDestroy(cont); }
   TSCont        cont;
   StatusMapType status_map;
-  bool          use_pristine = false;
+  bool          use_pristine      = false;
+  bool          only_escalate_get = false;
 };
 
 // Little helper function, to update the Host portion of a URL, and stringify the result.
@@ -92,6 +96,31 @@ MakeEscalateUrl(TSMBuffer mbuf, TSMLoc url, const char *host, size_t host_len, i
   return url_str;
 }
 
+/**
+ * Check if the method is GET.
+ *
+ * @param txn The transaction whose method is to be checked.
+ * @return True if @a txn's method is GET, false otherwise.
+ */
+static bool
+MethodIsGet(TSHttpTxn txn)
+{
+  TSMBuffer req_mbuf;
+  TSMLoc    req_hdrp;
+  if (TSHttpTxnClientReqGet(txn, &req_mbuf, &req_hdrp) != TS_SUCCESS) {
+    return false;
+  }
+  int         method_len = 0;
+  char const *method     = TSHttpHdrMethodGet(req_mbuf, req_hdrp, &method_len);
+  if (method == nullptr) {
+    return false;
+  }
+  std::string_view method_view{method, static_cast<size_t>(method_len)};
+  bool const       is_get = (method_view == TS_HTTP_METHOD_GET);
+  TSHandleMLocRelease(req_mbuf, TS_NULL_MLOC, req_hdrp);
+  return is_get;
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Main continuation for the plugin, examining an origin response for a potential retry.
 //
@@ -105,6 +134,12 @@ EscalateResponse(TSCont cont, TSEvent event, void *edata)
 
   TSAssert(event == TS_EVENT_HTTP_READ_RESPONSE_HDR || event == TS_EVENT_HTTP_SEND_RESPONSE_HDR);
   bool const processing_connection_error = (event == TS_EVENT_HTTP_SEND_RESPONSE_HDR);
+
+  if (es->only_escalate_get && !MethodIsGet(txn)) {
+    Dbg(dbg_ctl, "Skipping escalation for non-GET method");
+    TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);
+    return TS_EVENT_NONE;
+  }
 
   if (processing_connection_error) {
     TSServerState const state = TSHttpTxnServerStateGet(txn);
@@ -199,6 +234,8 @@ TSRemapNewInstance(int argc, char *argv[], void **instance, char *errbuf, int er
     // Ugly, but we set the precedence before with non-command line parsing of args
     if (0 == strncasecmp(argv[i], "--pristine", 10)) {
       es->use_pristine = true;
+    } else if (0 == strncasecmp(argv[i], "--get-method-only", 17)) {
+      es->only_escalate_get = true;
     } else {
       // Each token should be a status code then a URL, separated by ':'.
       sep = strchr(argv[i], ':');

--- a/tests/gold_tests/pluginTest/escalate/escalate_get_method_only.replay.yaml
+++ b/tests/gold_tests/pluginTest/escalate/escalate_get_method_only.replay.yaml
@@ -1,0 +1,253 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  # Original GET transactions from escalate_original.replay.yaml
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, first ]
+        - [ uuid, GET ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: first, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, first ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: first, as: equal } ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_chunked
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, second ]
+        - [ uuid, GET_chunked ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: second, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Response, second ]
+      content:
+        size: 320000
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: second, as: equal } ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_failed
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third ]
+        - [ uuid, GET_failed ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: third, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    proxy-response:
+      # The failover server should reply with a 200 OK (GET requests are still escalated with --get-head-only).
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: third, as: equal } ]
+
+  # This will not make it to the origin server since the Host is set to a
+  # non-responsive server. But the failover server should reply with a 200 OK.
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_down
+      headers:
+        fields:
+        - [ Host, down_origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fourth ]
+        - [ uuid, GET_down_origin ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: fourth, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: fourth, as: equal } ]
+
+  # POST request with sizable body that gets proxied normally.
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /api/upload/data
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Type, "application/json" ]
+        - [ Content-Length, 1234 ]
+        - [ X-Request, post_success ]
+        - [ uuid, POST_success ]
+      content:
+        encoding: plain
+        size: 1234
+
+    proxy-request:
+      method: "POST"
+      headers:
+        fields:
+        - [ X-Request, { value: post_success, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 1234 ]
+        - [ X-Response, post_success ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Response, { value: post_success, as: equal } ]
+
+  # A HEAD request that should NOT be escalated with --get-method-only
+  - client-request:
+      method: "HEAD"
+      version: "1.1"
+      url: /api/head/data
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ X-Request, head_fail_no_escalation ]
+        - [ uuid, HEAD_fail_no_escalation ]
+
+    proxy-request:
+      method: "HEAD"
+      headers:
+        fields:
+        - [ X-Request, { value: head_fail_no_escalation, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ X-Response, head_fail_no_escalation ]
+
+    # No failover due to --get-method-only (only GET is allowed).
+    proxy-response:
+      status: 502
+      headers:
+        fields:
+        - [ X-Response, { value: head_fail_no_escalation, as: equal } ]
+
+  # A 502 which is not escalated due to --get-method-only.
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /api/post/fail_no_escalation
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Type, "application/json" ]
+        - [ Content-Length, 1234 ]
+        - [ X-Request, post_fail_no_escalation ]
+        - [ uuid, POST_fail_no_escalation ]
+      content:
+        encoding: plain
+        size: 1234
+
+    proxy-request:
+      method: "POST"
+      headers:
+        fields:
+        - [ X-Request, { value: post_fail_no_escalation, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ X-Response, post_fail_no_escalation ]
+
+    # Again, no failover due to --get-head-only.
+    proxy-response:
+      status: 502
+      headers:
+        fields:
+        - [ X-Response, { value: post_fail_no_escalation, as: equal } ]


### PR DESCRIPTION
Implement --get-method-only for the escalate plugin, limiting the failover feature to GET method requests only. All other requests of different methods are not failed over.