### PR TITLE
Remove a redundant flag in CacheVC

### DIFF
--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -276,7 +276,7 @@ CacheVC::get_data(int i, void *data)
     *(static_cast<CacheHTTPInfo **>(data)) = &alternate;
     return true;
   case CACHE_DATA_RAM_CACHE_HIT_FLAG:
-    *(static_cast<int *>(data)) = !f.not_from_ram_cache;
+    *(static_cast<int *>(data)) = f.doc_from_ram_cache;
     return true;
   default:
     break;
@@ -386,9 +386,6 @@ CacheVC::handleReadDone(int event, Event * /* e ATS_UNUSED */)
     // put into ram cache?
     if (io.ok() && ((doc->first_key == *read_key) || (doc->key == *read_key) || STORE_COLLISION) && doc->magic == DOC_MAGIC) {
       int okay = 1;
-      if (!f.doc_from_ram_cache) {
-        f.not_from_ram_cache = 1;
-      }
       if (cache_config_enable_checksum && doc->checksum != DOC_NO_CHECKSUM) {
         // verify that the checksum matches
         uint32_t checksum = 0;

--- a/src/iocore/cache/CacheVC.h
+++ b/src/iocore/cache/CacheVC.h
@@ -58,7 +58,7 @@ struct CacheVC : public CacheVConnection {
   is_ram_cache_hit() const override
   {
     ink_assert(vio.op == VIO::READ);
-    return !f.not_from_ram_cache;
+    return f.doc_from_ram_cache;
   }
 
   int
@@ -302,7 +302,6 @@ struct CacheVC : public CacheVConnection {
       unsigned int open_read_timeout       : 1; // UNUSED
       unsigned int data_done               : 1;
       unsigned int read_from_writer_called : 1;
-      unsigned int not_from_ram_cache      : 1; // entire object was from ram cache
       unsigned int rewrite_resident_alt    : 1;
       unsigned int readers                 : 1;
       unsigned int doc_from_ram_cache      : 1;


### PR DESCRIPTION
There is already a flag called f.doc_from_ram_cache.  This flag, f.not_from_ram_cache, is always its negation.  Remove this redundant flag and fix up the one place where it's used.