### PR TITLE
Remove ready=When.PortOpen that are used for httpbin

### DIFF
--- a/tests/gold_tests/cache/background_fill.test.py
+++ b/tests/gold_tests/cache/background_fill.test.py
@@ -88,7 +88,7 @@ class BackgroundFillTest:
             tr.StillRunningBefore = self.ts['for_httpbin']
             tr.StillRunningBefore = self.ts['for_pv']
         else:
-            tr.Processes.Default.StartBefore(self.httpbin, ready=When.PortOpen(self.httpbin.Variables.Port))
+            tr.Processes.Default.StartBefore(self.httpbin)
             tr.Processes.Default.StartBefore(self.pv_server)
             tr.Processes.Default.StartBefore(self.ts['for_httpbin'])
             tr.Processes.Default.StartBefore(self.ts['for_pv'])

--- a/tests/gold_tests/connect/connect.test.py
+++ b/tests/gold_tests/connect/connect.test.py
@@ -73,7 +73,7 @@ logging:
             tr.StillRunningBefore = self.httpbin
             tr.StillRunningBefore = self.ts
         else:
-            tr.Processes.Default.StartBefore(self.httpbin, ready=When.PortOpen(self.httpbin.Variables.Port))
+            tr.Processes.Default.StartBefore(self.httpbin)
             tr.Processes.Default.StartBefore(self.ts)
             self.state = self.State.RUNNING
 

--- a/tests/gold_tests/h2/h2spec.test.py
+++ b/tests/gold_tests/h2/h2spec.test.py
@@ -59,7 +59,7 @@ h2spec_targets = "generic http2/3 http2/4 http2/5 http2/6 http2/7 http2/8 hpack"
 test_run = Test.AddTestRun()
 test_run.Processes.Default.Command = 'h2spec {0} -t -k --timeout 10 -p {1}'.format(h2spec_targets, ts.Variables.ssl_port)
 test_run.Processes.Default.ReturnCode = 0
-test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+test_run.Processes.Default.StartBefore(httpbin)
 test_run.Processes.Default.StartBefore(Test.Processes.ts)
 test_run.Processes.Default.Streams.stdout = "gold/h2spec_stdout.gold"
 test_run.StillRunningAfter = httpbin

--- a/tests/gold_tests/h2/httpbin.test.py
+++ b/tests/gold_tests/h2/httpbin.test.py
@@ -83,7 +83,7 @@ json_printer = f'''
 test_run = Test.AddTestRun()
 test_run.MakeCurlCommand("-vs -k --http2 https://127.0.0.1:{0}/get | {1}".format(ts.Variables.ssl_port, json_printer), ts=ts)
 test_run.Processes.Default.ReturnCode = 0
-test_run.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+test_run.Processes.Default.StartBefore(httpbin)
 test_run.Processes.Default.StartBefore(Test.Processes.ts)
 test_run.Processes.Default.Streams.stdout = "gold/httpbin_0_stdout.gold"
 # Different versions of curl will have different cases for HTTP/2 field names.

--- a/tests/gold_tests/h2/nghttp.test.py
+++ b/tests/gold_tests/h2/nghttp.test.py
@@ -71,7 +71,7 @@ tr = Test.AddTestRun()
 tr.TimeOut = 10
 tr.Processes.Default.Command = f"nghttp -vn --no-dep 'https://127.0.0.1:{ts.Variables.ssl_port}/httpbin/post' --trailer 'foo: bar' -d 'post_body'"
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+tr.Processes.Default.StartBefore(httpbin)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stdout = "gold/nghttp_0_stdout.gold"
 tr.StillRunningAfter = httpbin

--- a/tests/gold_tests/logging/new_log_flds.test.py
+++ b/tests/gold_tests/logging/new_log_flds.test.py
@@ -69,7 +69,7 @@ logging:
 tr = Test.AddTestRun()
 # Delay on readiness of ssl port
 tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+tr.Processes.Default.StartBefore(httpbin)
 #
 tr.MakeCurlCommand('"http://127.0.0.1:{0}" --verbose'.format(ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSHttpSsnInfo.test.py
@@ -77,7 +77,7 @@ tr.TimeOut = 10
 # size which exponentially reduces the gold file processing time.
 tr.Processes.Default.Command = f"nghttp -vn --continuation 'https://localhost:{ts.Variables.ssl_port}/httpbin/post' -d 'post_body' | grep -v 'continuation-test'"
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+tr.Processes.Default.StartBefore(httpbin)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stdout = "test_TSHttpSsnInfo_nghttp0.gold"
 tr.StillRunningAfter = httpbin

--- a/tests/gold_tests/pluginTest/tsapi/test_TSHttpTxnVerifiedAddr.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSHttpTxnVerifiedAddr.test.py
@@ -62,7 +62,7 @@ ts.Disk.records_config.update(
 tr = Test.AddTestRun()
 tr.MakeCurlCommand(f'-v http://127.0.0.1:{ts.Variables.port}/httpbin/get', ts=ts)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+tr.Processes.Default.StartBefore(httpbin)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stderr.Content = Testers.ContainsExpression(
     "ip: 1.1.1.1", "Verifiy header_rewrite picked the verified address")

--- a/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py
@@ -75,7 +75,7 @@ tr = Test.AddTestRun()
 tr.TimeOut = 10
 tr.Processes.Default.Command = f"curl --haproxy-protocol --haproxy-clientip 1.2.3.4 'http://127.0.0.1:{ts.Variables.proxy_protocol_port}/httpbin/get'"
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.StartBefore(httpbin, ready=When.PortOpen(httpbin.Variables.Port))
+tr.Processes.Default.StartBefore(httpbin)
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 tr.Processes.Default.Streams.stdout = "test_TSVConnPPInfo_curl0.gold"
 tr.StillRunningAfter = httpbin


### PR DESCRIPTION
The optional `ready` parameter is unnecessary for httpbin because it's set in `MakeHttpBinServer`.