### PR TITLE
Skip SO_REUSEPORT for AF_UNIX sockets

### DIFF
--- a/src/iocore/net/Server.cc
+++ b/src/iocore/net/Server.cc
@@ -38,6 +38,7 @@
 #include "tscore/ink_inet.h"
 #include "tscore/ink_platform.h"
 #include "tscore/ink_sock.h"
+#include <sys/socket.h>
 
 #if TS_USE_HWLOC
 #include <hwloc.h>
@@ -229,7 +230,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
     goto Lerror;
   }
   listen_per_thread = RecGetRecordInt("proxy.config.exec_thread.listen").value_or(0);
-  if (listen_per_thread == 1) {
+  if (listen_per_thread == 1 && opt.ip_family != AF_UNIX) {
     if (sock.enable_option(SOL_SOCKET, SO_REUSEPORT) < 0) {
       goto Lerror;
     }


### PR DESCRIPTION
unix sockets don't support reuse port, so this call isn't needed and on some kernel versions actually returns an error.  So just skip this call for domain sockets.