### PR TITLE
Fix integer overflow in compress plugin for large file compression

### DIFF
--- a/plugins/compress/compress.cc
+++ b/plugins/compress/compress.cc
@@ -22,6 +22,7 @@
  */
 
 #include <cstring>
+#include <cinttypes>
 #include <zlib.h>
 
 #include "ts/apidefs.h"
@@ -539,7 +540,7 @@ gzip_transform_finish(Data *data)
     }
 
     if (data->downstream_length != static_cast<int64_t>(data->zstrm.total_out)) {
-      error("gzip-transform: output lengths don't match (%d, %ld)", data->downstream_length, data->zstrm.total_out);
+      error("gzip-transform: output lengths don't match (%" PRId64 ", %lu)", data->downstream_length, data->zstrm.total_out);
     }
 
     debug("gzip-transform: Finished gzip");
@@ -564,7 +565,7 @@ brotli_transform_finish(Data *data)
   }
 
   if (data->downstream_length != static_cast<int64_t>(data->bstrm.total_out)) {
-    error("brotli-transform: output lengths don't match (%d, %ld)", data->downstream_length, data->bstrm.total_out);
+    error("brotli-transform: output lengths don't match (%" PRId64 ", %zu)", data->downstream_length, data->bstrm.total_out);
   }
 
   debug("brotli-transform: Finished brotli");

--- a/plugins/compress/misc.h
+++ b/plugins/compress/misc.h
@@ -76,7 +76,7 @@ using Data = struct {
   TSVIO                    downstream_vio;
   TSIOBuffer               downstream_buffer;
   TSIOBufferReader         downstream_reader;
-  int                      downstream_length;
+  int64_t                  downstream_length;
   z_stream                 zstrm;
   enum transform_state     state;
   int                      compression_type;


### PR DESCRIPTION
The compress plugin was crashing when compressing large files due to integer overflow in the downstream_length tracking variable:
```
[ET_NET 4] ERROR: <InkAPI.cc:250 (TSError)> [/trafficserver/plugins/compress/compress.cc:507] [brotli_transform_finish] ERROR: brotli-transform: output lengths don't match (-2102735855, 2192231441)
Fatal: /trafficserver/src/api/InkIOCoreAPI.cc:356: failed assertion `nbytes >= 0`
traffic_server: received signal 6 (Aborted)
```

The issue occurred when compressing files larger than ~2GB, causing the 32-bit signed downstream_length to overflow and wrap to negative values, while the compression libraries' output counters (uLong/size_t) reported correct values.

Changes:
- Upgraded downstream_length from 'int' to 'int64_t' to handle large files
- Updated printf format specifiers for handling the int64_t values
