### PR TITLE
ESI: --allowed-response-codes

### DIFF
--- a/doc/admin-guide/plugins/esi.en.rst
+++ b/doc/admin-guide/plugins/esi.en.rst
@@ -92,6 +92,9 @@ Enabling ESI
   1024 * 1024.  Example values: 500, 5K, 2M.  If this option is omitted, the maximum document size defaults to 1M.
 - ``--max-inclusion-depth <max-depth>`` controls the maximum depth of recursive ESI inclusion allowed (between 0 and 9).
   Default is 3.
+- ``--allowed-response-codes <code1,code2,...>`` specifies a comma-separated list of HTTP response codes that should
+  be processed for ESI transformation.  Only responses with these status codes will be examined for ESI content. Default
+  is ``200,304``.
 
 3. ``HTTP_COOKIE`` variable support is turned off by default. It can be turned on with ``-f <handler_config>`` or
    ``-handler <handler_config>``. For example:

--- a/tests/gold_tests/pluginTest/esi/esi.test.py
+++ b/tests/gold_tests/pluginTest/esi/esi.test.py
@@ -186,9 +186,9 @@ echo date('l jS \of F Y h:i:s A');
         client_process.Streams.stdout = "gold/esi_body.gold"
         if self._cc_behavior == CcBehaviorT.REMOVE_CC:
             client_process.Streams.stderr += Testers.ExcludesExpression(
-                'cache-control:', 'The Cache-Control field not be present in the response', reflags=re.IGNORECASE)
+                'cache-control:', 'The Cache-Control field should not be present in the response', reflags=re.IGNORECASE)
             client_process.Streams.stderr += Testers.ExcludesExpression(
-                'expires:', 'The Expires field not be present in the response', reflags=re.IGNORECASE)
+                'expires:', 'The Expires field should not be present in the response', reflags=re.IGNORECASE)
         if self._cc_behavior == CcBehaviorT.MAKE_PRIVATE:
             client_process.Streams.stderr += Testers.ContainsExpression(
                 'cache-control:.*max-age=0, private',
@@ -310,6 +310,22 @@ echo date('l jS \of F Y h:i:s A');
         tr.StillRunningAfter = self._server
         tr.StillRunningAfter = self._ts
 
+    def run_cases_expecting_no_transformation(self):
+        tr = Test.AddTestRun(f"Verify the ESI plugin does not transform responses: {self._plugin_config}")
+        client = tr.MakeCurlCommand(
+            f'http://127.0.0.1:{self._ts.Variables.port}/esi.php '
+            '-H"Host: www.example.com" -H"Accept: */*" --verbose',
+            ts=self._ts)
+        client.ReturnCode = 0
+
+        # Expect no transformation: the tag should be present without any transformation.
+        client.Streams.stdout += Testers.ContainsExpression(
+            'Hello, <esi:include src="http://www.example.com/date.php"/>',
+            'The response should not be transformed',
+            reflags=re.IGNORECASE)
+        tr.StillRunningAfter = self._server
+        tr.StillRunningAfter = self._ts
+
 
 #
 # Configure and run the test cases.
@@ -352,3 +368,13 @@ max_doc_2K_test = EsiTest(plugin_config='esi.so --max-doc-size 2K')
 max_doc_2K_test.run_cases_expecting_gzip()
 max_doc_20M_test = EsiTest(plugin_config='esi.so --max-doc-size 20M')
 max_doc_20M_test.run_cases_expecting_gzip()
+
+# The test doesn't use 304 redirect, so restricting the allowed response codes to 200
+# should not affect the test.
+allowed_response_codes_test = EsiTest(plugin_config='esi.so --allowed-response-codes 200')
+allowed_response_codes_test.run_cases_expecting_gzip()
+
+# Do not allow transforming the 200 OK response. Since the test uses a 200 OK response,
+# the plugin should not transform it.
+response_not_allowed_test = EsiTest(plugin_config='esi.so --allowed-response-codes 304')
+response_not_allowed_test.run_cases_expecting_no_transformation()


### PR DESCRIPTION
Adds --allowed-response-codes to the ESI plugin for response code filtering for which ESI transformations will take place. Some origins may add X-Esi headers to every response, even 5xx responses or the like. Setting those up for transformation can be wasteful.