### PR TITLE
Retry connect if server closes before receiving response

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -1933,13 +1933,15 @@ HttpSM::state_read_server_response_header(int event, void *data)
   switch (event) {
   case VC_EVENT_EOS:
     server_entry->eos = true;
+    // If we have received any bytes for this transaction do not retry
+    if (server_response_hdr_bytes > 0) {
+      t_state.current.retry_attempts.maximize(t_state.configured_connect_attempts_max_retries());
+    }
+    break;
 
-  // Fall through
   case VC_EVENT_READ_READY:
   case VC_EVENT_READ_COMPLETE:
     // More data to parse
-    // Got some data, won't retry origin connection on error
-    t_state.current.retry_attempts.maximize(t_state.configured_connect_attempts_max_retries());
     break;
 
   case VC_EVENT_ERROR:


### PR DESCRIPTION
This moves the check for retry or not into the `VC_EVENT_EOS` case and no longer does a fall-through.  Looking at the comment, it looks like the intent was to stop retrying when bytes were received, but neglected to handle the EOS case so the fall-through would unconditionally end retries.  This is not the behavior from 9.2, which would retry here.

This is certainly a funny edge-case in the protocol, and since we have sent the request to the server at this point, it is possible that the server has changed state and retries might not be appropriate.  It seems more likely that we wrote the request to an already closed connection, so a retry should be fine.

Since it's open to interpretation or situational, it might be something to add a config option for.  For now though, I'd like to just restore the 9.2 behavior except in the case when we have received some bytes and the connection has closed.

