### PR TITLE
traffic_cache: use single regex in url_matcher port

### DIFF
--- a/src/traffic_cache_tool/CacheDefs.h
+++ b/src/traffic_cache_tool/CacheDefs.h
@@ -320,7 +320,7 @@ struct url_matcher {
       std::cout << "Check your regular expression" << std::endl;
       return;
     }
-    if (!port.compile(R"([0-9]+$)")) {
+    if (!port.compile(R"(^[0-9]+$)")) {
       std::cout << "Check your regular expression" << std::endl;
       return;
     }


### PR DESCRIPTION
This match is a single regex match.  DFA is meant for multiple regex matching.