### PR TITLE
Fix of use-after-free tunnel_handler_100_continue_ua

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -3425,9 +3425,9 @@ HttpSM::tunnel_handler_100_continue_ua(int event, HttpTunnelConsumer *c)
     _ua.get_entry()->in_tunnel = false;
     c->write_success           = true;
 
-    // remove the buffer reader from the consumer's vc
+    // Disable any write operation in case there are timeout events.
     if (c->vc != nullptr) {
-      c->vc->do_io_write();
+      c->vc->do_io_write(nullptr, 0, nullptr);
     }
   }
 


### PR DESCRIPTION
From a recent instrumented core taking traffic in production:

```
(gdb) p write_state.vio
$22 = {
  cont = 0x0,
  cont_handler_name = 0x9046f2 "&HttpTunnel::main_handler",
  nbytes = 9223372036854775807,
  ndone = 0,
  op = 2,
  _disabled = false,
  buffer = {
    mbuf = 0x0,
    entry = 0x0
  },
  vc_server = 0x7faa48983920,
  mutex = {
    m_ptr = 0x7fa7bfa24a00
  }
}
```

Notice that:

* cont is nullptr
* nbytes is 9223372036854775807 (INT64_MAX)

These are the default value of do_io_write when no values are passed to it. This doesn't happen in a lot of places, but it does currently in tunnel_handler_100_continue_ua:

```cpp
       c->vc->do_io_write();
```

This changes the call to the following more typical way of canceling a vc write operation:

```cpp
  c->vc->do_io_write(nullptr, 0, nullptr);
```

This way when a PluginVC::process_timeout event is processed, the ntodo will be 0 and thus the non-existent handler will not be called (see PluginVC.cc):

```cpp
    } else if (write_state.vio.op == VIO::WRITE && !write_state.shutdown && write_state.vio.ntodo() > 0) {
```