### PR TITLE
10.1.x: Fix pqus marshaling (#12490)

### DIFF
--- a/include/proxy/logging/LogAccess.h
+++ b/include/proxy/logging/LogAccess.h
@@ -330,12 +330,24 @@ public:
 
   static int unmarshal_record(char **buf, char *dest, int len);
 
-  //
-  // our own strlen function that pads strings to even int64_t boundaries
-  // so that there are no alignment problems with the int values.
-  //
-  static int round_strlen(int len);
-  static int strlen(const char *str);
+  /** Find the padded length of a given value for alignment purposes.
+   * @param[in] len The length from which to calculate the padded length.
+   * @return The padded length on an even int64_t boundary.
+   */
+  static int padded_length(int len);
+
+  /** strlen wrapped in @a padded_length for calculaing padded string lengths.
+   *
+   * This is our own version of strlen which takes into account nullptr input
+   * for DEFAULT_STR and adds space for the null terminator. After accounting
+   * for these, it passes the result to @a padded_length to ensure space for
+   * alignment.  This function is useful, for example, when calculating the
+   * length for @a marshal_str.
+   *
+   * @param[in] str The string from which to calculate the padded length.
+   * @return The padded length for the string on an even int64_t boundary.
+   */
+  static int padded_strlen(const char *str);
 
 public:
   static void marshal_int(char *dest, int64_t source);
@@ -385,25 +397,25 @@ private:
 };
 
 inline int
-LogAccess::round_strlen(int len)
+LogAccess::padded_length(int len)
 {
   return INK_ALIGN_DEFAULT(len);
 }
 
 /*-------------------------------------------------------------------------
-  LogAccess::strlen
+  LogAccess::padded_strlen
 
   Take trailing null and alignment padding into account.  This makes sure
   that strings in the LogBuffer are laid out properly.
   -------------------------------------------------------------------------*/
 
 inline int
