### PR TITLE
HRW: Better txn slot management

### DIFF
--- a/doc/developer-guide/api/functions/TSUserArgs.en.rst
+++ b/doc/developer-guide/api/functions/TSUserArgs.en.rst
@@ -61,7 +61,8 @@ plugin can reserve a slot of a particular type by calling :func:`TSUserArgIndexR
    The type for which the plugin intend to reserve a slot. See :code:`TSUserArgType` above.
 
 :arg:`name`
-   An identifying name for the plugin that reserved the index. Required.
+   An unique and identifying name for the reserved slot index. A plugin registering
+   multiple slots (not recommended!) must make sure the identifier is unique.
 
 :arg:`description`
    An optional description of the use of the arg. This can be :code:`nullptr`.

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -376,10 +376,9 @@ static void
 setPluginControlValues(TSHttpTxn txnp, RulesConfig *conf)
 {
   if (conf->timezone() != 0 || conf->inboundIpSource() != 0) {
-    ConditionNow temporal_statement; // This could be any statement that use the private slot.
-    int          slot = temporal_statement.get_txn_private_slot();
-
+    int             slot = Statement::acquire_txn_private_slot();
     PrivateSlotData private_data;
+
     private_data.raw       = reinterpret_cast<uint64_t>(TSUserArgGet(txnp, slot));
     private_data.timezone  = conf->timezone();
     private_data.ip_source = conf->inboundIpSource();

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -168,8 +168,13 @@ public:
   {
     TSReleaseAssert(_initialized == false);
     initialize_hooks();
-    acquire_txn_slot();
-    acquire_txn_private_slot();
+
+    if (need_txn_slot()) {
+      _txn_slot = acquire_txn_slot();
+    }
+    if (need_txn_private_slot()) {
+      _txn_private_slot = acquire_txn_private_slot();
+    }
 
     _initialized = true;
   }
@@ -180,18 +185,14 @@ public:
     return _initialized;
   }
 
-  int
-  get_txn_private_slot()
-  {
-    acquire_txn_private_slot();
-    return _txn_private_slot;
-  }
-
   void
   require_resources(const ResourceIDs ids)
   {
     _rsrc = static_cast<ResourceIDs>(_rsrc | ids);
   }
+
+  static int acquire_txn_slot();
+  static int acquire_txn_private_slot();
 
 protected:
   virtual void initialize_hooks();
@@ -217,9 +218,6 @@ protected:
   int        _txn_private_slot = -1;
 
 private:
-  void acquire_txn_slot();
-  void acquire_txn_private_slot();
-
   ResourceIDs               _rsrc = RSRC_NONE;
   TSHttpHookID              _hook = TS_HTTP_READ_RESPONSE_HDR_HOOK;
   std::vector<TSHttpHookID> _allowed_hooks;


### PR DESCRIPTION
This also fixes a real bug, where the txn slot for the state variables could overlap / conflict with the control mechanism and its txn slot. They need to have different names.