### PR TITLE
Add to API to get a strategy during TSRemapNewInstance

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategyFind.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategyFind.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: cpp
 
-TSHttpTxnNextHopNameGet
-***********************
+TSHttpTxnNextHopStrategyFind
+****************************
 
 Synopsis
 ========
@@ -28,24 +28,20 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const* strategy)
+.. function:: void const* TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name)
 
 Description
 ===========
 
-Sets the next hop strategy for the transaction :arg:`txnp`
-This :arg:`strategy` pointer must be a valid strategy and can be
-nullptr to indicate that parent.config will be used instead.
+Gets a pointer to the specified :arg:`name` NextHopSelectionStrategy.
+This may be nullptr indicating that no strategy exists with the given name.
 
-Plugins can get a strategy by name by calling
-:func:`TSHttpTxnNextHopStrategyGet` to get the current transaction's
-active strategy or :func:`TSHttpTxnNextHopStrategyFind` to
-look up a strategy by name using the transaction's pointer to the
-NextHopStrategyFactory strategy database.
+This function uses the transaction :arg:`txnp` to get access to the
+NextHopStrategyFactory associated with the current configuration.
 
 .. note::
 
-   This strategy pointer must not be freed and the contents must not
+   This returned pointer must not be freed and the contents must not
    be changed.
    Strategy pointers held by plugins will become invalid when ATS
    configs are reloaded and should be reset with :func:`TSRemapNewInstance`
@@ -53,4 +49,4 @@ NextHopStrategyFactory strategy database.
 See Also
 ========
 
-:func:`TSHttpTxnNextHopStrategyGet`, :func:`TSHttpTxnNextHopStrategyFind`.
+:func:`TSHttpTxnNextHopStrategySet`

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategyFind.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategyFind.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void const* TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name)
+.. function:: TSStrategy TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategyGet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategyGet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void const* TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp)
+.. function:: TSStrategy TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategySet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnNextHopStrategySet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const* strategy)
+.. function:: void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, TSStrategy strategy)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSNextHopStrategyNameGet.en.rst
+++ b/doc/developer-guide/api/functions/TSNextHopStrategyNameGet.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: cpp
 
-TSHttpTxnNextHopNameGet
-***********************
+TSNextHopStrategyNameGet
+************************
 
 Synopsis
 ========
@@ -28,24 +28,17 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const* strategy)
+.. function:: char const* TSNextHopStrategyNameGet(void const* strategy)
 
 Description
 ===========
 
-Sets the next hop strategy for the transaction :arg:`txnp`
-This :arg:`strategy` pointer must be a valid strategy and can be
-nullptr to indicate that parent.config will be used instead.
-
-Plugins can get a strategy by name by calling
-:func:`TSHttpTxnNextHopStrategyGet` to get the current transaction's
-active strategy or :func:`TSHttpTxnNextHopStrategyFind` to
-look up a strategy by name using the transaction's pointer to the
-NextHopStrategyFactory strategy database.
+Gets the name associated with the provided strategy pointer.
+This may be nullptr which indicates that parent.config is in use.
 
 .. note::
 
-   This strategy pointer must not be freed and the contents must not
+   This returned pointer must not be freed and the contents must not
    be changed.
    Strategy pointers held by plugins will become invalid when ATS
    configs are reloaded and should be reset with :func:`TSRemapNewInstance`
@@ -53,4 +46,4 @@ NextHopStrategyFactory strategy database.
 See Also
 ========
 
-:func:`TSHttpTxnNextHopStrategyGet`, :func:`TSHttpTxnNextHopStrategyFind`.
+:func:`TSHttpTxnNextHopStrategyGet`

--- a/doc/developer-guide/api/functions/TSNextHopStrategyNameGet.en.rst
+++ b/doc/developer-guide/api/functions/TSNextHopStrategyNameGet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: char const* TSNextHopStrategyNameGet(void const* strategy)
+.. function:: char const* TSNextHopStrategyNameGet(TSStrategy strategy)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategyFind.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategyFind.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: cpp
 
-TSHttpTxnNextHopNameGet
-***********************
+TSRemapNextHopStrategyFind
+**************************
 
 Synopsis
 ========
@@ -28,24 +28,20 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const* strategy)
+.. function:: void const* TSRemapNextHopStrategyFind(const char *name)
 
 Description
 ===========
 
-Sets the next hop strategy for the transaction :arg:`txnp`
-This :arg:`strategy` pointer must be a valid strategy and can be
-nullptr to indicate that parent.config will be used instead.
+Gets a pointer to the specified :arg:`name` NextHopSelectionStrategy.
+This may be nullptr indicating that no strategy exists with the given name.
 
-Plugins can get a strategy by name by calling
-:func:`TSHttpTxnNextHopStrategyGet` to get the current transaction's
-active strategy or :func:`TSHttpTxnNextHopStrategyFind` to
-look up a strategy by name using the transaction's pointer to the
-NextHopStrategyFactory strategy database.
+This function may ONLY be called during TSRemapNewInstance.
+The resulting strategy pointer is valid for all subsequent transactions.
 
 .. note::
 
