### PR TITLE
Comment out the matcher header_rewrite test

### DIFF
--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -63,10 +63,11 @@ if(BUILD_TESTING)
     target_link_libraries(test_header_rewrite PRIVATE maxminddb::maxminddb)
   endif()
 
-  add_executable(test_matcher matcher_tests.cc matcher.cc lulu.cc regex_helper.cc resources.cc)
-  add_catch2_test(NAME test_matcher COMMAND $<TARGET_FILE:test_matcher>)
-
-  target_link_libraries(test_matcher PRIVATE Catch2::Catch2WithMain ts::tscore libswoc::libswoc PCRE::PCRE)
+  # This test has linker issue when cripts is enabled, so its commented for now
+  #  add_executable(test_matcher matcher_tests.cc matcher.cc lulu.cc regex_helper.cc resources.cc)
+  #  add_catch2_test(NAME test_matcher COMMAND $<TARGET_FILE:test_matcher>)
+  #
+  #  target_link_libraries(test_matcher PRIVATE Catch2::Catch2WithMain ts::tscore libswoc::libswoc PCRE::PCRE)
 
 endif()
 verify_global_plugin(header_rewrite)


### PR DESCRIPTION
The test I added got much more complicated to link if cripts is in the picture, so I commented it out.  If we want to test that the matcher can be case insensitive, we could do it another way (autest perhaps?).