### PR TITLE
Docs: Correct the mismatch between the documentation and actual behavior

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -780,7 +780,7 @@ proto
 
 pp
    Enables Proxy Protocol on the port.  If Proxy Protocol is enabled on the
-   port, all incoming requests must be prefaced with the PROXY header.  See
+   port, |TS| tries to parse the header first, and it falls back to the regular connection handling based on other keywords. See
    :ref:`Proxy Protocol <proxy-protocol>` for more details on how to configure
    this option properly.
 


### PR DESCRIPTION
PR #9383 added the fallback mechanism for ports that are configured to accept PROXY protocol, and the existence of PROXY header is no longer mandatory.