### PR TITLE
Fix crash when ESI plugin exceeds max_doc_size limit

### DIFF
--- a/plugins/esi/esi.cc
+++ b/plugins/esi/esi.cc
@@ -837,8 +837,8 @@ transformData(TSCont contp)
     CONT_DATA_DBG(cont_data, "[%s] trying to process doc", __FUNCTION__);
     string                   out_data;
     string                   cdata;
-    int                      overall_len;
-    EsiProcessor::ReturnCode retval = cont_data->esi_proc->flush(out_data, overall_len);
+    int                      overall_len = 0;
+    EsiProcessor::ReturnCode retval      = cont_data->esi_proc->flush(out_data, overall_len);
 
     if ((cont_data->curr_state == ContData::FETCHING_DATA) && cont_data->data_fetcher->isFetchComplete()) {
       CONT_DATA_DBG(cont_data, "[%s] data ready; last process() will have finished the entire processing", __FUNCTION__);

--- a/plugins/esi/lib/EsiProcessor.cc
+++ b/plugins/esi/lib/EsiProcessor.cc
@@ -352,6 +352,8 @@ EsiProcessor::ReturnCode
 EsiProcessor::flush(string &data, int &overall_len)
 {
   if (_curr_state == ERRORED) {
+    overall_len = 0;
+    data.assign("");
     return FAILURE;
   }
   if (_curr_state == PROCESSED) {


### PR DESCRIPTION
When ESI documents exceeded the configured max_doc_size, ATS would crash with an assertion failure in TSVIONBytesSet() due to passing an uninitialized value. The crash occurred because the overall_len variable in transformData() was declared but not initialized, and EsiProcessor::flush() would return FAILURE without setting output parameters when in an ERRORED state. This fix initializes overall_len to 0, ensures flush() sets valid output parameters before returning FAILURE. The connection now closes gracefully when the limit is exceeded.