### PR TITLE
[10.1.x] HRW: Better txn slot management (#12566)

### DIFF
--- a/doc/developer-guide/api/functions/TSUserArgs.en.rst
+++ b/doc/developer-guide/api/functions/TSUserArgs.en.rst
@@ -61,7 +61,8 @@ plugin can reserve a slot of a particular type by calling :func:`TSUserArgIndexR
    The type for which the plugin intend to reserve a slot. See :code:`TSUserArgType` above.
 
 :arg:`name`
-   An identifying name for the plugin that reserved the index. Required.
+   An unique and identifying name for the reserved slot index. A plugin registering
+   multiple slots (not recommended!) must make sure the identifier is unique.
 
 :arg:`description`
    An optional description of the use of the arg. This can be :code:`nullptr`.

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -154,8 +154,13 @@ public:
   {
     TSReleaseAssert(_initialized == false);
     initialize_hooks();
-    acquire_txn_slot();
-    acquire_txn_private_slot();
+
+    if (need_txn_slot()) {
+      _txn_slot = acquire_txn_slot();
+    }
+    if (need_txn_private_slot()) {
+      _txn_private_slot = acquire_txn_private_slot();
+    }
 
     _initialized = true;
   }
@@ -165,6 +170,9 @@ public:
   {
     return _initialized;
   }
+
+  static int acquire_txn_slot();
+  static int acquire_txn_private_slot();
 
 protected:
   virtual void initialize_hooks();
@@ -196,9 +204,6 @@ protected:
   int        _txn_private_slot = -1;
 
 private:
-  void acquire_txn_slot();
-  void acquire_txn_private_slot();
-
   ResourceIDs               _rsrc = RSRC_NONE;
   TSHttpHookID              _hook = TS_HTTP_READ_RESPONSE_HDR_HOOK;
   std::vector<TSHttpHookID> _allowed_hooks;


### PR DESCRIPTION
* HRW: Better txn slot management

This also fixes a real bug, where the txn slot for the state variables could overlap / conflict with the control mechanism and its txn slot. They need to have different names.

* Add some docs to clarify slots naming

(cherry picked from commit 4af1b1cc8b82030440850fcd454c5028a7c248e6)