### PR TITLE
access_control: use Regex instead of pcre

### DIFF
--- a/plugins/experimental/access_control/CMakeLists.txt
+++ b/plugins/experimental/access_control/CMakeLists.txt
@@ -28,7 +28,7 @@ add_atsplugin(
   utils.cc
 )
 
-target_link_libraries(access_control PRIVATE OpenSSL::SSL OpenSSL::Crypto PCRE::PCRE)
+target_link_libraries(access_control PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 verify_remap_plugin(access_control)
 

--- a/plugins/experimental/access_control/pattern.h
+++ b/plugins/experimental/access_control/pattern.h
@@ -23,13 +23,9 @@
 
 #pragma once
 
-#ifdef HAVE_PCRE_PCRE_H
-#include <pcre/pcre.h>
-#else
-#include <pcre.h>
-#endif
-
 #include "common.h"
+
+class Regex;
 
 /**
  * @brief PCRE matching, capturing and replacing
@@ -37,11 +33,10 @@
 class Pattern
 {
 public:
-  static const int TOKENCOUNT = 10;             /**< @brief Capturing groups $0..$9 */
-  static const int OVECOUNT   = TOKENCOUNT * 3; /**< @brief pcre_exec() array count, handle 10 capture groups */
+  static const int TOKENCOUNT = 10; /**< @brief Capturing groups $0..$9 */
 
   Pattern();
-  virtual ~Pattern();
+  ~Pattern(); // Keep in pattern.cc for pimpl use of Regex.
 
   bool   init(const String &pattern, const String &replacement, bool replace);
   bool   init(const String &config);
@@ -54,10 +49,8 @@ public:
 
 private:
   bool compile();
-  void pcreFree();
 
-  pcre       *_re    = nullptr; /**< @brief PCRE compiled info structure, computed during initialization */
-  pcre_extra *_extra = nullptr; /**< @brief PCRE study data block, computed during initialization */
+  std::unique_ptr<Regex> _re; /**< @brief Regex compiled object, computed during initialization */
 
   String _pattern;     /**< @brief PCRE pattern string, containing PCRE patterns and capturing groups. */
   String _replacement; /**< @brief PCRE replacement string, containing $0..$9 to be replaced with content of the capturing groups */


### PR DESCRIPTION
Updates the access_control plugin to use tsutil Regex instead of pcre.