### PR TITLE
Add a freebsd ifdef check for tcpinfo retrans

### DIFF
--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -277,7 +277,11 @@ class ConnBase
     retrans()
     {
       initialize();
+#if defined(__FreeBSD__)
+      return (_ready ? info.__tcpi_retrans : 0);
+#else
       return (_ready ? info.tcpi_retrans : 0);
+#endif
     }
 
     struct tcp_info info;


### PR DESCRIPTION
Tested building cripts on freebsd and hit this issue with the tcpinfo struct differences. I dont think retrans is implemented on freebsd so this probably wont give valid data, but at least it will build now.