### PR TITLE
Skip SO_REUSEPORT for AF_UNIX sockets (#12470)

### DIFF
--- a/src/iocore/net/Server.cc
+++ b/src/iocore/net/Server.cc
@@ -38,6 +38,7 @@
 #include "tscore/ink_inet.h"
 #include "tscore/ink_platform.h"
 #include "tscore/ink_sock.h"
+#include <sys/socket.h>
 
 #if TS_USE_HWLOC
 #include <hwloc.h>
@@ -229,7 +230,7 @@ Server::setup_fd_for_listen(bool non_blocking, const NetProcessor::AcceptOptions
     goto Lerror;
   }
   REC_ReadConfigInteger(listen_per_thread, "proxy.config.exec_thread.listen");
-  if (listen_per_thread == 1) {
+  if (listen_per_thread == 1 && opt.ip_family != AF_UNIX) {
     if (sock.enable_option(SOL_SOCKET, SO_REUSEPORT) < 0) {
       goto Lerror;
     }


### PR DESCRIPTION
(cherry picked from commit 9d9a8faf9c11bb0f660aaa277f9587a293d5f1d1)