### PR TITLE
Reset write lock state to init after closing write (#12215)

### DIFF
--- a/proxy/http/HttpSM.cc
+++ b/proxy/http/HttpSM.cc
@@ -6286,6 +6286,7 @@ HttpSM::perform_cache_write_action()
     // Write close deletes the old alternate
     cache_sm.close_write();
     cache_sm.close_read();
+    t_state.cache_info.write_lock_state = HttpTransact::CACHE_WL_INIT;
     break;
   }
 
@@ -6344,6 +6345,7 @@ HttpSM::issue_cache_update()
   }
   // Now close the write which commits the update
   cache_sm.close_write();
+  t_state.cache_info.write_lock_state = HttpTransact::CACHE_WL_INIT;
 }
 
 int


### PR DESCRIPTION
This commit mitigates the crash reported in #11700. That crash happens when a redirect is issued on a state machine that has already cached a response and closed the cache write VC.

After this patch, the state machine will likely open a new cache VC to cache the response from the origin it was redirected to. We will refer to the original origin as A, and the origin the state machine was redirected to after the response from A as B.

We have not yet reproduced this locally - the exact sequence of events that gets the state machine into this state are still unknown.

(cherry picked from commit 5c0aaf2f9578506089c166b017a5b1c1973f9846)