### PR TITLE
xdebug probe: fix empty value handling

### DIFF
--- a/plugins/xdebug/xdebug_headers.cc
+++ b/plugins/xdebug/xdebug_headers.cc
@@ -66,8 +66,8 @@ public:
       if (BEFORE_NAME == _state) {
         return {""};
       } else if (BEFORE_VALUE == _state) {
-        // Failsafe -- missing value -- this should never happen.
-        result = _missing_value(_full_json);
+        // The header field has no value.
+        result = _handle_empty_value(_full_json);
       }
       _state = BEFORE_NAME;
       return result;
@@ -116,16 +116,14 @@ private:
   }
 
   /** The separator content when there is an empty value.
-   *
-   * This is hopefully never used.
    */
   static std::string_view
-  _missing_value(bool full_json)
+  _handle_empty_value(bool full_json)
   {
     if (full_json) {
-      return {R"(":")"};
+      return {R"(",")"};
     } else {
-      return {"' : '','\n\t"};
+      return {"',\n\t'"};
     }
   }
 

--- a/tests/gold_tests/pluginTest/xdebug/x_probe/x_probe.replay.yaml
+++ b/tests/gold_tests/pluginTest/xdebug/x_probe/x_probe.replay.yaml
@@ -42,6 +42,7 @@ sessions:
         - [ Content-Type, "text/html" ]
         - [ Content-Length, "20" ]
         - [ X-Server, "TestOrigin" ]
+        - [ X-No-Value, "" ]
       content:
         encoding: plain
         data: "Original server body"

--- a/tests/gold_tests/pluginTest/xdebug/x_probe/x_probe.test.py
+++ b/tests/gold_tests/pluginTest/xdebug/x_probe/x_probe.test.py
@@ -74,6 +74,7 @@ class XDebugProbeTest:
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
             'ATS xDebug Probe Injection Boundary', "ATS xDebug Probe Injection Boundary should be present")
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('xDebugProbeAt', "xDebugProbeAt should be present")
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression("'x-no-value' : ''", "x-no-value should be present")
 
 
 # Execute the test

--- a/tests/gold_tests/pluginTest/xdebug/x_probe_full_json/x_probe_full_json.replay.yaml
+++ b/tests/gold_tests/pluginTest/xdebug/x_probe_full_json/x_probe_full_json.replay.yaml
@@ -41,6 +41,7 @@ sessions:
         - [ Content-Type, "text/html" ]
         - [ Content-Length, "24" ]
         - [ X-Response, "from-origin" ]
+        - [ X-No-Value, "" ]
       content:
         encoding: plain
         data: "Original server response"


### PR DESCRIPTION
This fixes a bug in xdebug prob/probe-full-json for handling empty values.