### PR TITLE
test: make test_layout independent of TS_ROOT part 2

### DIFF
--- a/src/tscore/unit_tests/test_layout.cc
+++ b/src/tscore/unit_tests/test_layout.cc
@@ -60,6 +60,7 @@ TEST_CASE("environment variable constructor test", "[env_constructor]")
 
 TEST_CASE("layout create test", "[create]")
 {
+  unsetenv("TS_ROOT");
   Layout::create();
   REQUIRE(Layout::get()->prefix == TS_BUILD_PREFIX);
   REQUIRE(Layout::get()->sysconfdir == Layout::get()->relative(TS_BUILD_SYSCONFDIR));
@@ -68,6 +69,7 @@ TEST_CASE("layout create test", "[create]")
 // tests below based on the created layout
 TEST_CASE("relative test", "[relative]")
 {
+  unsetenv("TS_ROOT");
   Layout::create();
   // relative (1 argument)
   std::string_view sv("file");
@@ -77,6 +79,7 @@ TEST_CASE("relative test", "[relative]")
 
 TEST_CASE("relative to test", "[relative_to]")
 {
+  unsetenv("TS_ROOT");
   Layout::create();
   // relative to (2 parameters)
   std::string str1 = append_slash(TS_BUILD_PREFIX) + "file";
@@ -92,6 +95,7 @@ TEST_CASE("relative to test", "[relative_to]")
 
 TEST_CASE("update_sysconfdir test", "[update_sysconfdir]")
 {
+  unsetenv("TS_ROOT");
   Layout::create();
   Layout::get()->update_sysconfdir("/abc");
   REQUIRE(Layout::get()->sysconfdir == "/abc");


### PR DESCRIPTION
Apply the fix from #12481 to the other tests as well.