### PR TITLE
API for Strategy rebind during transaction

### DIFF
--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -724,11 +724,11 @@ public:
     //  able to defer some work in building the request
     TransactFunc_t pending_work = nullptr;
 
-    HttpRequestData                           request_data;
-    ParentConfigParams                       *parent_params     = nullptr;
-    std::shared_ptr<NextHopSelectionStrategy> next_hop_strategy = nullptr;
-    ParentResult                              parent_result;
-    CacheControlResult                        cache_control;
+    HttpRequestData           request_data;
+    ParentConfigParams       *parent_params     = nullptr;
+    NextHopSelectionStrategy *next_hop_strategy = nullptr;
+    ParentResult              parent_result;
+    CacheControlResult        cache_control;
 
     StateMachineAction_t next_action                      = StateMachineAction_t::UNDEFINED; // out
     StateMachineAction_t api_next_action                  = StateMachineAction_t::UNDEFINED; // out

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1575,6 +1575,55 @@ void TSHttpTxnErrorBodySet(TSHttpTxn txnp, char *buf, size_t buflength, char *mi
    @param mimetype Optional output pointer to the MIME type of the response.
 */
 char *TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype);
+/**
+    Sets the Transaction's Next Hop Parent Strategy.
+    Calling this after TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK will
+    result in bad behavior.
+
+    You can get this strategy pointer by calling TSHttpTxnParentStrategyGet().
+
+    @param txnp HTTP transaction whose parent strategy to get.
+    @param pointer to the given strategy.
+
+ */
+void TSHttpTxnParentStrategySet(TSHttpTxn txnp, void *const strategy);
+
+/**
+    Retrieves a pointer to the current next hop selection strategy.
+    This value may be a nullptr due to:
+      - parent proxying not enabled
+      - no parent selection strategy (using parent.config)
+
+    @param txnp HTTP transaction whose parent proxy to get.
+    @param pointer to the current selection strategy.
+
+ */
+TSReturnCode TSHttpTxnParentStrategyGet(TSHttpTxn txnp, void **strategy);
+
+/**
+    Retrieves a pointer to the named strategy in the loaded strategy table.
+    This will return nullptr if the named strategy is not found.
+
+    Typically this should be called by TSRemapInit/TSPluginInit
+    to avoid constant table lookups during transaction processing.
+
+    @param txnp HTTP transaction whose parent proxy to get.
+    @param pointer to the current selection strategy.
+
+ */
+TSReturnCode TSParentNamedStrategyGet(char const *name, void **strategy);
+
+/**
+    Sets the parent proxy name and port. The string hostname is copied
+    into the TSHttpTxn; you can modify or delete the string after
+    calling TSHttpTxnParentProxySet().
+
+    @param txnp HTTP transaction whose parent proxy to set.
+    @param hostname parent proxy host name string.
+    @param port parent proxy port to set.
+
+ */
+void TSHttpTxnParentProxySet(TSHttpTxn txnp, const char *hostname, int port);
 
 /**
     Retrieves the parent proxy hostname and port, if parent

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1586,7 +1586,7 @@ char *TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype);
     @param pointer to the given strategy.
 
  */
-void TSHttpTxnParentStrategySet(TSHttpTxn txnp, void *const strategy);
+void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void *const strategy);
 
 /**
     Retrieves a pointer to the current next hop selection strategy.
@@ -1598,7 +1598,7 @@ void TSHttpTxnParentStrategySet(TSHttpTxn txnp, void *const strategy);
     @param pointer to the current selection strategy.
 
  */
-TSReturnCode TSHttpTxnParentStrategyGet(TSHttpTxn txnp, void **strategy);
+TSReturnCode TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp, void **strategy);
 
 /**
     Retrieves a pointer to the named strategy in the loaded strategy table.
@@ -1611,7 +1611,20 @@ TSReturnCode TSHttpTxnParentStrategyGet(TSHttpTxn txnp, void **strategy);
     @param pointer to the current selection strategy.
 
  */
