### PR TITLE
Add TLS 1.3 half-open support

### DIFF
--- a/include/iocore/net/TLSBasicSupport.h
+++ b/include/iocore/net/TLSBasicSupport.h
@@ -44,6 +44,7 @@ public:
   static void             unbind(SSL *ssl);
 
   TLSHandle   get_tls_handle() const;
+  int         get_tls_version() const;
   const char *get_tls_protocol_name() const;
   const char *get_tls_cipher_suite() const;
   const char *get_tls_curve() const;

--- a/include/proxy/http/Http1ClientSession.h
+++ b/include/proxy/http/Http1ClientSession.h
@@ -64,7 +64,6 @@ public:
   void do_io_close(int lerrno = -1) override;
 
   // Accessor Methods
-  bool         allow_half_open() const;
   void         set_half_close_flag(bool flag) override;
   bool         get_half_close_flag() const override;
   int          get_transact_count() const override;

--- a/include/proxy/http/Http1ClientTransaction.h
+++ b/include/proxy/http/Http1ClientTransaction.h
@@ -37,7 +37,6 @@ public:
   // Methods
   void release() override;
 
-  bool allow_half_open() const override;
   void transaction_done() override;
   void increment_transactions_stat() override;
   void decrement_transactions_stat() override;

--- a/src/iocore/net/TLSBasicSupport.cc
+++ b/src/iocore/net/TLSBasicSupport.cc
@@ -79,6 +79,17 @@ TLSBasicSupport::get_tls_handle() const
   return this->_get_ssl_object();
 }
 
+int
+TLSBasicSupport::get_tls_version() const
+{
+  auto ssl = this->_get_ssl_object();
+  if (ssl) {
+    return SSL_version(ssl);
+  } else {
+    return 0;
+  }
+}
+
 const char *
 TLSBasicSupport::get_tls_protocol_name() const
 {

--- a/src/proxy/ProxyTransaction.cc
+++ b/src/proxy/ProxyTransaction.cc
@@ -272,6 +272,19 @@ ProxyTransaction::set_expect_receive_trailer()
 bool
 ProxyTransaction::allow_half_open() const
 {
+  bool config_allows_it = (_sm) ? _sm->t_state.txn_conf->allow_half_open > 0 : true;
+  if (config_allows_it) {
+    // Check with the session to make sure the underlying transport allows the half open scenario
+    if (auto vc = this->get_netvc(); vc != nullptr) {
+      if (auto tbs = vc->get_service<TLSBasicSupport>(); tbs != nullptr) {
+        if (tbs->get_tls_version() == TLS1_3_VERSION) {
+          return true;
+        }
+      } else {
+        return true;
+      }
+    }
+  }
   return false;
 }
 

--- a/src/proxy/http/Http1ClientSession.cc
+++ b/src/proxy/http/Http1ClientSession.cc
@@ -540,13 +540,6 @@ Http1ClientSession::start()
   this->release(&trans);
 }
 
-bool
-Http1ClientSession::allow_half_open() const
-{
-  // Only allow half open connections if the not over TLS
-  return (_vc && _vc->get_service<TLSBasicSupport>() == nullptr);
-}
-
 void
 Http1ClientSession::set_half_close_flag(bool flag)
 {

--- a/src/proxy/http/Http1ClientTransaction.cc
+++ b/src/proxy/http/Http1ClientTransaction.cc
@@ -45,17 +45,6 @@ Http1ClientTransaction::transaction_done()
   }
 }
 
-bool
-Http1ClientTransaction::allow_half_open() const
-{
-  bool config_allows_it = (_sm) ? _sm->t_state.txn_conf->allow_half_open > 0 : true;
-  if (config_allows_it) {
-    // Check with the session to make sure the underlying transport allows the half open scenario
-    return static_cast<Http1ClientSession *>(_proxy_ssn)->allow_half_open();
-  }
-  return false;
-}
-
 void
 Http1ClientTransaction::increment_transactions_stat()
 {


### PR DESCRIPTION
Part of fix for #12473. Depends on #12502.

Co-authored-by: Masakazu Kitajo [maskit@apache.org](mailto:maskit@apache.org)