### PR TITLE
Cripts: Fix standalone query URI component

### DIFF
--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -463,9 +463,10 @@ public:
 
     Query(cripts::string_view load)
     {
-      _data   = load;
-      _size   = load.size();
-      _loaded = true;
+      _data       = load;
+      _size       = load.size();
+      _loaded     = true;
+      _standalone = true;
     }
 
     void Reset() override;
@@ -517,7 +518,8 @@ public:
   private:
     void _parser();
 
-    bool           _modified = false;
+    bool           _modified   = false;
+    bool           _standalone = false;  // This component is used outside of a URL owner, not common
     OrderedParams  _ordered;             // Ordered vector of all parameters, can be sorted etc.
     HashParams     _hashed;              // Unordered map to go from "name" to the query parameter
     cripts::string _storage;             // Used when recombining the query params into a

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -229,6 +229,7 @@ Url::Path::_parser()
 Url::Query::Parameter &
 Url::Query::Parameter::operator=(const cripts::string_view str)
 {
+  CAssert(!_owner->_standalone);
   _ensure_initialized(_owner->_owner);
   CAssert(!_owner->_owner->ReadOnly()); // This can not be a read-only URL
   auto iter = _owner->_hashed.find(_name);
@@ -247,7 +248,9 @@ Url::Query::Parameter::operator=(const cripts::string_view str)
 cripts::string_view
 Url::Query::GetSV()
 {
-  _ensure_initialized(_owner);
+  if (!_standalone) {
+    _ensure_initialized(_owner);
+  }
   if (_ordered.size() > 0) {
     _storage.clear();
     _storage.reserve(_size);
@@ -291,6 +294,7 @@ Url::Query::GetSV()
 Url::Query
 Url::Query::operator=(cripts::string_view query)
 {
+  CAssert(!_standalone);
   _ensure_initialized(_owner);
   CAssert(!_owner->ReadOnly()); // This can not be a read-only URL
   TSUrlHttpQuerySet(_owner->_bufp, _owner->_urlp, query.data(), query.size());
@@ -318,8 +322,10 @@ Url::Query::operator+=(cripts::string_view add)
 Url::Query::Parameter
 Url::Query::operator[](cripts::string_view param)
 {
-  // Make sure the hash and vector are populated
-  _ensure_initialized(_owner);
+  // Make sure the hash and vector are populated, but only if we have an owner
+  if (!_standalone) {
+    _ensure_initialized(_owner);
+  }
   _parser();
 
   Parameter ret;


### PR DESCRIPTION
This fixes a regression introduced with the Convenience APIs, and is a rare edge cases where URI components can be created outside of an owning URL.