### PR TITLE
Fix traffic_ctl server AuTest

### DIFF
--- a/tests/gold_tests/traffic_ctl/traffic_ctl_server_output.test.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_server_output.test.py
@@ -28,9 +28,16 @@ Test traffic_ctl different commands.
 
 Test.ContinueOnFail = True
 
+records_yaml = '''
+  exec_thread:
+    autoconfig:
+      enabled: 0
+    limit: 4
+    '''
+
 Test.Summary = 'Basic test for traffic_ctl server command features.'
 
-traffic_ctl = Make_traffic_ctl(Test)
+traffic_ctl = Make_traffic_ctl(Test, records_yaml)
 ######
 # traffic_ctl server status
 traffic_ctl.server().status().validate_with_text(


### PR DESCRIPTION
Disable `proxy.config.exec_thread.autoconfig.enabled` to pin exec_thread number to 4.