-   This strategy pointer must not be freed and the contents must not
+   This returned pointer must not be freed and the contents must not
    be changed.
    Strategy pointers held by plugins will become invalid when ATS
    configs are reloaded and should be reset with :func:`TSRemapNewInstance`
@@ -53,4 +49,4 @@ NextHopStrategyFactory strategy database.
 See Also
 ========
 
-:func:`TSHttpTxnNextHopStrategyGet`, :func:`TSHttpTxnNextHopStrategyFind`.
+:func:`TSRemapNextHopStrategySet`

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategyFind.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategyFind.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void const* TSRemapNextHopStrategyFind(const char *name)
+.. function:: TSStrategy TSRemapNextHopStrategyFind(const char *name)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategyGet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategyGet.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: cpp
 
-TSHttpNextHopStrategyNameGet
-****************************
+TSRemapNextHopStrategyGet
+*************************
 
 Synopsis
 ========
@@ -28,17 +28,20 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: char const* TSHttpNextHopStrategyNameGet(void const* strategy)
+.. function:: void const* TSRemapNextHopStrategyGet()
 
 Description
 ===========
 
-Gets the name associated with the provided strategy.
+Gets a pointer to the current remap rule being loaded.
 This may be nullptr indicating that parent.config is in use.
+
+This function may ONLY be called during TSRemapNewInstance.
+The resulting strategy pointer is valid for all subsequent transactions.
 
 .. note::
 
-   This returned pointer must not be freed and the contents must not
+   This strategy pointer must not be freed and the contents must not
    be changed.
    Strategy pointers held by plugins will become invalid when ATS
    configs are reloaded and should be reset with :func:`TSRemapNewInstance`
@@ -46,4 +49,4 @@ This may be nullptr indicating that parent.config is in use.
 See Also
 ========
 
-:func:`TSHttpTxnNextHopStrategyGet`
+:func:`TSRemapNextHopStrategySet`

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategyGet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategyGet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void const* TSRemapNextHopStrategyGet()
+.. function:: TSStrategy TSRemapNextHopStrategyGet()
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategySet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategySet.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: cpp
 
-TSHttpTxnNextHopNamedStrategyGet
-********************************
+TSRemapNextHopNameGet
+***********************
 
 Synopsis
 ========
@@ -28,20 +28,24 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void const* TSHttpTxnNextHopNamedStrategyGet(TSHttpTxn txnp, const char *name)
+.. function:: void TSRemapNextHopStrategySet(void const* strategy)
 
 Description
 ===========
 
-Gets a pointer to the specified :arg:`name` NextHopSelectionStrategy.
-This may be nullptr indicating that no strategy exists with the given name.
+Sets the next hop strategy for the currently loading remap rule.
+This :arg:`strategy` pointer must be a valid strategy and can be
+nullptr to indicate that parent.config will be used instead.
 
-This function uses the transaction :arg:`txnp` to get access to the
-NextHopStrategyFactory associated with the current configuration.
+Plugins can get a strategy by name by calling
+:func:`TSRemapNextHopStrategyGet` to get the current transaction's active
+strategy or :func:`TSRemapNextHopStrategyFind` to look up a strategy by
+name using the loading remap rule's pointer to the NextHopStrategyFactory
+strategy database.
 
 .. note::
 
-   This returned pointer must not be freed and the contents must not
+   This strategy pointer must not be freed and the contents must not
    be changed.
    Strategy pointers held by plugins will become invalid when ATS
    configs are reloaded and should be reset with :func:`TSRemapNewInstance`
@@ -49,4 +53,4 @@ NextHopStrategyFactory associated with the current configuration.
 See Also
 ========
 
-:func:`TSHttpTxnNextHopStrategySet`
+:func:`TSRemapNextHopStrategyGet`, :func:`TSRemapNextHopStrategyFind`.

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategySet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategySet.en.rst
@@ -28,7 +28,7 @@ Synopsis
 
     #include <ts/ts.h>
 
-.. function:: void TSRemapNextHopStrategySet(void const* strategy)
+.. function:: void TSRemapNextHopStrategySet(TSStrategy strategy)
 
 Description
 ===========

--- a/doc/developer-guide/api/functions/TSRemapNextHopStrategySet.en.rst
+++ b/doc/developer-guide/api/functions/TSRemapNextHopStrategySet.en.rst
@@ -18,8 +18,8 @@
 
 .. default-domain:: cpp
 
-TSRemapNextHopNameGet
-***********************
+TSRemapNextHopStrategySet
+*************************
 
 Synopsis
 ========

--- a/doc/developer-guide/api/functions/TSTypes.en.rst
+++ b/doc/developer-guide/api/functions/TSTypes.en.rst
@@ -335,6 +335,8 @@ more widely. Those are described on this page.
 .. type:: TSFetchSM
 .. type:: TSFetchEvent
 
+.. type:: TSStrategy
+
 .. type:: TSHttpPriority
 
    The abstract type of the various HTTP priority implementations.

--- a/include/proxy/http/remap/UrlMapping.h
+++ b/include/proxy/http/remap/UrlMapping.h
@@ -116,7 +116,7 @@ public:
   bool              ip_allow_check_enabled_p = false;
   acl_filter_rule  *filter                   = nullptr; // acl filtering (linked list of rules)
   LINK(url_mapping, link);                              // For use with the main Queue linked list holding all the mapping
