### PR TITLE
fix skip_bytes crash by setting correct cache-write header skip

### DIFF
--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -496,6 +496,8 @@ private:
   int     find_server_buffer_size();
   int     find_http_resp_buffer_size(int64_t cl);
   int64_t server_transfer_init(MIOBuffer *buf, int hdr_size);
+  // Helper to compute how the server-to-client body will be tunneled (chunked, dechunked, or passthrough).
+  TunnelChunkingAction_t compute_server_to_client_action() const;
 
   /// Update the milestones to track time spent in the plugin API.
   void milestone_update_api_time();


### PR DESCRIPTION
This assert failed:
- Fatal: src/proxy/http/HttpTunnel.cc:1005: failed assertion `c->skip_bytes <= c->buffer_reader->read_avail()`

It was triggered when CACHE_WRITE read from a dechunked buffer while a TRANSFORM consumer was present (header not in that buffer)

I think the root cause is this:
- HttpSM passed client_response_hdr_bytes as skip_bytes to CACHE_WRITE unconditionally
- In DECHUNK_CONTENT or PASSTHRU_CHUNKED_CONTENT with a transform consumer, header bytes aren’t copied to the dechunked buffer, so c->buffer_reader->read_avail() < skip_bytes and the tunnel assert fired