### PR TITLE
header_rewrite: Fix uninitialized bufp/hdr_loc

### DIFF
--- a/plugins/header_rewrite/resources.cc
+++ b/plugins/header_rewrite/resources.cc
@@ -52,16 +52,16 @@ Resources::gather(const ResourceIDs ids, TSHttpHookID hook)
   switch (hook) {
   case TS_HTTP_READ_RESPONSE_HDR_HOOK:
     // Read response headers from server
-    if (ids & RSRC_SERVER_RESPONSE_HEADERS) {
+    if ((ids & RSRC_SERVER_RESPONSE_HEADERS) || (ids & RSRC_RESPONSE_STATUS)) {
       Dbg(pi_dbg_ctl, "\tAdding TXN server response header buffers");
       if (TSHttpTxnServerRespGet(state.txnp, &bufp, &hdr_loc) != TS_SUCCESS) {
         Dbg(pi_dbg_ctl, "could not gather bufp/hdr_loc for response");
         return;
       }
-    }
-    if (ids & RSRC_RESPONSE_STATUS) {
-      Dbg(pi_dbg_ctl, "\tAdding TXN server response status resource");
-      resp_status = TSHttpHdrStatusGet(bufp, hdr_loc);
+      if (ids & RSRC_RESPONSE_STATUS) {
+        Dbg(pi_dbg_ctl, "\tAdding TXN server response status resource");
+        resp_status = TSHttpHdrStatusGet(bufp, hdr_loc);
+      }
     }
     break;
 


### PR DESCRIPTION
Fix a bug where if RSRC_RESPONSE_STATUS is requested without RSRC_SERVER_RESPONSE_HEADERS, the bufp and hdr_loc variables would be uninitialized when passed to TSHttpHdrStatusGet().

This change ensures that TSHttpTxnServerRespGet() is called when either resource is requested, properly initializing the required variables.