### PR TITLE
libswoc 1.5.15: version update

### DIFF
--- a/lib/swoc/CMakeLists.txt
+++ b/lib/swoc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Lib-SWOC LANGUAGES CXX VERSION 1.5.14)
-set(LIBSWOC_VERSION "1.5.14")
+project(Lib-SWOC LANGUAGES CXX VERSION 1.5.15)
+set(LIBSWOC_VERSION "1.5.15")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/lib/swoc/include/swoc/swoc_version.h
+++ b/lib/swoc/include/swoc/swoc_version.h
@@ -23,11 +23,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#define SWOC_VERSION_NS _1_5_14
+#define SWOC_VERSION_NS _1_5_15
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 14;
+static constexpr unsigned POINT_VERSION = 15;
 }} // namespace swoc::SWOC_VERSION_NS


### PR DESCRIPTION
This updates our lib/swoc version to 1.5.15 to match the apache/trafficserver-libswoc version with which it is identical. This is a version metadata only update to document the parity. There is no functional change with this PR.