### PR TITLE
Logging: Add chiv field from real-ip plugin

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -480,6 +480,7 @@ Network Addresses, Ports, and Interfaces
 
 .. _chi:
 .. _chih:
+.. _chiv:
 .. _hii:
 .. _hiih:
 .. _chp:
@@ -501,6 +502,8 @@ chi   Client         IP address of the client's host. If :ref:`Proxy Protocol <p
                      is used, this represents the IP address of the peer, rather than
                      the client IP behind the peer.
 chih  Client         IP address of the client's host, in hexadecimal.
+chiv  Client         IP address of the client's host verified by a plugin. If not available,
+                     ``chi`` is used.
 hii   Proxy          IP address for the proxy's incoming interface (to which
                      the client connected).
 hiih  Proxy          IP address for the proxy's incoming interface (to which

--- a/include/proxy/logging/LogAccess.h
+++ b/include/proxy/logging/LogAccess.h
@@ -124,6 +124,7 @@ public:
   //
   int marshal_client_host_ip(char *);                // STR
   int marshal_host_interface_ip(char *);             // STR
+  int marshal_client_host_ip_verified(char *);       // STR
   int marshal_client_host_port(char *);              // INT
   int marshal_client_auth_user_name(char *);         // STR
   int marshal_client_req_timestamp_sec(char *);      // INT

--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -343,6 +343,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("chih", field);
 
+  field = new LogField("client_host_ip_verified", "chiv", LogField::IP, &LogAccess::marshal_client_host_ip_verified,
+                       &LogAccess::unmarshal_ip_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("chiv", field);
+
   // interface ip
 
   field =

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -1451,6 +1451,21 @@ LogAccess::marshal_host_interface_ip(char *buf)
   return marshal_ip(buf, &m_http_sm->t_state.client_info.dst_addr.sa);
 }
 
+int
+LogAccess::marshal_client_host_ip_verified(char *buf)
+{
+  if (m_http_sm) {
+    auto txn = m_http_sm->get_ua_txn();
+    if (txn) {
+      sockaddr const *addr = txn->get_verified_client_addr();
+      if (addr && ats_is_ip(addr)) {
+        return marshal_ip(buf, addr);
+      }
+    }
+  }
+  return marshal_ip(buf, &m_http_sm->t_state.client_info.src_addr.sa);
+}
+
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/
 int


### PR DESCRIPTION
Adds `chiv` logging field that is verified by real-ip plugin. If no IP is available, `chi` value is used

Dependent on #12359 changes to expose verified client IP address
- Update: merged