-TSReturnCode TSParentNamedStrategyGet(char const *name, void **strategy);
+TSReturnCode TSHttpTxnNamedNextHopStrategyGet(char const *name, void **strategy);
+
+/**
+    Retrieves a pointer to the named strategy in the loaded strategy table.
+    This will return nullptr if the named strategy is not found.
+
+    Typically this should be called by TSRemapInit/TSPluginInit
+    to avoid constant table lookups during transaction processing.
+
+    @param txnp HTTP transaction whose parent proxy to get.
+    @param pointer to the current selection strategy.
+
+ */
+TSReturnCode TSRemapNamedNextHopStrategyGet(char const *name, void **strategy);
 
 /**
     Sets the parent proxy name and port. The string hostname is copied

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -4973,6 +4973,32 @@ TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void *strategy)
 }
 
 TSReturnCode
+TSHttpTxnNamedNextHopStrategyGet(TSHttpTxn txnp, char const *const name, void **strategy)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
+
+  auto sm = reinterpret_cast<HttpSM const *>(txnp);
+
+  sdk_assert(sdk_sanity_check_null_ptr((void *)sm->m_remap) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_null_ptr((void *)sm->m_remap->strategyFactory) == TS_SUCCESS);
+
+  // HttpSM has a reference count handle to UrlRewrite which has a
+  // pointer to NextHopStrategyFactory
+  std::shared_ptr<NextHopSelectionStrategy> const strat = sm->m_remap->strategyFactory->strategyInstance(name);
+
+  if (!strat) {
+    *strategy = nullptr;
+    return TS_ERROR;
+  } else {
+    *strategy = static_cast<void *>(strat.get());
+  }
+
+  return TS_SUCCESS;
+}
+
+/*
+TSReturnCode
 TSParentNamedStrategyGet(const char *name, void **strategy)
 {
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
@@ -4983,6 +5009,7 @@ TSParentNamedStrategyGet(const char *name, void **strategy)
 
   return TS_SUCCESS;
 }
+*/
 
 TSReturnCode
 TSHttpTxnParentProxyGet(TSHttpTxn txnp, const char **hostname, int *port)

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -4950,6 +4950,41 @@ TSHttpTxnServerRequestBodySet(TSHttpTxn txnp, char *buf, int64_t buflength)
 }
 
 TSReturnCode
+TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp, void **strategy)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  auto sm = reinterpret_cast<HttpSM const *>(txnp);
+
+  *strategy = static_cast<void *>(sm->t_state.next_hop_strategy);
+
+  return TS_SUCCESS;
+}
+
+void
+TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void *strategy)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_null_ptr(strategy) == TS_SUCCESS);
+
+  auto sm = reinterpret_cast<HttpSM *>(txnp);
+
+  sm->t_state.next_hop_strategy = reinterpret_cast<NextHopSelectionStrategy *>(strategy);
+}
+
+TSReturnCode
+TSParentNamedStrategyGet(const char *name, void **strategy)
+{
+  sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
+  sdk_assert(sdk_sanity_check_null_ptr(strategy) == TS_SUCCESS);
+
+  // BNO this must be implemented
+  *strategy = nullptr;
+
+  return TS_SUCCESS;
+}
+
+TSReturnCode
 TSHttpTxnParentProxyGet(TSHttpTxn txnp, const char **hostname, int *port)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -314,8 +314,9 @@ HttpSM::init(bool from_early_data)
   // Added to skip dns if the document is in cache. DNS will be forced if there is a ip based ACL in
   // cache control or parent.config or if the doc_in_cache_skip_dns is disabled or if http caching is disabled
   // TODO: This probably doesn't honor this as a per-transaction overridable config.
-  t_state.force_dns = (ip_rule_in_CacheControlTable() || t_state.parent_params->parent_table->ipMatch ||
-                       !(t_state.txn_conf->doc_in_cache_skip_dns) || !(t_state.txn_conf->cache_http));
+  t_state.force_dns =
+    (ip_rule_in_CacheControlTable() || (nullptr != t_state.parent_params && t_state.parent_params->parent_table->ipMatch) ||
+     !(t_state.txn_conf->doc_in_cache_skip_dns) || !(t_state.txn_conf->cache_http));
 
   SET_HANDLER(&HttpSM::main_handler);
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -6513,8 +6513,8 @@ HttpTransact::process_quick_http_filter(State *s, int method)
   }
 
   // if the "ip_allow" named filter is deactivated in the remap.config, then don't modify anything
