### PR TITLE
[Doc] additional delays with linux defer_accept

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -5185,8 +5185,8 @@ Sockets
    default: ``1`` meaning ``on`` all Platforms except Linux: ``45`` seconds
 
    This directive enables operating system specific optimizations for a listening socket. ``defer_accept`` holds a call to ``accept(2)``
-   back until data has arrived. In Linux' special case this is up to a maximum of 45 seconds.
-   On FreeBSD, ``accf_data`` module needs to be loaded.
+   back until data has arrived. In Linux' special case this is up to a maximum of 45 seconds. Note in Linux, additional delays may
+   occur as kernel handles retries using exponential backoff algorithm. On FreeBSD, ``accf_data`` module needs to be loaded.
    Note: If MPTCP is enabled, TCP_DEFER_ACCEPT is only supported on Linux kernels 5.19+.
 
 .. ts:cv:: CONFIG proxy.config.net.listen_backlog INT -1


### PR DESCRIPTION
Explaining why there might be additional delay in the inactivity timeout period when opening a connection on Linux. ATS should timeout (`defer_accept` + `accept_no_activity_timeout`) seconds but kernel sends transmits using exponential backoff algo so `defer_accept` is rounded to nearest exponential value