-  NextHopSelectionStrategy      *strategy = nullptr;
+  NextHopSelectionStrategy      *strategy        = nullptr;
   NextHopStrategyFactory        *strategyFactory = nullptr;
   std::string                    remapKey;
   std::atomic<uint64_t>          _hitCount       = 0; // counter can overflow
@@ -144,7 +144,6 @@ public:
   {
     return _volume_str;
   }
-  std::atomic<uint64_t>     _hitCount = 0; // counter can overflow
 
   int
   getRank() const

--- a/include/proxy/http/remap/UrlMapping.h
+++ b/include/proxy/http/remap/UrlMapping.h
@@ -123,7 +123,7 @@ public:
   std::atomic<CacheHostRecord *> volume_host_rec = nullptr;
 
   // For use with the strategies API to be called during TSRemapNewInstance.
-  static inline url_mapping *instance = nullptr;
+  static inline thread_local url_mapping *instance = nullptr;
 
   CacheHostRecord *
   getVolumeHostRec() const

--- a/include/proxy/http/remap/UrlMapping.h
+++ b/include/proxy/http/remap/UrlMapping.h
@@ -38,6 +38,7 @@
 #include "tscore/List.h"
 
 class NextHopSelectionStrategy;
+class NextHopStrategyFactory;
 struct CacheHostRecord;
 
 /**
@@ -116,9 +117,13 @@ public:
   acl_filter_rule  *filter                   = nullptr; // acl filtering (linked list of rules)
   LINK(url_mapping, link);                              // For use with the main Queue linked list holding all the mapping
   NextHopSelectionStrategy      *strategy = nullptr;
+  NextHopStrategyFactory        *strategyFactory = nullptr;
   std::string                    remapKey;
   std::atomic<uint64_t>          _hitCount       = 0; // counter can overflow
   std::atomic<CacheHostRecord *> volume_host_rec = nullptr;
+
+  // For use with the strategies API to be called during TSRemapNewInstance.
+  static inline url_mapping *instance = nullptr;
 
   CacheHostRecord *
   getVolumeHostRec() const
@@ -139,6 +144,7 @@ public:
   {
     return _volume_str;
   }
+  std::atomic<uint64_t>     _hitCount = 0; // counter can overflow
 
   int
   getRank() const

--- a/include/ts/apidefs.h.in
+++ b/include/ts/apidefs.h.in
@@ -1158,6 +1158,7 @@ using TSHostLookupResult = struct tsapi_hostlookupresult *;
 using TSAIOCallback      = struct tsapi_aiocallback *;
 using TSAcceptor         = struct tsapi_net_accept *;
 using TSRemapPluginInfo  = struct tsapi_remap_plugin_info *;
+using TSStrategy         = struct tsapi_strategy *;
 
 using TSFetchSM = struct tsapi_fetchsm *;
 

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1671,7 +1671,7 @@ char *TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype);
     @param name of the strategy to look up.
 
  */
-void const *TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name);
+TSStrategy TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name);
 
 /**
     Sets the Transaction's Next Hop Parent Strategy.
@@ -1683,7 +1683,7 @@ void const *TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name);
     @param pointer to the given strategy.
 
  */
-void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const *strategy);
+void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, TSStrategy strategy);
 
 /**
     Retrieves a pointer to the current next hop selection strategy.
@@ -1694,7 +1694,7 @@ void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const *strategy);
     @param txnp HTTP transaction whose next hop strategy to get.
 
  */
-void const *TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp);
+TSStrategy TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp);
 
 /**
     Returns either null pointer or null terminated pointer to name.
@@ -1707,7 +1707,7 @@ void const *TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp);
     @param pointer to the NextHopStrategy.
 
  */
-char const *TSNextHopStrategyNameGet(void const *strategy);
+char const *TSNextHopStrategyNameGet(TSStrategy strategy);
 
 /**
     Retrieves a pointer to the named strategy in the strategy table.
@@ -1720,7 +1720,7 @@ char const *TSNextHopStrategyNameGet(void const *strategy);
     @param name of the strategy to look up.
 
  */
-void const *TSRemapNextHopStrategyFind(const char *name);
+TSStrategy TSRemapNextHopStrategyFind(const char *name);
 
 /**
     Retrieves a pointer to remap rule strategy pointer.
@@ -1730,7 +1730,7 @@ void const *TSRemapNextHopStrategyFind(const char *name);
     Returns nullptr if no strategy assigned.
 
  */
-void const *TSRemapNextHopStrategyGet();
+TSStrategy TSRemapNextHopStrategyGet();
 
 /**
     Sets the remap rule's next hop strategy.
@@ -1742,7 +1742,7 @@ void const *TSRemapNextHopStrategyGet();
     @param handle to the strategy to set.
 
  */