-  url_mapping *mp = s->url_map.getMapping();
-  if (mp && !mp->ip_allow_check_enabled_p) {
+  url_mapping const *const mp = s->url_map.getMapping();
+  if (nullptr != mp && !mp->ip_allow_check_enabled_p) {
     return;
   }
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -128,13 +128,13 @@ extern HttpBodyFactory *body_factory;
 inline static bool
 bypass_ok(HttpTransact::State *s)
 {
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *const mp = s->url_map.getMapping();
   if (s->response_action.handled) {
     return s->response_action.action.goDirect;
-  } else if (mp && mp->strategy) {
+  } else if (nullptr != s->next_hop_strategy) {
     // remap strategies do not support the TSHttpTxnParentProxySet API.
-    return mp->strategy->go_direct;
-  } else if (s->parent_params) {
+    return s->next_hop_strategy->go_direct;
+  } else if (nullptr != s->parent_params) {
     return s->parent_result.bypass_ok();
   }
   return false;
@@ -145,13 +145,13 @@ bypass_ok(HttpTransact::State *s)
 inline static bool
 is_api_result(HttpTransact::State *s)
 {
-  bool         r  = false;
-  url_mapping *mp = s->url_map.getMapping();
+  bool r = false;
+  // url_mapping *mp = s->url_map.getMapping();
 
-  if (mp && mp->strategy) {
+  if (nullptr != s->next_hop_strategy) {
     // remap strategies do not support the TSHttpTxnParentProxySet API.
     r = false;
-  } else if (s->parent_params) {
+  } else if (nullptr != s->parent_params) {
     r = s->parent_result.is_api_result();
   }
   return r;
@@ -184,12 +184,12 @@ numParents(HttpTransact::State *s)
 inline static bool
 parent_is_proxy(HttpTransact::State *s)
 {
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *mp = s->url_map.getMapping();
   if (s->response_action.handled) {
     return s->response_action.action.parentIsProxy;
-  } else if (mp && mp->strategy) {
-    return mp->strategy->parent_is_proxy;
-  } else if (s->parent_params) {
+  } else if (nullptr != s->next_hop_strategy) {
+    return s->next_hop_strategy->parent_is_proxy;
+  } else if (nullptr != s->parent_params) {
     return s->parent_result.parent_is_proxy();
   }
   return false;
@@ -211,7 +211,7 @@ retry_type(HttpTransact::State *s)
 inline static void
 findParent(HttpTransact::State *s)
 {
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *mp = s->url_map.getMapping();
   Metrics::Counter::increment(http_rsb.parent_count);
   if (s->response_action.handled) {
     s->parent_result.hostname = s->response_action.action.hostname;
@@ -224,9 +224,9 @@ findParent(HttpTransact::State *s)
     } else {
       s->parent_result.result = ParentResultType::FAIL;
     }
-  } else if (mp && mp->strategy) {
-    mp->strategy->findNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine));
-  } else if (s->parent_params) {
+  } else if (nullptr != s->next_hop_strategy) {
+    s->next_hop_strategy->findNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine));
+  } else if (nullptr != s->parent_params) {
     s->parent_params->findParent(&s->request_data, &s->parent_result, s->txn_conf->parent_fail_threshold,
                                  s->txn_conf->parent_retry_time);
   }
@@ -237,7 +237,7 @@ findParent(HttpTransact::State *s)
 inline static void
 markParentDown(HttpTransact::State *s)
 {
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *mp = s->url_map.getMapping();
 
   TxnDbg(dbg_ctl_http_trans, "enable_parent_timeout_markdowns: %d, disable_parent_markdowns: %d",
          s->txn_conf->enable_parent_timeout_markdowns, s->txn_conf->disable_parent_markdowns);
@@ -258,10 +258,10 @@ markParentDown(HttpTransact::State *s)
 
   if (s->response_action.handled) {
     // Do nothing. If a plugin handled the response, let it handle markdown.
-  } else if (mp && mp->strategy) {
-    mp->strategy->markNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine), s->parent_result.hostname, s->parent_result.port,
-                              NHCmd::MARK_DOWN);
-  } else if (s->parent_params) {
+  } else if (nullptr != s->next_hop_strategy) {
+    s->next_hop_strategy->markNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine), s->parent_result.hostname,
+                                      s->parent_result.port, NHCmd::MARK_DOWN);
+  } else if (nullptr != s->parent_params) {
     s->parent_params->markParentDown(&s->parent_result, s->txn_conf->parent_fail_threshold, s->txn_conf->parent_retry_time);
   }
 }
@@ -271,13 +271,13 @@ markParentDown(HttpTransact::State *s)
 inline static void
 markParentUp(HttpTransact::State *s)
 {
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *mp = s->url_map.getMapping();
   if (s->response_action.handled) {
     // Do nothing. If a plugin handled the response, let it handle markdown
-  } else if (mp && mp->strategy) {
-    mp->strategy->markNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine), s->parent_result.hostname, s->parent_result.port,
-                              NHCmd::MARK_UP);
-  } else if (s->parent_params) {
+  } else if (nullptr != s->next_hop_strategy) {
+    s->next_hop_strategy->markNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine), s->parent_result.hostname,
+                                      s->parent_result.port, NHCmd::MARK_UP);
+  } else if (nullptr != s->parent_params) {
     s->parent_params->markParentUp(&s->parent_result);
   }
 }
