### PR TITLE
ControlMatcher: error versus NOMATCH checking

### DIFF
--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -305,7 +305,7 @@ Regex::exec(std::string_view subject, uint32_t flags) const
   RegexMatches matches;
 
   int count = this->exec(subject, matches, flags);
-  return count > 0;
+  return count >= 0;
 }
 
 //----------------------------------------------------------------------------
@@ -316,7 +316,7 @@ Regex::exec(std::string_view subject, RegexMatches &matches, uint32_t flags) con
 
   // check if there is a compiled regex
   if (code == nullptr) {
-    return 0;
+    return PCRE2_ERROR_NULL;
   }
   int count = pcre2_match(code, reinterpret_cast<PCRE2_SPTR>(subject.data()), subject.size(), 0, flags,
                           RegexMatches::_MatchData::get(matches._match_data), RegexContext::get_instance()->get_match_context());

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -23,6 +23,9 @@
 #include <string_view>
 #include <vector>
 
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
 #include "tscore/ink_assert.h"
 #include "tscore/ink_defs.h"
 #include "tsutil/Regex.h"
@@ -168,7 +171,7 @@ TEST_CASE("Regex", "[libts][Regex]")
     Regex        r;
     RegexMatches matches;
     REQUIRE(r.exec("foo") == false);
-    REQUIRE(r.exec("foo", matches) == 0);
+    REQUIRE(r.exec("foo", matches) == PCRE2_ERROR_NULL);
   }
 
   // test for recompiling the regular expression


### PR DESCRIPTION
This updates the ControlMatcher logic to distinguish between error conditions versus NOMATCH conditions. Without this patch, ControlMatcher was emitting incorrect regex matching warnings for NOMATCH conditions.