### PR TITLE
Provide Regex::exec backwards compatibility

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -125,7 +125,17 @@ public:
    *
    * It is safe to call this method concurrently on the same instance of @a this.
    */
-  bool exec(std::string_view subject, uint32_t flags = 0) const;
+  bool exec(std::string_view subject) const;
+
+  /** Execute the regular expression.
+   *
+   * @param subject String to match against.
+   * @param flags Match flags (e.g., RE_NOTEMPTY).
+   * @return @c true if the pattern matched, @a false if not.
+   *
+   * It is safe to call this method concurrently on the same instance of @a this.
+   */
+  bool exec(std::string_view subject, uint32_t flags) const;
 
   /** Execute the regular expression.
    *
@@ -138,7 +148,21 @@ public:
    * Each capture group takes 3 elements of @a ovector, therefore @a ovecsize must
    * be a multiple of 3 and at least three times the number of desired capture groups.
    */
-  int exec(std::string_view subject, RegexMatches &matches, uint32_t flags = 0) const;
+  int exec(std::string_view subject, RegexMatches &matches) const;
+
+  /** Execute the regular expression.
+   *
+   * @param subject String to match against.
+   * @param matches Place to store the capture groups.
+   * @param flags Match flags (e.g., RE_NOTEMPTY).
+   * @return @c The number of capture groups. < 0 if an error occurred. 0 if the number of Matches is too small.
+   *
+   * It is safe to call this method concurrently on the same instance of @a this.
+   *
+   * Each capture group takes 3 elements of @a ovector, therefore @a ovecsize must
+   * be a multiple of 3 and at least three times the number of desired capture groups.
+   */
+  int exec(std::string_view subject, RegexMatches &matches, uint32_t flags) const;
 
   /// @return The number of capture groups in the compiled pattern.
   int get_capture_count();

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -297,6 +297,13 @@ Regex::compile(std::string_view pattern, std::string &error, int &erroroffset, u
 
 //----------------------------------------------------------------------------
 bool
+Regex::exec(std::string_view subject) const
+{
+  return this->exec(subject, 0);
+}
+
+//----------------------------------------------------------------------------
+bool
 Regex::exec(std::string_view subject, uint32_t flags) const
 {
   if (_Code::get(_code) == nullptr) {
@@ -306,6 +313,13 @@ Regex::exec(std::string_view subject, uint32_t flags) const
 
   int count = this->exec(subject, matches, flags);
   return count > 0;
+}
+
+//----------------------------------------------------------------------------
+int32_t
+Regex::exec(std::string_view subject, RegexMatches &matches) const
+{
+  return this->exec(subject, matches, 0);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This tweaks #12546 to maintain ABI compatibility for the already existing exec functions.