@@ -287,12 +287,12 @@ markParentUp(HttpTransact::State *s)
 inline static bool
 parentExists(HttpTransact::State *s)
 {
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *mp = s->url_map.getMapping();
   if (s->response_action.handled) {
     return s->response_action.action.nextHopExists;
-  } else if (mp && mp->strategy) {
-    return mp->strategy->nextHopExists(reinterpret_cast<TSHttpTxn>(s->state_machine));
-  } else if (s->parent_params) {
+  } else if (nullptr != s->next_hop_strategy) {
+    return s->next_hop_strategy->nextHopExists(reinterpret_cast<TSHttpTxn>(s->state_machine));
+  } else if (nullptr != s->parent_params) {
     return s->parent_params->parentExists(&s->request_data);
   } else {
     return false;
@@ -306,7 +306,7 @@ nextParent(HttpTransact::State *s)
 {
   TxnDbg(dbg_ctl_parent_down, "connection to parent %s failed, conn_state: %s, request to origin: %s", s->parent_result.hostname,
          HttpDebugNames::get_server_state_name(s->current.state), s->request_data.get_host());
-  url_mapping *mp = s->url_map.getMapping();
+  // url_mapping *mp = s->url_map.getMapping();
   Metrics::Counter::increment(http_rsb.parent_count);
   if (s->response_action.handled) {
     s->parent_result.hostname = s->response_action.action.hostname;
@@ -319,10 +319,10 @@ nextParent(HttpTransact::State *s)
     } else {
       s->parent_result.result = ParentResultType::FAIL;
     }
-  } else if (mp && mp->strategy) {
+  } else if (nullptr != s->next_hop_strategy) {
     // NextHop only has a findNextHop() function.
-    mp->strategy->findNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine));
-  } else if (s->parent_params) {
+    s->next_hop_strategy->findNextHop(reinterpret_cast<TSHttpTxn>(s->state_machine));
+  } else if (nullptr != s->parent_params) {
     s->parent_params->nextParent(&s->request_data, &s->parent_result, s->txn_conf->parent_fail_threshold,
                                  s->txn_conf->parent_retry_time);
   }
@@ -404,12 +404,12 @@ response_is_retryable(HttpTransact::State *s, HTTPStatus response_code)
   if (s->response_action.handled) {
     return s->response_action.action.responseIsRetryable ? ParentRetry_t::SIMPLE : ParentRetry_t::NONE;
   }
-  const url_mapping *mp = s->url_map.getMapping();
-  if (mp && mp->strategy) {
-    return mp->strategy->responseIsRetryable(s->state_machine->sm_id, s->current, response_code);
+  // const url_mapping *mp = s->url_map.getMapping();
+  if (nullptr != s->next_hop_strategy) {
+    return s->next_hop_strategy->responseIsRetryable(s->state_machine->sm_id, s->current, response_code);
   }
 
-  if (s->parent_params && !s->parent_result.response_is_retryable(s->parent_result.retry_type(), response_code)) {
+  if (nullptr != s->parent_params && !s->parent_result.response_is_retryable(s->parent_result.retry_type(), response_code)) {
     return ParentRetry_t::NONE;
   }
   const ParentRetry_t s_retry_type = retry_type(s);

--- a/src/proxy/http/remap/RemapProcessor.cc
+++ b/src/proxy/http/remap/RemapProcessor.cc
@@ -151,7 +151,7 @@ RemapProcessor::finish_remap(HttpTransact::State *s, UrlRewrite *table)
 
   // if there is a configured next hop strategy, make it available in the state.
   if (map->strategy) {
-    s->next_hop_strategy = map->strategy;
+    s->next_hop_strategy = map->strategy.get();
   }
   // Do fast ACL filtering (it is safe to check map here)
   table->PerformACLFiltering(s, map);


### PR DESCRIPTION
This adds to the ts api to allows the selected parent strategy to be changed during a transaction.

APIs added:

- void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void *const strategy);
- TSReturnCode TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp, void **strategy);
- TSReturnCode TSHttpTxnNamedNextHopStrategyGet(char const *name, void **strategy);