### PR TITLE
Fix setting HostDBRecord::record_type

### DIFF
--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -21,6 +21,7 @@
   limitations under the License.
  */
 
+#include "iocore/hostdb/HostDBProcessor.h"
 #include "swoc/swoc_file.h"
 #include "tscore/Regression.h"
 #include "tsutil/ts_bw_format.h"
@@ -740,20 +741,17 @@ HostDBContinuation::lookup_done(TextView query_name, ts_seconds answer_ttl, SRVH
   if (query_name.empty()) {
     if (hash.is_byname()) {
       Dbg(dbg_ctl_hostdb, "lookup_done() failed for '%.*s'", int(hash.host_name.size()), hash.host_name.data());
+      record->record_type = HostDBType::ADDR;
     } else if (hash.is_srv()) {
       Dbg(dbg_ctl_dns_srv, "SRV failed for '%.*s'", int(hash.host_name.size()), hash.host_name.data());
+      record->record_type = HostDBType::SRV;
     } else {
       ip_text_buffer b;
       Dbg(dbg_ctl_hostdb, "failed for %s", hash.ip.toString(b, sizeof b));
+      record->record_type = HostDBType::HOST;
     }
     record->ip_timestamp        = hostdb_current_timestamp;
     record->ip_timeout_interval = ts_seconds(std::clamp(hostdb_ip_fail_timeout_interval, 1u, HOST_DB_MAX_TTL));
-
-    if (hash.is_srv()) {
-      record->record_type = HostDBType::SRV;
-    } else if (!hash.is_byname()) {
-      record->record_type = HostDBType::HOST;
-    }
 
     record->set_failed();
 
@@ -785,6 +783,7 @@ HostDBContinuation::lookup_done(TextView query_name, ts_seconds answer_ttl, SRVH
 
     if (hash.is_byname()) {
       Dbg_bw(dbg_ctl_hostdb, "done {} TTL {}", hash.host_name, answer_ttl);
+      record->record_type = HostDBType::ADDR;
     } else if (hash.is_srv()) {
       ink_assert(srv && srv->hosts.size() && srv->hosts.size() <= hostdb_round_robin_max_count);
 


### PR DESCRIPTION
I noticed many HostDBRecored are `UNSPEC` while testing new `traffic_ctl hostdb status` cmd (
https://github.com/apache/trafficserver/pull/12603).

It looks like `HostDBContinuation::lookup_done` should set the `record_type`, but setting `HostDBType::ADDR` is missing in some case.