### PR TITLE
IPRangeSet::erase

### DIFF
--- a/lib/swoc/include/swoc/IPRange.h
+++ b/lib/swoc/include/swoc/IPRange.h
@@ -1570,6 +1570,13 @@ public:
    */
   self_type &fill(swoc::IPRange const &r);
 
+  /** Erase addresses from the set.
+   *
+   * @param r Range of addresses to erase.
+   * @return @a this
+   */
+  self_type &erase(swoc::IPRange const &r);
+
   /// @return @c true if @a addr is in the set.
   bool contains(swoc::IPAddr const &addr) const;
 
@@ -1672,6 +1679,12 @@ IPRangeSet::mark(swoc::IPRange const &r) -> self_type & {
 inline auto
 IPRangeSet::fill(swoc::IPRange const &r) -> self_type & {
   _addrs.mark(r, MARK);
+  return *this;
+}
+
+inline auto
+IPRangeSet::erase(swoc::IPRange const &r) -> self_type & {
+  _addrs.erase(r);
   return *this;
 }
 


### PR DESCRIPTION
This adds IPRangeSet::erase to libswoc. This is in the libswoc 1.5.15 release and brings us up to date with that release. I'll do a separate PR with the version update.