### PR TITLE
header_rewrite: explicit check for TS_SUCCESS to avoid erroring out on success

### DIFF
--- a/plugins/header_rewrite/resources.cc
+++ b/plugins/header_rewrite/resources.cc
@@ -70,7 +70,7 @@ Resources::gather(const ResourceIDs ids, TSHttpHookID hook)
     // Read request headers to server
     if (ids & RSRC_SERVER_REQUEST_HEADERS) {
       Dbg(pi_dbg_ctl, "\tAdding TXN server request header buffers");
-      if (!TSHttpTxnServerReqGet(state.txnp, &bufp, &hdr_loc)) {
+      if (TSHttpTxnServerReqGet(state.txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
         Dbg(pi_dbg_ctl, "could not gather bufp/hdr_loc for request");
         return;
       }


### PR DESCRIPTION
Explicitly check for `TS_SUCCESS` in header_rewrite's `Resources::gather` instead of negation to avoid unexpectedly entering  the error branch.

Since `TS_SUCCESS` has integer value 0, using the negation operator here results in entering in the error branch on success from `TSHttpTxnServerReqGet`. Other conditionals in this method already use `!= TS_SUCCESS`.

Fixes #12496 