### PR TITLE
esi: Add URL to many error messages

### DIFF
--- a/plugins/esi/CMakeLists.txt
+++ b/plugins/esi/CMakeLists.txt
@@ -19,13 +19,13 @@ add_subdirectory(common)
 add_subdirectory(fetcher)
 add_subdirectory(lib)
 
-add_atsplugin(esi esi.cc serverIntercept.cc)
+add_atsplugin(esi esi.cc serverIntercept.cc http_utils.cc)
 target_link_libraries(esi PRIVATE esi-common esicore fetcher libswoc::libswoc)
 target_include_directories(esi PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 verify_global_plugin(esi)
 verify_remap_plugin(esi)
 
-add_atsplugin(combo_handler combo_handler.cc)
+add_atsplugin(combo_handler combo_handler.cc http_utils.cc)
 
 target_link_libraries(combo_handler PRIVATE esicore fetcher)
 target_include_directories(combo_handler PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/plugins/esi/http_utils.cc
+++ b/plugins/esi/http_utils.cc
@@ -1,0 +1,62 @@
+/** @file
+
+  Implementation of HTTP utilities for ESI plugins.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "http_utils.h"
+
+#include <ts/ts.h>
+
+std::string
+getRequestUrlString(TSHttpTxn txnp)
+{
+  std::string request_url = UNKNOWN_URL_STRING;
+  TSMBuffer   req_bufp;
+  TSMLoc      req_hdr_loc;
+  TSMLoc      url_loc;
+
+  if (TSHttpTxnClientReqGet(txnp, &req_bufp, &req_hdr_loc) == TS_SUCCESS) {
+    if (TSHttpTxnPristineUrlGet(txnp, &req_bufp, &url_loc) == TS_SUCCESS) {
+      request_url = getUrlString(req_bufp, url_loc);
+      TSHandleMLocRelease(req_bufp, TS_NULL_MLOC, url_loc);
+    }
+    TSHandleMLocRelease(req_bufp, TS_NULL_MLOC, req_hdr_loc);
+  }
+
+  return request_url;
+}
+
+std::string
+getUrlString(TSMBuffer bufp, TSMLoc url_loc)
+{
+  std::string url_string;
+  int         url_len = 0;
+  char       *url_ptr = TSUrlStringGet(bufp, url_loc, &url_len);
+
+  if (url_ptr) {
+    url_string.assign(url_ptr, url_len);
+    TSfree(url_ptr);
+  } else {
+    url_string = UNKNOWN_URL_STRING;
+  }
+
+  return url_string;
+}

--- a/plugins/esi/http_utils.h
+++ b/plugins/esi/http_utils.h
@@ -1,0 +1,49 @@
+/** @file
+
+  HTTP utilities for ESI plugins.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <ts/ts.h>
+
+/// The string to use when the URL cannot be retrieved.
+inline constexpr const char *UNKNOWN_URL_STRING = "(unknown)";
+
+/** Returns the pristine request URL for a transaction.
+ *
+ * @param[in] txnp The transaction to get the URL for.
+ *
+ * @return The URL. Returns UNKNOWN_URL_STRING if the URL cannot be retrieved
+ *   due to API failures or invalid parameters.
+ */
+std::string getRequestUrlString(TSHttpTxn txnp);
+
+/** Returns a URL string from a buffer and URL loc.
+ *
+ * @param[in] bufp The buffer to get the URL for.
+ * @param[in] url_loc The location of the URL within the buffer.
+ *
+ * @return The URL. Returns UNKNOWN_URL_STRING if the URL cannot be retrieved
+ *   due to API failures or invalid parameters.
+ */
+std::string getUrlString(TSMBuffer bufp, TSMLoc url_loc);

--- a/plugins/esi/lib/EsiParser.h
+++ b/plugins/esi/lib/EsiParser.h
@@ -24,13 +24,14 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 #include "DocNode.h"
 
 class EsiParser
 {
 public:
-  EsiParser(unsigned max_doc_size);
+  EsiParser(unsigned max_doc_size, std::string_view request_url = "");
 
   /** clears state */
   void clear();
@@ -91,6 +92,7 @@ private:
   };
 
   const unsigned _max_doc_size;
+  std::string    _request_url;
 
   std::string _data;
   int         _parse_start_pos;

--- a/plugins/esi/lib/EsiProcessor.h
+++ b/plugins/esi/lib/EsiProcessor.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <map>
 #include "StringHash.h"
 #include "DocNode.h"
@@ -45,7 +46,7 @@ public:
   };
 
   EsiProcessor(void *cont_addr, HttpDataFetcher &fetcher, EsiLib::Variables &variables, const EsiLib::HandlerManager &handler_mgr,
-               unsigned max_doc_size);
+               unsigned max_doc_size, std::string_view request_url = "");
 
   /** Initializes the processor with the context of the request to be processed */
   bool start();
@@ -166,6 +167,7 @@ private:
   int          _n_try_blocks_processed;
 
   const EsiLib::HandlerManager &_handler_manager;
+  std::string                   _request_url;
 
   static const char *INCLUDE_DATA_ID_ATTR;
 

--- a/plugins/esi/serverIntercept.cc
+++ b/plugins/esi/serverIntercept.cc
@@ -27,6 +27,7 @@
 #include <string>
 #include <climits>
 #include <strings.h>
+#include "http_utils.h"
 #include <cstdio>
 
 const char *ECHO_HEADER_PREFIX          = "Echo-";
@@ -350,7 +351,9 @@ setupServerIntercept(TSHttpTxn txnp)
 {
   TSCont contp = TSContCreate(serverIntercept, TSMutexCreate());
   if (!contp) {
-    TSError("[server_intercept][%s] Could not create intercept request", __FUNCTION__);
+    // Get URL for error reporting.
+    std::string url_string = getRequestUrlString(txnp);
+    TSError("[server_intercept][%s] Could not create intercept request for URL [%s]", __FUNCTION__, url_string.c_str());
     return false;
   }
   SContData *cont_data = new SContData(contp);

--- a/tests/gold_tests/pluginTest/esi/esi.test.py
+++ b/tests/gold_tests/pluginTest/esi/esi.test.py
@@ -281,7 +281,7 @@ echo date('l jS \of F Y h:i:s A');
             ts=self._ts)
         tr.Processes.Default.ReturnCode = 0
         self._ts.Disk.diags_log.Content = Testers.ContainsExpression(
-            r"ERROR: \[_setup\] Cannot allow attempted doc of size 121; Max allowed size is 100",
+            r"ERROR: \[_setup\] Cannot allow attempted doc of size 121; Max allowed size is 100 for URL \[.*esi\.php.*\]",
             "max doc size test should have doc size error log")
         tr.StillRunningAfter = self._server
         tr.StillRunningAfter = self._ts


### PR DESCRIPTION
It was difficult to track down some issues with ESI because ops didn't easily know which URLs some error messages belonged to. This adds identifying URLs to many of the error messages.