### PR TITLE
Add tests for compress plugin handling of chunked responses

### DIFF
--- a/tests/gold_tests/compress_chunked_transform_skip_bytes/compress_chunked_transform_skip_bytes.test.py
+++ b/tests/gold_tests/compress_chunked_transform_skip_bytes/compress_chunked_transform_skip_bytes.test.py
@@ -1,0 +1,76 @@
+'''Verify no crash when cache-write skip_bytes with transform and chunked origin.'''
+
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+from ports import get_port
+
+Test.Summary = '''
+Ensure cache-write consumer does not assert on skip_bytes when a transform is
+present (compress plugin) and origin response is chunked.
+'''
+
+# Skip if compress plugin not present.
+Test.SkipUnless(Condition.PluginExists('compress.so'))
+
+tr = Test.AddTestRun('compress + chunked origin + cache write should not crash')
+# Give ATS and the origin ample time to become ready on slower CI
+tr.TimeOut = 60
+
+# Origin server that responds with chunked-encoding and cacheable headers.
+tr.Setup.Copy('server_chunked.sh')
+server = tr.Processes.Process('chunked_origin')
+server_port = get_port(server, 'http_port')
+server.Command = f"bash server_chunked.sh {server_port} outserver"
+server.ReturnCode = 0
+server.Ready = When.PortOpen(server_port)
+
+# ATS with cache enabled, remap to origin, compress plugin enabled (gzip only).
+ts = tr.MakeATSProcess('ts', enable_cache=True)
+# Explicitly mark ATS ready when its HTTP port is open
+ts.Ready = When.PortOpen(ts.Variables.port)
+
+# Minimal debug to help triage if it fails.
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|http_tunnel|cache|compress',
+    })
+
+# Provide a compress config that only enables gzip to avoid brotli dependency.
+tr.Setup.Copy('compress_gzip_only.config')
+
+ts.Disk.remap_config.AddLine(
+    f"map http://test/ http://127.0.0.1:{server_port}/ @plugin=compress.so @pparam={Test.RunDirectory}/compress_gzip_only.config")
+
+# Simple client request that should trigger compression and exercise the tunnel.
+client = tr.Processes.Default
+client.Command = (
+    f"curl -sS --dump-header - --proxy http://127.0.0.1:{ts.Variables.port} "
+    f"-H 'Accept-Encoding: gzip' http://test/obj && "
+    f"curl -sS --dump-header - --proxy http://127.0.0.1:{ts.Variables.port} "
+    f"-H 'Accept-Encoding: gzip' http://test/obj")
+client.ReturnCode = 0
+
+# Verify ATS served 200 and applied gzip encoding (plugin transform), which implies
+# the tunnel ran without the skip_bytes assertion.
+client.Streams.All += Testers.ContainsExpression('HTTP/1.1 200', 'Received 200 from ATS')
+client.Streams.All += Testers.ContainsExpression('Content-Encoding: gzip', 'Response compressed by plugin')
+
+# Startup ordering.
+client.StartBefore(server)
+client.StartBefore(ts)

--- a/tests/gold_tests/compress_chunked_transform_skip_bytes/compress_gzip_only.config
+++ b/tests/gold_tests/compress_chunked_transform_skip_bytes/compress_gzip_only.config
@@ -1,0 +1,6 @@
+cache false
+remove-accept-encoding true
+compressible-content-type text/*
+supported-algorithms gzip
+
+

--- a/tests/gold_tests/compress_chunked_transform_skip_bytes/server_chunked.py
+++ b/tests/gold_tests/compress_chunked_transform_skip_bytes/server_chunked.py
@@ -1,0 +1,55 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import socket
+import sys
+import time
+
+
+def main() -> int:
+    host = sys.argv[1]
+    port = int(sys.argv[2])
+
+    # A small cacheable, chunked response that is compressible (text/*).
+    headers = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Connection: close\r\n"
+        b"Cache-Control: public, max-age=60\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"Transfer-Encoding: chunked\r\n"
+        b"\r\n")
+
+    # Two chunks + zero-chunk terminator.
+    chunk1 = b"1E\r\nThis is a small compressible body.\r\n\r\n"
+    chunk2 = b"0\r\n\r\n"
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind((host, port))
+        s.listen(1)
+        conn, _ = s.accept()
+        with conn:
+            # Read and ignore request; simple single transaction.
+            _ = conn.recv(4096)
+            conn.sendall(headers)
+            conn.sendall(chunk1)
+            time.sleep(0.01)
+            conn.sendall(chunk2)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gold_tests/compress_chunked_transform_skip_bytes/server_chunked.sh
+++ b/tests/gold_tests/compress_chunked_transform_skip_bytes/server_chunked.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Usage: server_chunked.sh <port> <outfile>
+
+response() {
+  # Wait for end of Request message (blank line) recorded into $outfile.
+  while true; do
+    if [ -f "$outfile" ]; then
+      if tr '\r\n' '=!' < "$outfile" | grep '=!=!' > /dev/null; then
+        break
+      fi
+    fi
+    sleep 0.1
+  done
+
+  # Send a cacheable, chunked response.
+  printf "HTTP/1.1 200 OK\r\n"
+  printf "Connection: close\r\n"
+  printf "Cache-Control: public, max-age=60\r\n"
+  printf "Content-Type: text/plain\r\n"
+  printf "Transfer-encoding: chunked\r\n\r\n"
+
+  # Body: one valid chunk (larger to ensure compression) then terminator.
+  # Use a repeated, compressible string and compute the correct chunk size.
+  body=$(printf 'This is a small compressible body.%.0s' {1..128})
+  size_hex=$(printf "%X" ${#body})
+  printf "%s\r\n%s\r\n0\r\n\r\n" "$size_hex" "$body"
+}
+
+port=$1
+outfile=$2
+
+response | nc -l "$port" > "$outfile"
+


### PR DESCRIPTION
add a new test suite to verify that the cache-write process does not crash when using the compress plugin with chunked origin responses