### PR TITLE
Fix document syntax errors #12385

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -88,10 +88,34 @@ This is done by adding the following line to your :file:`plugin.config`::
 You may specify multiple configuration files. Their rules will be evaluated in
 the order the files are listed.
 
-The plugin takes an optional switch ``--geo-db-path``. If MaxMindDB support has
-been compiled in, use this switch to point at your .mmdb file. This also applies to
-the remap context.
+The plugin takes an optional switches.
 
+====================================== ==================================================================================================
+ Option                                Description
+====================================== ==================================================================================================
+ ``--geo-db-path <path_to_geoip_db>``  A file path for MaxMindDB.
+ ``--timezone <value>``                Timezone to use on header rewrite rules.
+ ``--inbound-ip-source <value>``       The source of IP address for the client.
+====================================== ==================================================================================================
+
+Please note that these optional switches needs to appear before config files like you would do on UNIX command lines.
+
+``--geo-db-path``
+~~~~~~~~~~~~~~~~~
+
+If MaxMindDB support has been compiled in, use this switch to point at your .mmdb file.
+This also applies to the remap context.
+
+``--timezone``
+~~~~~~~~~~~~~~
+
+This applies ``set-plugin-cntl TIMEZONE <value>`` to every transaction unconditionally.
+See set-plugin-cntl for the setting values and the effect.
+
+``--inbound-ip-source``
+~~~~~~~~~~~~~~~~~~~~~~~
+This applies ``set-plugin-cntl INBOUND_IP_SOURCE <value>`` to every transaction unconditionally.
+See set-plugin-cntl for the setting values and the effect.
 
 Enabling Per-Mapping
 --------------------
@@ -261,7 +285,7 @@ The two arguments, if provided, are comma separated. Valid syntax includes::
 A typical use case is to insert the @-prefixed header as above, and then use
 this header in a custom log format, rather than logging the full client
 IP. Another use case could be to make a special condition on a sub-net,
-e.g.::
+e.g. ::
 
     cond %{CIDR:8} ="8.0.0.0"
         set-header X-Is-Eight "Yes"
@@ -1100,16 +1124,27 @@ set-plugin-cntl
 This operator lets you control the fundamental behavior of this plugin for a particular transaction.
 The available controllers are:
 