-LogAccess::strlen(const char *str)
+LogAccess::padded_strlen(const char *str)
 {
   if (str == nullptr || str[0] == 0) {
-    return round_strlen(sizeof(DEFAULT_STR));
+    return padded_length(sizeof(DEFAULT_STR));
   } else {
-    return (int)(round_strlen(((int)::strlen(str) + 1))); // actual bytes for string
+    return (int)(padded_length(((int)::strlen(str) + 1))); // actual bytes for string
   }
 }
 

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -156,7 +156,7 @@ LogAccess::marshal_proxy_host_ip(char *buf)
 int
 LogAccess::marshal_process_uuid(char *buf)
 {
-  int len = round_strlen(TS_UUID_STRING_LEN + 1);
+  int len = padded_length(TS_UUID_STRING_LEN + 1);
 
   if (buf) {
     const char *str = const_cast<char *>(Machine::instance()->uuid.getString());
@@ -186,7 +186,7 @@ LogAccess::marshal_config_str_var(char *config_var, char *buf)
 {
   char *str = nullptr;
   str       = REC_ConfigReadString(config_var);
-  int len   = LogAccess::strlen(str);
+  int len   = LogAccess::padded_strlen(str);
   if (buf) {
     marshal_str(buf, str, len);
   }
@@ -742,7 +742,7 @@ unmarshal_str_json(char **buf, char *dest, int len, LogSlice *slice)
   int   val_len     = static_cast<int>(::strlen(val_buf));
   int   escaped_len = escape_json(nullptr, val_buf, val_len);
 
-  *buf += LogAccess::strlen(val_buf); // this is how it was stored
+  *buf += LogAccess::padded_strlen(val_buf); // this is how it was stored
 
   if (slice && slice->m_enable) {
     int offset, n;
@@ -794,7 +794,7 @@ LogAccess::unmarshal_str(char **buf, char *dest, int len, LogSlice *slice, LogEs
   char *val_buf = *buf;
   int   val_len = static_cast<int>(::strlen(val_buf));
 
-  *buf += LogAccess::strlen(val_buf); // this is how it was stored
+  *buf += LogAccess::padded_strlen(val_buf); // this is how it was stored
 
   if (slice && slice->m_enable) {
     int offset, n;
@@ -1403,7 +1403,7 @@ LogAccess::marshal_plugin_identity_tag(char *buf)
   if (!tag) {
     tag = "*";
   } else {
-    len = LogAccess::strlen(tag);
+    len = LogAccess::padded_strlen(tag);
   }
 
   if (buf) {
@@ -1437,7 +1437,7 @@ LogAccess::marshal_cache_lookup_url_canon(char *buf)
     // If the lookup URL isn't populated, we'll fall back to the request URL.
     len = marshal_client_req_url_canon(buf);
   } else {
-    len = round_strlen(m_cache_lookup_url_canon_len + 1); // +1 for eos
+    len = padded_length(m_cache_lookup_url_canon_len + 1); // +1 for eos
     if (buf) {
       marshal_mem(buf, m_cache_lookup_url_canon_str, m_cache_lookup_url_canon_len, len);
     }
@@ -1471,7 +1471,7 @@ LogAccess::marshal_client_sni_server_name(char *buf)
       }
     }
   }
-  int len = round_strlen(server_name.length() + 1);
+  int len = padded_length(server_name.length() + 1);
   if (buf) {
     marshal_str(buf, server_name.data(), len);
   }
@@ -1523,7 +1523,7 @@ int
 LogAccess::marshal_version_build_number(char *buf)
 {
   auto &version = AppVersionInfo::get_version();
-  int   len     = LogAccess::strlen(version.build_number());
+  int   len     = LogAccess::padded_strlen(version.build_number());
   if (buf) {
     marshal_str(buf, version.build_number(), len);
   }
@@ -1537,7 +1537,7 @@ int
 LogAccess::marshal_version_string(char *buf)
 {
   auto &version = AppVersionInfo::get_version();
-  int   len     = LogAccess::strlen(version.version());
+  int   len     = LogAccess::padded_strlen(version.version());
   if (buf) {
     marshal_str(buf, version.version(), len);
   }
@@ -1567,7 +1567,7 @@ LogAccess::marshal_proxy_protocol_version(char *buf)
       version_str = "-";
       break;
     }
-    len = LogAccess::strlen(version_str);
+    len = LogAccess::padded_strlen(version_str);
   }
 
   if (buf) {
@@ -1790,7 +1790,7 @@ LogAccess::marshal_client_req_http_method(char *buf)
     // buffer if str is nil, and we need room for this.
     //
     if (alen) {
-      plen = round_strlen(alen + 1); // +1 for trailing 0
+      plen = padded_length(alen + 1); // +1 for trailing 0
     }
   }
 
@@ -1806,7 +1806,7 @@ LogAccess::marshal_client_req_http_method(char *buf)
 int
 LogAccess::marshal_client_req_url(char *buf)
 {
-  int len = round_strlen(m_client_req_url_len + 1); // +1 for trailing 0
+  int len = padded_length(m_client_req_url_len + 1); // +1 for trailing 0
 
   if (buf) {
     marshal_mem(buf, m_client_req_url_str, m_client_req_url_len, len);
@@ -1820,7 +1820,7 @@ LogAccess::marshal_client_req_url(char *buf)
 int
 LogAccess::marshal_client_req_url_canon(char *buf)
 {
-  int len = round_strlen(m_client_req_url_canon_len + 1);
+  int len = padded_length(m_client_req_url_canon_len + 1);
 
   if (buf) {
     marshal_mem(buf, m_client_req_url_canon_str, m_client_req_url_canon_len, len);
@@ -1843,7 +1843,7 @@ LogAccess::marshal_client_req_unmapped_url_canon(char *buf)
     // log the requests, even when there is no remap rule for it.
     len = marshal_client_req_url_canon(buf);
   } else {
-    len = round_strlen(m_client_req_unmapped_url_canon_len + 1); // +1 for eos
+    len = padded_length(m_client_req_unmapped_url_canon_len + 1); // +1 for eos
     if (buf) {
       marshal_mem(buf, m_client_req_unmapped_url_canon_str, m_client_req_unmapped_url_canon_len, len);
     }
@@ -1866,7 +1866,7 @@ LogAccess::marshal_client_req_unmapped_url_path(char *buf)
   if (m_client_req_unmapped_url_path_str == INVALID_STR) {
     len = marshal_client_req_url_path(buf);
   } else {
-    len = round_strlen(m_client_req_unmapped_url_path_len + 1); // +1 for eos
+    len = padded_length(m_client_req_unmapped_url_path_len + 1); // +1 for eos
     if (buf) {
       marshal_mem(buf, m_client_req_unmapped_url_path_str, m_client_req_unmapped_url_path_len, len);
     }
@@ -1883,7 +1883,7 @@ LogAccess::marshal_client_req_unmapped_url_host(char *buf)
   validate_unmapped_url();
   validate_unmapped_url_path();
 
-  int len = round_strlen(m_client_req_unmapped_url_host_len + 1); // +1 for eos
+  int len = padded_length(m_client_req_unmapped_url_host_len + 1); // +1 for eos
   if (buf) {
     marshal_mem(buf, m_client_req_unmapped_url_host_str, m_client_req_unmapped_url_host_len, len);
   }
@@ -1894,7 +1894,7 @@ LogAccess::marshal_client_req_unmapped_url_host(char *buf)
 int
 LogAccess::marshal_client_req_url_path(char *buf)
 {
-  int len = round_strlen(m_client_req_url_path_len + 1);
+  int len = padded_length(m_client_req_url_path_len + 1);
   if (buf) {
     marshal_mem(buf, m_client_req_url_path_str, m_client_req_url_path_len, len);
   }
@@ -1915,17 +1915,9 @@ LogAccess::marshal_client_req_url_scheme(char *buf)
     alen = hdrtoken_index_to_length(scheme);
   } else {
     str  = "UNKNOWN";
-    alen = strlen(str);
+    alen = ::strlen(str);
   }
-
-  // calculate the padded length only if the actual length
-  // is not zero. We don't want the padded length to be zero
-  // because marshal_mem should write the DEFAULT_STR to the
-  // buffer if str is nil, and we need room for this.
-  //
-  if (alen) {
-    plen = round_strlen(alen + 1); // +1 for trailing 0
-  }
+  plen = padded_length(alen + 1); // +1 for trailing 0
 
   if (buf) {
     marshal_mem(buf, str, alen, plen);
@@ -1962,7 +1954,7 @@ int
 LogAccess::marshal_client_req_protocol_version(char *buf)
 {
   const char *protocol_str = m_http_sm->get_user_agent().get_client_protocol();
-  int         len          = LogAccess::strlen(protocol_str);
+  int         len          = LogAccess::padded_strlen(protocol_str);
 
   // Set major & minor versions when protocol_str is not "http/2".
   if (::strlen(protocol_str) == 4 && strncmp("http", protocol_str, 4) == 0) {
@@ -1977,7 +1969,7 @@ LogAccess::marshal_client_req_protocol_version(char *buf)
       protocol_str = "*";
     }
 
-    len = LogAccess::strlen(protocol_str);
+    len = LogAccess::padded_strlen(protocol_str);
   }
 
   if (buf) {
@@ -1994,7 +1986,7 @@ int
 LogAccess::marshal_server_req_protocol_version(char *buf)
 {
   const char *protocol_str = m_http_sm->server_protocol;
-  int         len          = LogAccess::strlen(protocol_str);
+  int         len          = LogAccess::padded_strlen(protocol_str);
 
   // Set major & minor versions when protocol_str is not "http/2".
   if (::strlen(protocol_str) == 4 && strncmp("http", protocol_str, 4) == 0) {
@@ -2009,7 +2001,7 @@ LogAccess::marshal_server_req_protocol_version(char *buf)
       protocol_str = "*";
     }
 
-    len = LogAccess::strlen(protocol_str);
+    len = LogAccess::padded_strlen(protocol_str);
   }
 
   if (buf) {
@@ -2164,7 +2156,7 @@ LogAccess::marshal_client_req_uuid(char *buf)
   int         len  = snprintf(str, sizeof(str), "%s-%" PRId64 "", uuid, m_http_sm->sm_id);
 
   ink_assert(len <= TS_CRUUID_STRING_LEN);
-  len = round_strlen(len + 1);
+  len = padded_length(len + 1);
 
   if (buf) {
     marshal_str(buf, str, len); // This will pad the remaining bytes properly ...
@@ -2184,7 +2176,7 @@ LogAccess::marshal_client_rx_error_code(char *buf)
 {
   char error_code[MAX_PROXY_ERROR_CODE_SIZE] = {0};
   m_http_sm->t_state.client_info.rx_error_code.str(error_code, sizeof(error_code));
-  int round_len = LogAccess::strlen(error_code);
+  int round_len = LogAccess::padded_strlen(error_code);
 
   if (buf) {
     marshal_str(buf, error_code, round_len);
@@ -2198,7 +2190,7 @@ LogAccess::marshal_client_tx_error_code(char *buf)
 {
   char error_code[MAX_PROXY_ERROR_CODE_SIZE] = {0};
   m_http_sm->t_state.client_info.tx_error_code.str(error_code, sizeof(error_code));
-  int round_len = LogAccess::strlen(error_code);
+  int round_len = LogAccess::padded_strlen(error_code);
 
   if (buf) {
     marshal_str(buf, error_code, round_len);
@@ -2213,7 +2205,7 @@ int
 LogAccess::marshal_client_security_protocol(char *buf)
 {
   const char *proto     = m_http_sm->get_user_agent().get_client_sec_protocol();
-  int         round_len = LogAccess::strlen(proto);
+  int         round_len = LogAccess::padded_strlen(proto);
 
   if (buf) {
     marshal_str(buf, proto, round_len);
@@ -2226,7 +2218,7 @@ int
 LogAccess::marshal_client_security_cipher_suite(char *buf)
 {
   const char *cipher    = m_http_sm->get_user_agent().get_client_cipher_suite();
-  int         round_len = LogAccess::strlen(cipher);
+  int         round_len = LogAccess::padded_strlen(cipher);
 
   if (buf) {
     marshal_str(buf, cipher, round_len);
@@ -2239,7 +2231,7 @@ int
 LogAccess::marshal_client_security_curve(char *buf)
 {
   const char *curve     = m_http_sm->get_user_agent().get_client_curve();
-  int         round_len = LogAccess::strlen(curve);
+  int         round_len = LogAccess::padded_strlen(curve);
 
   if (buf) {
     marshal_str(buf, curve, round_len);
@@ -2252,7 +2244,7 @@ int
 LogAccess::marshal_client_security_group(char *buf)
 {
   const char *group     = m_http_sm->get_user_agent().get_client_security_group();
-  int         round_len = LogAccess::strlen(group);
+  int         round_len = LogAccess::padded_strlen(group);
 
   if (buf) {
     marshal_str(buf, group, round_len);
@@ -2270,7 +2262,7 @@ LogAccess::marshal_client_security_alpn(char *buf)
     alpn                           = client_sec_alpn.data();
   }
 
-  int round_len = LogAccess::strlen(alpn);
+  int round_len = LogAccess::padded_strlen(alpn);
 
   if (buf) {
     marshal_str(buf, alpn, round_len);
@@ -2285,7 +2277,7 @@ LogAccess::marshal_client_security_alpn(char *buf)
 int
 LogAccess::marshal_proxy_resp_content_type(char *buf)
 {
-  int len = round_strlen(m_proxy_resp_content_type_len + 1);
+  int len = padded_length(m_proxy_resp_content_type_len + 1);
   if (buf) {
     marshal_mem(buf, m_proxy_resp_content_type_str, m_proxy_resp_content_type_len, len);
   }
@@ -2298,7 +2290,7 @@ LogAccess::marshal_proxy_resp_content_type(char *buf)
 int
 LogAccess::marshal_proxy_resp_reason_phrase(char *buf)
 {
-  int len = round_strlen(m_proxy_resp_reason_phrase_len + 1);
+  int len = padded_length(m_proxy_resp_reason_phrase_len + 1);
   if (buf) {
     marshal_mem(buf, m_proxy_resp_reason_phrase_str, m_proxy_resp_reason_phrase_len, len);
   }
@@ -2604,7 +2596,7 @@ LogAccess::marshal_server_host_name(char *buf)
 
   if (m_http_sm->t_state.current.server) {
     str = m_http_sm->t_state.current.server->name;
-    len = LogAccess::strlen(str);
+    len = LogAccess::padded_strlen(str);
   }
 
   if (buf) {
@@ -3164,7 +3156,7 @@ LogAccess::marshal_http_header_field(LogField::Container container, char *field,
         buf++;
       }
       running_len += 1;
-      padded_len   = round_strlen(running_len);
+      padded_len   = padded_length(running_len);
 
 // Note: marshal_string fills the padding to
 //  prevent purify UMRs so we do it here too
@@ -3269,7 +3261,7 @@ LogAccess::marshal_http_header_field_escapify(LogField::Container container, cha
         buf++;
       }
       running_len += 1;
-      padded_len   = round_strlen(running_len);
+      padded_len   = padded_length(running_len);
 
 // Note: marshal_string fills the padding to
 //  prevent purify UMRs so we do it here too

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -1369,19 +1369,19 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
         switch (*reinterpret_cast<int *>(read_from)) {
         case GET_AS_INT:
           method     = METHOD_GET;
-          read_from += LogAccess::round_strlen(3 + 1);
+          read_from += LogAccess::padded_length(3 + 1);
           break;
         case PUT_AS_INT:
           method     = METHOD_PUT;
-          read_from += LogAccess::round_strlen(3 + 1);
+          read_from += LogAccess::padded_length(3 + 1);
           break;
         case HEAD_AS_INT:
           method     = METHOD_HEAD;
-          read_from += LogAccess::round_strlen(4 + 1);
+          read_from += LogAccess::padded_length(4 + 1);
           break;
         case POST_AS_INT:
           method     = METHOD_POST;
-          read_from += LogAccess::round_strlen(4 + 1);
+          read_from += LogAccess::padded_length(4 + 1);
           break;
         default:
           tok_len = strlen(read_from);
@@ -1404,7 +1404,7 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
               flag = 1;
             }
           }
-          read_from += LogAccess::round_strlen(tok_len + 1);
+          read_from += LogAccess::padded_length(tok_len + 1);
           break;
         }
         break;
@@ -1454,7 +1454,7 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
           }
           tok_len = strlen(read_from);
         }
-        read_from += LogAccess::round_strlen(tok_len + 1);
+        read_from += LogAccess::padded_length(tok_len + 1);
         if (!aggregate_per_userid) {
           update_stats(o_stats, method, scheme, http_code, size, result, hier, elapsed, ipv6);
         }
@@ -1471,9 +1471,9 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
         }
 
         if ('-' == *read_from) {
-          read_from += LogAccess::round_strlen(1 + 1);
+          read_from += LogAccess::padded_length(1 + 1);
         } else {
-          read_from += LogAccess::strlen(read_from);
+          read_from += LogAccess::padded_strlen(read_from);
         }
         break;
 
@@ -1531,9 +1531,9 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
       case P_STATE_PEER:
         state = P_STATE_TYPE;
         if ('-' == *read_from) {
-          read_from += LogAccess::round_strlen(1 + 1);
+          read_from += LogAccess::padded_length(1 + 1);
         } else {
-          read_from += LogAccess::strlen(read_from);
+          read_from += LogAccess::padded_strlen(read_from);
         }
         break;
 
@@ -1746,7 +1746,7 @@ parse_log_buff(LogBufferHeader *buf_header, bool summary = false, bool aggregate
             update_counter(o_stats->content.other, size);
           }
         }
-        read_from += LogAccess::round_strlen(tok_len + 1);
+        read_from += LogAccess::padded_length(tok_len + 1);
         flag       = 0; // We exited this state without errors
         break;
 

--- a/tests/gold_tests/ip_allow/gold/log.gold
+++ b/tests/gold_tests/ip_allow/gold/log.gold
@@ -1,3 +1,3 @@
-127.0.0.1 TCP_MISS/200 130 GET https://127.0.0.1:SOMEPORT/get DIRECT - - - 127.0.0.1:SOMEPORT -  sftover=- sftmat=- sftcls=- sftbadclf=- yra=- scheme=http
-127.0.0.1 ERR_PROXY_DENIED/403 453 CONNECT 127.0.0.1:SOMEPORT/connect DIRECT text/html - - 127.0.0.1:SOMEPORT -  sftover=- sftmat=- sftcls=- sftbadclf=- yra=- scheme=UNKNOWN
-127.0.0.1 ERR_PROXY_DENIED/403 453 PUSH https://127.0.0.1:SOMEPORT/h2_push DIRECT text/html - - 127.0.0.1:SOMEPORT -  sftover=- sftmat=- sftcls=- sftbadclf=- yra=- scheme=https
+scheme=http 127.0.0.1 TCP_MISS/200 130 GET https://127.0.0.1:SOMEPORT/get DIRECT - - - 127.0.0.1:SOMEPORT -  sftover=- sftmat=- sftcls=- sftbadclf=- yra=-
+scheme=UNKNOWN 127.0.0.1 ERR_PROXY_DENIED/403 453 CONNECT 127.0.0.1:SOMEPORT/connect DIRECT text/html - - 127.0.0.1:SOMEPORT -  sftover=- sftmat=- sftcls=- sftbadclf=- yra=-
+scheme=https 127.0.0.1 ERR_PROXY_DENIED/403 453 PUSH https://127.0.0.1:SOMEPORT/h2_push DIRECT text/html - - 127.0.0.1:SOMEPORT -  sftover=- sftmat=- sftcls=- sftbadclf=- yra=-

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -96,12 +96,12 @@ ts.Disk.records_config.update(
     })
 
 format_string = (
-    '%<cqtd>-%<cqtt> %<stms> %<ttms> %<chi> %<crc>/%<pssc> %<psql> '
+    'scheme=%<pqus> %<cqtd>-%<cqtt> %<stms> %<ttms> %<chi> %<crc>/%<pssc> %<psql> '
     '%<cqhm> %<pquc> %<phr> %<psct> %<{Y-RID}pqh> '
     '%<{Y-YPCS}pqh> %<{Host}cqh> %<{CHAD}pqh>  '
     'sftover=%<{x-safet-overlimit-rules}cqh> sftmat=%<{x-safet-matched-rules}cqh> '
     'sftcls=%<{x-safet-classification}cqh> '
-    'sftbadclf=%<{x-safet-bad-classifiers}cqh> yra=%<{Y-RA}cqh> scheme=%<pqus>')
+    'sftbadclf=%<{x-safet-bad-classifiers}cqh> yra=%<{Y-RA}cqh>')
 
 ts.Disk.logging_yaml.AddLines(
     ''' logging:
@@ -137,7 +137,7 @@ ts.Disk.traffic_out.Content += Testers.ContainsExpression(
 #
 # TEST 1: Perform a GET request. Should be allowed because GET is in the allowlist.
 #
-tr = Test.AddTestRun()
+tr = Test.AddTestRun('Allowed GET request')
 tr.Processes.Default.StartBefore(server, ready=When.PortOpen(server.Variables.SSL_Port))
 tr.Processes.Default.StartBefore(Test.Processes.ts)
 
@@ -151,7 +151,7 @@ tr.StillRunningAfter = server
 # TEST 2: Perform a CONNECT request. Should not be allowed because CONNECT is
 # not in the allowlist.
 #
-tr = Test.AddTestRun()
+tr = Test.AddTestRun('Denied CONNECT request')
 tr.MakeCurlCommand(
     '--verbose -X CONNECT -H "Host: localhost" http://localhost:{ts_port}/connect'.format(ts_port=ts.Variables.port), ts=ts)
 tr.Processes.Default.ReturnCode = 0
@@ -163,7 +163,7 @@ tr.StillRunningAfter = server
 # TEST 3: Perform a PUSH request over HTTP/2. Should not be allowed because
 # PUSH is not in the allowlist.
 #
-tr = Test.AddTestRun()
+tr = Test.AddTestRun('Denied PUSH request over HTTP/2')
 tr.MakeCurlCommand(
     '--http2 --verbose -k -X PUSH -H "Host: localhost" https://localhost:{ts_port}/h2_push'.format(ts_port=ts.Variables.ssl_port),
     ts=ts)
@@ -172,7 +172,7 @@ tr.Processes.Default.Streams.stderr = 'gold/403_h2.gold'
 tr.StillRunningAfter = ts
 tr.StillRunningAfter = server
 
-tr = Test.AddTestRun()
+tr = Test.AddTestRun('Await and verify the transaction log file')
 tr.Processes.Default.Command = (
     os.path.join(Test.Variables.AtsTestToolsDir, 'stdout_wait') + ' 60 "{} {}" {}'.format(
         os.path.join(Test.TestDirectory, 'run_sed.sh'), os.path.join(ts.Variables.LOGDIR, 'squid.log'),

--- a/tests/gold_tests/ip_allow/run_sed.sh
+++ b/tests/gold_tests/ip_allow/run_sed.sh
@@ -16,6 +16,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# The first sed command in the pipeline eliminates the first 3 log fields from each log line.
+# The first sed command in the pipeline eliminates the next 3 log fields from each log line after the scheme field.
 
-sed 's/^[^ ]* [^ ]* [^ ]* //' < $1 | sed 's/:[0-9][0-9]*\([^0-9]\)/:SOMEPORT\1/g'
+sed 's/^\([^ ]*\) [^ ]* [^ ]* [^ ]* /\1 /' < $1 | sed 's/:[0-9][0-9]*\([^0-9]\)/:SOMEPORT\1/g'


### PR DESCRIPTION
The pqus scheme marshaling logic used "strlen" which accidentally picked up LogAccess::strlen rather than the intended std strlen. This resulted in padded-counting rather than actual strlen counting, which threw off our buffer counting logic and led to corruption and/or crashing.

The updated ip_allow.test.py reproduced a crash without the LogAccess.cc patch included in this commit. With the LogAccess patch, the test now reproduces the expected scheme.

Function renames for clarity:

* LogAccess::round_strlen is not a strlen at all. Rather it converts a given length to a padded length for alignment.
* LogAccess::strlen returns the padded version of strlen. To make this explicit (and avoid potential accitantal clashes with ::strlen), I renamed this to padded_strlen.

This also adds doxygen comments to explain these functions further.

(cherry picked from commit 83adab4eaf1aa1c1504fb6ba5a22df413134cd26)