-void TSRemapNextHopStrategySet(void const *strategy);
+void TSRemapNextHopStrategySet(TSStrategy strategy);
 
 /**
     Sets the parent proxy name and port. The string hostname is copied

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1661,9 +1661,21 @@ void TSHttpTxnErrorBodySet(TSHttpTxn txnp, char *buf, size_t buflength, char *mi
 char *TSHttpTxnErrorBodyGet(TSHttpTxn txnp, size_t *buflength, char **mimetype);
 
 /**
+    Retrieves a handle to the named strategy in the strategy table.
+    Returns nullptr if no strategy is found.
+    This uses the current transaction's state machine to get
+    access to UrlRewrite's NextHopStrategyFactory.
+    It's preferable to retrieve strategies during TSRemapNewInstance.
+
+    @param txnp HTTP transaction which holds the strategy table.
+    @param name of the strategy to look up.
+
+ */
+void const *TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name);
+
+/**
     Sets the Transaction's Next Hop Parent Strategy.
-    Calling this after TS_HTTP_CACHE_LOOKUP_COMPLETE_HOOK will
-    result in bad behavior.
+    Must be called before parent selection logic is required.
 
     You can get this strategy pointer by calling TSHttpTxnParentStrategyGet().
 
@@ -1686,28 +1698,51 @@ void const *TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp);
 
 /**
     Returns either null pointer or null terminated pointer to name.
-                DO NOT FREE.
+    DO NOT FREE.
 
     This value may be a nullptr due to:
       - parent proxying not enabled
       - no parent selection strategy (using parent.config)
 
-    @param txnp HTTP transaction whose next hop strategy to get.
+    @param pointer to the NextHopStrategy.
 
  */
-char const *TSHttpNextHopStrategyNameGet(void const *strategy);
+char const *TSNextHopStrategyNameGet(void const *strategy);
 
 /**
     Retrieves a pointer to the named strategy in the strategy table.
-    Returns nullptr if no strategy is set.
-    This uses the current transaction's state machine to get
-    access to UrlRewrite's NextHopStrategyFactory.
+    This can only be called during TSRemapNewInstance.
+    DO NOT FREE.
 
-    @param txnp HTTP transaction which holds the strategy table.
+    Returns nullptr if no strategy found.
+    This uses the currently being loaded RemapConfig NextHopStrategyFactory.
+
     @param name of the strategy to look up.
 
  */