-+===================+========================+==============================================================================================+
-| Controller        | Operators/Conditions   | Description                                                                                  |
-+===================+========================+==============================================================================================+
-| TIMEZONE          | ``NOW``                | If ``GMT`` is passed, the operators and conditions use GMT regardles of the timezone setting |
-|                   |                        | on your system. The default value is ``LOCAL``.                                              |
-+===================+========================+==============================================================================================+
-| INBOUND_IP_SOURCE | ``IP``, ``INBOUND``,   | Selects which IP address to use for the operators and conditions. Available sources are      |
-|                   | ``CIDR``, and ``GEO``  | ``PEER`` (Uses the IP address of the peer), and ``PROXY`` (Uses the IP address from PROXY    |
-|                   |                        | protocol)                                                                                    |
-+===================+========================+==============================================================================================+
+================== ============================================ =======================
+Controller         Operators/Conditions                         Available values
+================== ============================================ =======================
+TIMEZONE           ``NOW``                                      ``GMT``, or ``LOCAL``
+INBOUND_IP_SOURCE  ``IP``, ``INBOUND``, ``CIDR``, and ``GEO``   ``PEER``, or ``PROXY``
+================== ============================================ =======================
+
+TIMEZONE
+""""""""
+
+This controller selects the timezone to use for ``NOW`` condition.
+If ``GMT`` is set, GMT will be used regardles of the timezone setting on your system. The default value is ``LOCAL``.
+
+INBOUND_IP_SOURCE
+"""""""""""""""""
+This controller selects which IP address to use for the conditions on the table above.
+The default value is ``PEER`` and the IP address of the peer will be used.
+If ``PROXY`` is set, and PROXY protocol is used, the source IP address provided by PROXY protocol will be used.
+
+.. note::
+    The conditions return an empty string if the source is set to ``PROXY`` but PROXY protocol header does not present.
 
 Operator Flags
 --------------
@@ -1406,7 +1441,7 @@ Remove Origin Authentication Headers
 The following ruleset removes any authentication headers from the origin
 response before caching it or returning it to the client. This is accomplished
 by setting the hook context and then removing the cookie and basic
-authentication headers.::
+authentication headers. ::
 
    cond %{READ_RESPONSE_HDR_HOOK}
    rm-header Set-Cookie
@@ -1546,7 +1581,7 @@ add a ``Connection: close`` header to have clients drop their connection,
 allowing the server to drain. Although Connection header is only available on
 HTTP/1.1 in terms of protocols, but this also works for HTTP/2 connections
 because the header triggers HTTP/2 graceful shutdown. This should be a global
-configuration.::
+configuration. ::
 
    cond %{SEND_RESPONSE_HDR_HOOK}
    cond %{ACCESS:/path/to/the/healthcheck/file.txt}    [NOT,OR]
@@ -1557,7 +1592,7 @@ Use Internal header to pass data
 
 In |TS|, a header that begins with ``@`` does not leave |TS|. Thus, you can use
 this to pass data to different |TS| systems. For instance, a series of remap rules
-could each be tagged with a consistent name to make finding logs easier.::
+could each be tagged with a consistent name to make finding logs easier. ::
 
    cond %{REMAP_PSEUDO_HOOK}
    set-header @PropertyName "someproperty"
@@ -1572,7 +1607,7 @@ could each be tagged with a consistent name to make finding logs easier.::
 Remove Client Query Parameters
 ------------------------------------
 
-The following ruleset removes any query parameters set by the client.::
+The following ruleset removes any query parameters set by the client. ::
 
    cond %{REMAP_PSEUDO_HOOK}
    rm-destination QUERY
@@ -1591,7 +1626,7 @@ Mimic X-Debug Plugin's X-Cache Header
 -------------------------------------
 
 This rule can mimic X-Debug plugin's ``X-Cache`` header by accumulating
-the ``CACHE`` condition results to a header.::
+the ``CACHE`` condition results to a header. ::
 
    cond %{SEND_RESPONSE_HDR_HOOK} [AND]
    cond %{HEADER:All-Cache} ="" [NOT]
@@ -1606,7 +1641,7 @@ Add Identifier from Server with Data
 
 This rule adds an unique identifier from the server if the data is fresh from
 the cache or if the identifier has not been generated yet. This will inform
-the client where the requested data was served from.::
+the client where the requested data was served from. ::
 
    cond %{SEND_RESPONSE_HDR_HOOK} [AND]
    cond %{HEADER:ATS-SRVR-UUID} ="" [OR]
@@ -1617,7 +1652,7 @@ Apply rate limiting for some select requests
 --------------------------------------------
 
 This rule will conditiionally, based on the client request headers, apply rate
-limiting to the request.::
+limiting to the request. ::
 
    cond %{REMAP_PSEUDO_HOOK} [AND]
    cond %{CLIENT-HEADER:Some-Special-Header} ="yes"
@@ -1635,7 +1670,7 @@ This rule will deny all requests for URIs with the ``.php`` file extension::
 Use GMT regardless of system timezone setting
 ---------------------------------------------
 
-This rule will change the behavior of %{NOW}. It will always return time in GMT.
+This rule will change the behavior of %{NOW}. It will always return time in GMT. ::
 
    cond %{READ_REQUEST_HDR_HOOK}
       set-plugin-cntl TIMEZONE GMT
@@ -1647,7 +1682,7 @@ Use IP address provided by PROXY protocol
 -----------------------------------------
 
 This rule will change the behavior of all header_rewrite conditions which use the client's IP address on a connection.
-Those will pick the address provided by PROXY protocol, instead of the peer's address.
+Those will pick the address provided by PROXY protocol, instead of the peer's address. ::
 
    cond %{READ_REQUEST_HDR_HOOK}
       set-plugin-cntl INBOUND_IP_SOURCE PROXY


### PR DESCRIPTION
* Fix document syntax errors

* Fix the table

* Fix title levele inconsistency

* Fix typo

* Try to fix .:

(cherry picked from commit 3338f60e1ebe2d3ccdc22a9defaaf6f3950f5d6c)