### PR TITLE
hrw: forward declare template specializations

### DIFF
--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -57,6 +57,12 @@ if(BUILD_TESTING)
   if(maxminddb_FOUND)
     target_link_libraries(test_header_rewrite PRIVATE maxminddb::maxminddb)
   endif()
+
+  add_executable(test_matcher matcher_tests.cc matcher.cc lulu.cc regex_helper.cc resources.cc)
+  add_test(NAME test_matcher COMMAND $<TARGET_FILE:test_matcher>)
+
+  target_link_libraries(test_matcher PRIVATE catch2::catch2 ts::tsutil libswoc::libswoc PCRE::PCRE)
+
 endif()
 verify_global_plugin(header_rewrite)
 verify_remap_plugin(header_rewrite)

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -40,12 +40,6 @@
 // Debugs
 namespace header_rewrite_ns
 {
-const char PLUGIN_NAME[]     = "header_rewrite";
-const char PLUGIN_NAME_DBG[] = "dbg_header_rewrite";
-
-DbgCtl dbg_ctl{PLUGIN_NAME_DBG};
-DbgCtl pi_dbg_ctl{PLUGIN_NAME};
-
 std::once_flag initHRWLibs;
 PluginFactory  plugin_factory;
 

--- a/plugins/header_rewrite/matcher.cc
+++ b/plugins/header_rewrite/matcher.cc
@@ -21,10 +21,20 @@
   limitations under the License.
 */
 
+#include "tsutil/DbgCtl.h"
 #include <string>
 #include <algorithm>
 
 #include "matcher.h"
+
+namespace header_rewrite_ns
+{
+const char PLUGIN_NAME[]     = "header_rewrite";
+const char PLUGIN_NAME_DBG[] = "dbg_header_rewrite";
+
+DbgCtl dbg_ctl{PLUGIN_NAME_DBG};
+DbgCtl pi_dbg_ctl{PLUGIN_NAME};
+} // namespace header_rewrite_ns
 
 static bool
 match_with_modifiers(std::string_view rhs, std::string_view lhs, CondModifiers mods)
@@ -116,7 +126,7 @@ Matchers<const sockaddr *>::test(const sockaddr *const &addr, const Resources & 
   if (ranges.contains(swoc::IPAddr(addr))) {
     if (pi_dbg_ctl.on()) {
       char text[INET6_ADDRSTRLEN];
-      Dbg(pi_dbg_ctl, "Successfully found IP-range match on %s", getIP(addr, text));
+      Dbg(dbg_ctl, "Successfully found IP-range match on %s", getIP(addr, text));
     }
     return true;
   }

--- a/plugins/header_rewrite/matcher.cc
+++ b/plugins/header_rewrite/matcher.cc
@@ -126,7 +126,7 @@ Matchers<const sockaddr *>::test(const sockaddr *const &addr, const Resources & 
   if (ranges.contains(swoc::IPAddr(addr))) {
     if (pi_dbg_ctl.on()) {
       char text[INET6_ADDRSTRLEN];
-      Dbg(dbg_ctl, "Successfully found IP-range match on %s", getIP(addr, text));
+      Dbg(pi_dbg_ctl, "Successfully found IP-range match on %s", getIP(addr, text));
     }
     return true;
   }

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -380,3 +380,11 @@ private:
   std::variant<T, std::set<T>, swoc::IPRangeSet, regexHelper> _data;
   CondModifiers                                               _mods = CondModifiers::NONE;
 };
+
+// forward declare spcializations implemented in matcher.cc
+
+template <> bool Matchers<std::string>::test_eq(const std::string &) const;
+
+template <> bool Matchers<std::string>::test_set(const std::string &) const;
+
+template <> bool Matchers<const sockaddr *>::test(const sockaddr *const &, const Resources &) const;

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -361,13 +361,13 @@ private:
   test_reg(const std::string &t, const Resources &res) const
   {
     TSAssert(std::holds_alternative<regexHelper>(_data));
-    Dbg(pi_dbg_ctl, "Test regular expression against: %s (NOCASE = %s)", t.c_str(),
+    Dbg(header_rewrite_ns::dbg_ctl, "Test regular expression against: %s (NOCASE = %s)", t.c_str(),
         has_modifier(_mods, CondModifiers::MOD_NOCASE) ? "true" : "false");
     const auto &re    = std::get<regexHelper>(_data);
     int         count = re.regexMatch(t.c_str(), t.length(), const_cast<Resources &>(res).ovector);
 
     if (count > 0) {
-      Dbg(pi_dbg_ctl, "Successfully found regular expression match");
+      Dbg(header_rewrite_ns::dbg_ctl, "Successfully found regular expression match");
       const_cast<Resources &>(res).ovector_ptr   = t.c_str();
       const_cast<Resources &>(res).ovector_count = count;
 

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -361,13 +361,13 @@ private:
   test_reg(const std::string &t, const Resources &res) const
   {
     TSAssert(std::holds_alternative<regexHelper>(_data));
-    Dbg(header_rewrite_ns::dbg_ctl, "Test regular expression against: %s (NOCASE = %s)", t.c_str(),
+    Dbg(pi_dbg_ctl, "Test regular expression against: %s (NOCASE = %s)", t.c_str(),
         has_modifier(_mods, CondModifiers::MOD_NOCASE) ? "true" : "false");
     const auto &re    = std::get<regexHelper>(_data);
     int         count = re.regexMatch(t.c_str(), t.length(), const_cast<Resources &>(res).ovector);
 
     if (count > 0) {
-      Dbg(header_rewrite_ns::dbg_ctl, "Successfully found regular expression match");
+      Dbg(pi_dbg_ctl, "Successfully found regular expression match");
       const_cast<Resources &>(res).ovector_ptr   = t.c_str();
       const_cast<Resources &>(res).ovector_count = count;
 

--- a/plugins/header_rewrite/matcher_tests.cc
+++ b/plugins/header_rewrite/matcher_tests.cc
@@ -1,0 +1,107 @@
+/**
+  @file Test for matcher.cc
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "matcher.h"
+#include "ts/apidefs.h"
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+int
+_TSAssert(const char *, const char *, int)
+{
+  return 0;
+}
+
+void
+TSError(const char *fmt, ...)
+{
+  va_list args;
+
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+  fprintf(stderr, "\n");
+}
+
+TSHttpStatus
+TSHttpHdrStatusGet(TSMBuffer, TSMLoc)
+{
+  return TS_HTTP_STATUS_OK;
+}
+
+TSReturnCode
+TSHandleMLocRelease(TSMBuffer, TSMLoc, TSMLoc)
+{
+  return TS_SUCCESS;
+}
+
+const char *
+TSHttpHookNameLookup(TSHttpHookID)
+{
+  return nullptr;
+}
+
+TSReturnCode
+TSHttpTxnClientReqGet(TSHttpTxn, TSMBuffer *, TSMLoc *)
+{
+  return TS_SUCCESS;
+}
+
+TSReturnCode
+TSHttpTxnServerReqGet(TSHttpTxn, TSMBuffer *, TSMLoc *)
+{
+  return TS_SUCCESS;
+}
+
+TSReturnCode
+TSHttpTxnClientRespGet(TSHttpTxn, TSMBuffer *, TSMLoc *)
+{
+  return TS_SUCCESS;
+}
+
+TSReturnCode
+TSHttpTxnServerRespGet(TSHttpTxn, TSMBuffer *, TSMLoc *)
+{
+  return TS_SUCCESS;
+}
+
+TEST_CASE("Matcher", "[plugins][header_rewrite]")
+{
+  Matchers<std::string> foo(MATCH_EQUAL);
+  TSHttpTxn             txn = nullptr;
+  TSCont                c   = nullptr;
+  Resources             res(txn, c);
+
+  foo.set("FOO", CondModifiers::MOD_NOCASE);
+  REQUIRE(foo.test("foo", res) == true);
+}
+
+TEST_CASE("MatcherSet", "[plugins][header_rewrite]")
+{
+  Matchers<std::string> foo(MATCH_SET);
+  TSHttpTxn             txn = nullptr;
+  TSCont                c   = nullptr;
+  Resources             res(txn, c);
+
+  foo.set("foo, bar, baz", CondModifiers::MOD_NOCASE);
+  REQUIRE(foo.test("FOO", res) == true);
+}


### PR DESCRIPTION
Older (but not that old) compiler's can't see template specializations implemented in another translation unit without forward declaring them.  This adds the forward declarations and also adds a unit test that was used to track down and verify this issue.

This is an alternative fix to #12433