-void const *TSHttpTxnNextHopNamedStrategyGet(TSHttpTxn txnp, const char *name);
+void const *TSRemapNextHopStrategyFind(const char *name);
+
+/**
+    Retrieves a pointer to remap rule strategy pointer.
+    This can only be called during TSRemapNewInstance.
+    DO NOT FREE.
+
+    Returns nullptr if no strategy assigned.
+
+ */
+void const *TSRemapNextHopStrategyGet();
+
+/**
+    Sets the remap rule's next hop strategy.
+    This can only be called during TSRemapNewInstance.
+    DO NOT FREE.
+
+    This strategy must be present in the loading NextHopStrategyFactory.
+
+    @param handle to the strategy to set.
+
+ */
+void TSRemapNextHopStrategySet(void const *strategy);
 
 /**
     Sets the parent proxy name and port. The string hostname is copied

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1646,12 +1646,13 @@ ConditionNextHop::append_value(std::string &s, const Resources &res)
     s.append(std::to_string(port));
   } break;
   case NEXT_HOP_STRATEGY: {
-    char const *const name = TSHttpNextHopStrategyNameGet(res.state.txnp);
-    if (nullptr != name) {
+    void const *const strategy = TSHttpTxnNextHopStrategyGet(res.state.txnp);
+    if (nullptr != strategy) {
+      char const *const name = TSNextHopStrategyNameGet(strategy);
       Dbg(pi_dbg_ctl, "Appending '%s' to evaluation value", name);
       s.append(name);
     } else {
-      Dbg(pi_dbg_ctl, "NextHopStrategyName is empty");
+      Dbg(pi_dbg_ctl, "NextHopStrategy is empty");
     }
   } break;
   default:

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1646,7 +1646,7 @@ ConditionNextHop::append_value(std::string &s, const Resources &res)
     s.append(std::to_string(port));
   } break;
   case NEXT_HOP_STRATEGY: {
-    void const *const strategy = TSHttpTxnNextHopStrategyGet(res.state.txnp);
+    TSStrategy const strategy = TSHttpTxnNextHopStrategyGet(res.state.txnp);
     if (nullptr != strategy) {
       char const *const name = TSNextHopStrategyNameGet(strategy);
       Dbg(pi_dbg_ctl, "Appending '%s' to evaluation value", name);

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1645,44 +1645,47 @@ void
 OperatorSetNextHopStrategy::initialize(Parser &p)
 {
   Operator::initialize(p);
+  _stratname = p.get_arg();
 
-  _value.set_value(p.get_arg(), this);
-  Dbg(pi_dbg_ctl, "OperatorSetNextHopStrategy::initialie: %s", _value.get_value().c_str());
+  if (_stratname.empty() || "null" == _stratname) {
+    Dbg(pi_dbg_ctl, "OperatorSetNextHopStrategy() 'clear'");
+  } else {
+    _strategy = TSRemapNextHopStrategyFind(_stratname.c_str());
+    if (nullptr == _strategy) {
+      TSError("[%s] Failed to get strategy '%s'", PLUGIN_NAME, _stratname.c_str());
+      _apply = false;
+    } else {
+      Dbg(pi_dbg_ctl, "OperatorSetNextHopStrategy() '%s'", _stratname.c_str());
+    }
+  }
 }
 
 void
 OperatorSetNextHopStrategy::initialize_hooks()
 {
-  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
   add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
 }
 
 bool
 OperatorSetNextHopStrategy::exec(const Resources &res) const
 {
-  if (!res.state.txnp) {
-    TSError("[%s] OperatorSetNextHopStrategy() failed. Transaction is null", PLUGIN_NAME);
-  }
-
-  auto const txnp = res.state.txnp;
-
-  std::string value;
-  _value.append_value(value, res);
-
-  // Setting an empty strategy clears it for either parent.config or remap to
-  if ("null" == value || value.empty()) {
-    Dbg(pi_dbg_ctl, "Clearing strategy");
-    TSHttpTxnNextHopStrategySet(txnp, nullptr);
+  if (!_apply) {
+    Dbg(pi_dbg_ctl, "OperatorSetNextHopStrategy::exec: do nothing");
     return true;
   }
-
-  void const *const stratptr = TSHttpTxnNextHopNamedStrategyGet(txnp, value.c_str());
-  if (nullptr == stratptr) {
-    TSWarning("[%s] Failed to get strategy '%s'", PLUGIN_NAME, value.c_str());
-  } else {
-    Dbg(pi_dbg_ctl, "   Setting strategy '%s'", value.c_str());
-    TSHttpTxnNextHopStrategySet(txnp, stratptr);
+  auto const txnp = res.state.txnp;
+  if (!txnp) {
+    TSError("[%s] OperatorSetNextHopStrategy() failed. Transaction is null", PLUGIN_NAME);
+    return false;
   }
+
+  if (nullptr == _strategy) {
+    Dbg(pi_dbg_ctl, "OperatorSetNextHopStrategy::exec: Clearing strategy");
+  } else {
+    Dbg(pi_dbg_ctl, "OperatorSetNextHopStrategy::exec: Setting strategy to '%s'", _stratname.c_str());
+  }
+
+  TSHttpTxnNextHopStrategySet(txnp, _strategy);
 
   return true;
 }

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -696,7 +696,9 @@ protected:
   bool exec(const Resources &res) const override;
 
 private:
-  Value _value;
+  bool        _apply = true;
+  std::string _stratname;
+  void const *_strategy = nullptr;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -698,7 +698,7 @@ protected:
 private:
   bool        _apply = true;
   std::string _stratname;
-  void const *_strategy = nullptr;
+  TSStrategy  _strategy = nullptr;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/plugins/lua/ts_lua_http.cc
+++ b/plugins/lua/ts_lua_http.cc
@@ -537,7 +537,7 @@ ts_lua_http_get_next_hop_strategy(lua_State *L)
 
   void const *const stratptr = TSHttpTxnNextHopStrategyGet(http_ctx->txnp);
   if (nullptr != stratptr) {
-    name = TSHttpNextHopStrategyNameGet(stratptr);
+    name = TSNextHopStrategyNameGet(stratptr);
   }
 
   if (name == nullptr) {
@@ -569,7 +569,7 @@ ts_lua_http_set_next_hop_strategy(lua_State *L)
       Dbg(dbg_ctl, "Clearning strategy (use parent.config)");
       TSHttpTxnNextHopStrategySet(http_ctx->txnp, nullptr);
     } else {
-      void const *const stratptr = TSHttpTxnNextHopNamedStrategyGet(http_ctx->txnp, name);
+      void const *const stratptr = TSHttpTxnNextHopStrategyFind(http_ctx->txnp, name);
       if (nullptr == stratptr) {
         TSError("[ts_lua][%s] Failed get next hop strategy name '%s'", __FUNCTION__, name);
       } else {

--- a/plugins/lua/ts_lua_http.cc
+++ b/plugins/lua/ts_lua_http.cc
@@ -535,7 +535,7 @@ ts_lua_http_get_next_hop_strategy(lua_State *L)
 
   GET_HTTP_CONTEXT(http_ctx, L);
 
-  void const *const stratptr = TSHttpTxnNextHopStrategyGet(http_ctx->txnp);
+  TSStrategy const stratptr = TSHttpTxnNextHopStrategyGet(http_ctx->txnp);
   if (nullptr != stratptr) {
     name = TSNextHopStrategyNameGet(stratptr);
   }
@@ -569,7 +569,7 @@ ts_lua_http_set_next_hop_strategy(lua_State *L)
       Dbg(dbg_ctl, "Clearning strategy (use parent.config)");
       TSHttpTxnNextHopStrategySet(http_ctx->txnp, nullptr);
     } else {
-      void const *const stratptr = TSHttpTxnNextHopStrategyFind(http_ctx->txnp, name);
+      TSStrategy const stratptr = TSHttpTxnNextHopStrategyFind(http_ctx->txnp, name);
       if (nullptr == stratptr) {
         TSError("[ts_lua][%s] Failed get next hop strategy name '%s'", __FUNCTION__, name);
       } else {

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -232,7 +232,7 @@ public:
   {
     return _strategy_name;
   }
-  inline void const *
+  inline TSStrategy
   strategy_option() const
   {
     return _strategy;
@@ -276,7 +276,7 @@ private:
 
   bool        _has_strategy  = false;
   std::string _strategy_name = {};
-  void const *_strategy      = nullptr;
+  TSStrategy  _strategy      = nullptr;
 
   Override *_first_override = nullptr;
   int       _sub_pos[MAX_SUBS];

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -326,7 +326,7 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
       _lowercase_substitutions = true;
     } else if (opt.compare(start, 8, "strategy") == 0) {
       _has_strategy  = true;
-      _strategy_name = std::move(opt_val);
+      _strategy_name = opt_val;
       if (!_strategy_name.empty() && "null" != _strategy_name) {
         _strategy = TSRemapNextHopStrategyFind(_strategy_name.c_str());
         if (nullptr == _strategy) {

--- a/plugins/regex_remap/regex_remap.cc
+++ b/plugins/regex_remap/regex_remap.cc
@@ -223,12 +223,17 @@ public:
     return _lowercase_substitutions;
   }
   inline bool
-  has_strategy() const
+  has_strategy_option() const
   {
     return _has_strategy;
   }
   inline std::string const &
-  strategy() const
+  strategy_name_option() const
+  {
+    return _strategy_name;
+  }
+  inline void const *
+  strategy_option() const
   {
     return _strategy;
   }
@@ -269,8 +274,9 @@ private:
   int _connect_timeout     = -1;
   int _dns_timeout         = -1;
 
-  bool        _has_strategy = false;
-  std::string _strategy     = {};
+  bool        _has_strategy  = false;
+  std::string _strategy_name = {};
+  void const *_strategy      = nullptr;
 
   Override *_first_override = nullptr;
   int       _sub_pos[MAX_SUBS];
@@ -319,8 +325,15 @@ RemapRegex::initialize(const std::string &reg, const std::string &sub, const std
     } else if (opt.compare(start, 23, "lowercase_substitutions") == 0) {
       _lowercase_substitutions = true;
     } else if (opt.compare(start, 8, "strategy") == 0) {
-      _has_strategy = true;
-      _strategy     = std::move(opt_val);
+      _has_strategy  = true;
+      _strategy_name = std::move(opt_val);
+      if (!_strategy_name.empty() && "null" != _strategy_name) {
+        _strategy = TSRemapNextHopStrategyFind(_strategy_name.c_str());
+        if (nullptr == _strategy) {
+          TSError("[%s] Unable to resolve strategy: '%s'", PLUGIN_NAME, opt_val.c_str());
+          _has_strategy = false; // disable the strategy action
+        }
+      }
     } else if (opt_val.size() <= 0) {
       // All other options have a required value
       TSError("[%s] Malformed options: %s", PLUGIN_NAME, opt.c_str());
@@ -975,20 +988,14 @@ TSRemapDoRemap(void *ih, TSHttpTxn txnp, TSRemapRequestInfo *rri)
         Dbg(dbg_ctl, "Setting DNS timeout to %d", re->dns_timeout_option());
         TSHttpTxnDNSTimeoutSet(txnp, re->dns_timeout_option());
       }
-      if (re->has_strategy()) {
-        auto const &strat = re->strategy();
-        if (strat.empty() || "null" == strat) {
+      if (re->has_strategy_option()) {
+        auto const strat = re->strategy_option();
+        if (nullptr == strat) {
           Dbg(dbg_ctl, "Clearing strategy (use parent.config)");
-          TSHttpTxnNextHopStrategySet(txnp, nullptr);
         } else {
-          void const *const stratptr = TSHttpTxnNextHopNamedStrategyGet(txnp, strat.c_str());
-          if (nullptr == stratptr) {
-            Dbg(dbg_ctl, "No strategy found with name '%s'", strat.c_str());
-          } else {
-            Dbg(dbg_ctl, "Setting strategy to %s", strat.c_str());
-            TSHttpTxnNextHopStrategySet(txnp, stratptr);
-          }
+          Dbg(dbg_ctl, "Setting strategy to %s", re->strategy_name_option().c_str());
         }
+        TSHttpTxnNextHopStrategySet(txnp, strat);
       }
       bool lowercase_substitutions = false;
       if (re->lowercase_substitutions_option() == true) {

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -5023,17 +5023,17 @@ TSHttpTxnServerRequestBodySet(TSHttpTxn txnp, char *buf, int64_t buflength)
   s->internal_msg_buffer_fast_allocator_size = -1;
 }
 
-void const *
+TSStrategy
 TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
 
   auto sm = reinterpret_cast<HttpSM const *>(txnp);
 
-  return static_cast<void *>(sm->t_state.next_hop_strategy);
+  return reinterpret_cast<TSStrategy>(sm->t_state.next_hop_strategy);
 }
 
-void const *
+TSStrategy
 TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
@@ -5046,30 +5046,29 @@ TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name)
 
   // HttpSM has a reference count handle to UrlRewrite which has a
   // pointer to NextHopStrategyFactory
-  NextHopSelectionStrategy const *const strategy = sm->m_remap->strategyFactory->strategyInstance(name);
+  NextHopSelectionStrategy *const strategy = sm->m_remap->strategyFactory->strategyInstance(name);
 
-  return static_cast<void const *>(strategy);
+  return reinterpret_cast<TSStrategy>(strategy);
 }
 
 void
-TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const *stratptr)
+TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, TSStrategy stratptr)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   // null strategy falls back to parent.config
   // sdk_assert(sdk_sanity_check_null_ptr(stratptr) == TS_SUCCESS);
 
   auto sm                       = reinterpret_cast<HttpSM *>(txnp);
-  auto strategy                 = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
-  sm->t_state.next_hop_strategy = const_cast<NextHopSelectionStrategy *>(strategy);
+  sm->t_state.next_hop_strategy = reinterpret_cast<NextHopSelectionStrategy *>(stratptr);
 }
 
-void const *
+TSStrategy
 TSRemapNextHopStrategyFind(const char *name)
 {
   auto const um = url_mapping::instance;
   sdk_assert(sdk_sanity_check_null_ptr((void *)um) == TS_SUCCESS);
 
-  NextHopSelectionStrategy const *strategy = nullptr;
+  NextHopSelectionStrategy *strategy = nullptr;
 
   if (nullptr != um->strategyFactory) {
     // HttpSM has a reference count handle to UrlRewrite which manages
@@ -5077,36 +5076,35 @@ TSRemapNextHopStrategyFind(const char *name)
     strategy = um->strategyFactory->strategyInstance(name);
   }
 
-  return static_cast<void const *>(strategy);
+  return reinterpret_cast<TSStrategy>(strategy);
 }
 
 void
-TSRemapNextHopStrategySet(void const *stratptr)
+TSRemapNextHopStrategySet(TSStrategy strategy)
 {
   auto const um = url_mapping::instance;
   sdk_assert(sdk_sanity_check_null_ptr((void *)um) == TS_SUCCESS);
   // null strategy falls back to parent.config
   // sdk_assert(sdk_sanity_check_null_ptr(stratptr) == TS_SUCCESS);
 
-  auto strategy = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
-  um->strategy  = const_cast<NextHopSelectionStrategy *>(strategy);
+  um->strategy = reinterpret_cast<NextHopSelectionStrategy *>(strategy);
 }
 
-void const *
+TSStrategy
 TSRemapNextHopStrategyGet()
 {
   auto const um = url_mapping::instance;
   sdk_assert(sdk_sanity_check_null_ptr((void *)um) == TS_SUCCESS);
-
-  return static_cast<void *>(um->strategy);
+  return reinterpret_cast<TSStrategy>(um->strategy);
 }
 
 char const *
-TSNextHopStrategyNameGet(void const *stratptr)
+TSNextHopStrategyNameGet(TSStrategy stratptr)
 {
-  char const *name = nullptr;
+  static char const *const nullname = "null";
+  char const              *name     = nullname;
   if (nullptr != stratptr) {
-    auto strategy = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
+    auto strategy = reinterpret_cast<NextHopSelectionStrategy *>(stratptr);
     name          = strategy->strategy_name.c_str();
   }
 

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -5033,33 +5033,8 @@ TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp)
   return static_cast<void *>(sm->t_state.next_hop_strategy);
 }
 
-void
-TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const *stratptr)
-{
-  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
-  // null strategy falls back to parent.config
-  // sdk_assert(sdk_sanity_check_null_ptr(strategy) == TS_SUCCESS);
-
-  auto sm       = reinterpret_cast<HttpSM *>(txnp);
-  auto strategy = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
-
-  sm->t_state.next_hop_strategy = const_cast<NextHopSelectionStrategy *>(strategy);
-}
-
-char const *
-TSHttpNextHopStrategyNameGet(void const *stratptr)
-{
-  char const *name = nullptr;
-  if (nullptr != stratptr) {
-    auto strategy = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
-    name          = strategy->strategy_name.c_str();
-  }
-
-  return name;
-}
-
 void const *
-TSHttpTxnNextHopNamedStrategyGet(TSHttpTxn txnp, const char *name)
+TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
   sdk_assert(sdk_sanity_check_null_ptr((void *)name) == TS_SUCCESS);
@@ -5071,9 +5046,71 @@ TSHttpTxnNextHopNamedStrategyGet(TSHttpTxn txnp, const char *name)
 
   // HttpSM has a reference count handle to UrlRewrite which has a
   // pointer to NextHopStrategyFactory
-  NextHopSelectionStrategy const *const strat = sm->m_remap->strategyFactory->strategyInstance(name);
+  NextHopSelectionStrategy const *const strategy = sm->m_remap->strategyFactory->strategyInstance(name);
 
-  return static_cast<void const *>(strat);
+  return static_cast<void const *>(strategy);
+}
+
+void
+TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, void const *stratptr)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  // null strategy falls back to parent.config
+  // sdk_assert(sdk_sanity_check_null_ptr(stratptr) == TS_SUCCESS);
+
+  auto sm                       = reinterpret_cast<HttpSM *>(txnp);
+  auto strategy                 = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
+  sm->t_state.next_hop_strategy = const_cast<NextHopSelectionStrategy *>(strategy);
+}
+
+void const *
+TSRemapNextHopStrategyFind(const char *name)
+{
+  auto const um = url_mapping::instance;
+  sdk_assert(sdk_sanity_check_null_ptr((void *)um) == TS_SUCCESS);
+
+  NextHopSelectionStrategy const *strategy = nullptr;
+
+  if (nullptr != um->strategyFactory) {
+    // HttpSM has a reference count handle to UrlRewrite which manages
+    // the NextHopStrategyFactory pointer.
+    strategy = um->strategyFactory->strategyInstance(name);
+  }
+
+  return static_cast<void const *>(strategy);
+}
+
+void
+TSRemapNextHopStrategySet(void const *stratptr)
+{
+  auto const um = url_mapping::instance;
+  sdk_assert(sdk_sanity_check_null_ptr((void *)um) == TS_SUCCESS);
+  // null strategy falls back to parent.config
+  // sdk_assert(sdk_sanity_check_null_ptr(stratptr) == TS_SUCCESS);
+
+  auto strategy = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
+  um->strategy  = const_cast<NextHopSelectionStrategy *>(strategy);
+}
+
+void const *
+TSRemapNextHopStrategyGet()
+{
+  auto const um = url_mapping::instance;
+  sdk_assert(sdk_sanity_check_null_ptr((void *)um) == TS_SUCCESS);
+
+  return static_cast<void *>(um->strategy);
+}
+
+char const *
+TSNextHopStrategyNameGet(void const *stratptr)
+{
+  char const *name = nullptr;
+  if (nullptr != stratptr) {
+    auto strategy = reinterpret_cast<NextHopSelectionStrategy const *>(stratptr);
+    name          = strategy->strategy_name.c_str();
+  }
+
+  return name;
 }
 
 TSReturnCode

--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -3541,7 +3541,7 @@ mytest_handler(TSCont contp, TSEvent event, void *data)
 
     // Set the strategy pointer here
     // this is an invalid pointer but the contents don't matter for this test.
-    TSHttpTxnNextHopStrategySet(static_cast<TSHttpTxn>(data), (void *)0x01);
+    TSHttpTxnNextHopStrategySet(static_cast<TSHttpTxn>(data), (TSStrategy)0x01);
 
     checkHttpTxnClientReqGet(test, data);
 

--- a/src/proxy/http/remap/RemapConfig.cc
+++ b/src/proxy/http/remap/RemapConfig.cc
@@ -120,7 +120,6 @@ clear_xstr_array(char *v[], size_t vsize)
 }
 
 BUILD_TABLE_INFO::BUILD_TABLE_INFO()
-
 {
   memset(this->paramv, 0, sizeof(this->paramv));
   memset(this->argv, 0, sizeof(this->argv));
@@ -1500,6 +1499,9 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti, ConfigContext ct
       }
     }
 
+    // Set up for ts API for strategies
+    new_mapping->strategyFactory = bti->rewrite->strategyFactory;
+
     // Check "remap" plugin options and load .so object
     if ((bti->remap_optflg & REMAP_OPTFLG_PLUGIN) != 0 &&
         (maptype == mapping_type::FORWARD_MAP || maptype == mapping_type::FORWARD_MAP_REFERER ||
@@ -1508,6 +1510,9 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti, ConfigContext ct
         int plugin_found_at = 0;
         int jump_to_argc    = 0;
 
+        // Set up for ts API for strategies
+        url_mapping::instance = new_mapping;
+
         // this loads the first plugin
         if (!remap_load_plugin(bti->argv, bti->argc, new_mapping, errStrBuf, sizeof(errStrBuf), 0, &plugin_found_at,
                                bti->rewrite)) {
@@ -1515,6 +1520,7 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti, ConfigContext ct
           errStr = errStrBuf;
           goto MAP_ERROR;
         }
+
         // this loads any subsequent plugins (if present)
         while (plugin_found_at) {
           jump_to_argc += plugin_found_at;
@@ -1525,6 +1531,8 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti, ConfigContext ct
             goto MAP_ERROR;
           }
         }
+
+        url_mapping::instance = nullptr;
       }
     }
 
@@ -1545,6 +1553,8 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti, ConfigContext ct
 
     snprintf(errBuf, sizeof(errBuf), "%s failed to add remap rule at %s line %d: %s", modulePrefix, path, cln + 1, errStr);
     CfgLoadLog(ctx, DL_Error, "%s", errBuf);
+
+    url_mapping::instance = nullptr;
 
     delete reg_map;
     delete new_mapping;


### PR DESCRIPTION
This gives the API access to the RemapConfig `url_mapping` during TSRemapNewInstance calls.  This contains both the assigned stragies pointer and a pointer to the loaded strategy factory.

This modifies the strategies ts API from the previous PR.

API is:

valid during TSRemapNewInstance:
```
TSStrategy TSRemapNextHopStrategyFind(const char *name);
TSStrategy TSRemapNextHopStrategyGet();
void TSRemapNextHopStrategySet(TSStrategy strategy);
```

valid during transaction (the Find call is changed):
```
TSStrategy TSHttpTxnNextHopStrategyFind(TSHttpTxn txnp, const char *name);
TSStrategy TSHttpTxnNextHopStrategyGet(TSHttpTxn txnp);
void TSHttpTxnNextHopStrategySet(TSHttpTxn txnp, TSStrategy strategy);
```

with utility function to get the null terminated strategy name (returns "null" if nullptr strategy):
```
char const *TSNextHopStrategyNameGet(TSStrategy strategy);
```

The header_rewrite and regex_remap plugins are modified to look up named strategies during TSRemapNewInstance instead of performing strategy factory lookups during each transaction remap hook.