### PR TITLE
Expose PCRE2 error codes in tsutils Regex.h API

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -33,10 +33,18 @@
 /// @internal These values are copied from pcre2.h, to avoid having to include it.  The values are checked (with
 /// static_assert) in Regex.cc against PCRE2 named constants, in case they change in future PCRE2 releases.
 enum REFlags {
-  RE_CASE_INSENSITIVE = 0x00000008u, ///< Ignore case (default: case sensitive).
-  RE_UNANCHORED       = 0x00000400u, ///< Unanchored (DFA defaults to anchored).
-  RE_ANCHORED         = 0x80000000u, ///< Anchored (Regex defaults to unanchored).
-  RE_NOTEMPTY         = 0x00000004u  ///< Not empty (default: may match empty string).
+  RE_CASE_INSENSITIVE = 0x00000008u, ///< Ignore case (by default, matches are case sensitive).
+  RE_UNANCHORED       = 0x00000400u, ///< Unanchored (@a DFA defaults to anchored).
+  RE_ANCHORED         = 0x80000000u, ///< Anchored (@a Regex defaults to unanchored).
+  RE_NOTEMPTY         = 0x00000004u  ///< Not empty (by default, matches may match empty string).
+};
+
+/// @brief Error codes returned by regular expression operations.
+///
+/// @internal As with REFlags, these values are copied from pcre2.h, to avoid having to include it.
+enum REErrors {
+  RE_ERROR_NOMATCH = -1, ///< No match found.
+  RE_ERROR_NULL    = -51 ///< NULL code or subject was passed.
 };
 
 /// @brief Wrapper for PCRE2 match data.

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -36,6 +36,9 @@ static_assert(RE_UNANCHORED == PCRE2_MULTILINE, "Update RE_UNANCHORED for curren
 static_assert(RE_ANCHORED == PCRE2_ANCHORED, "Update RE_ANCHORED for current PCRE2 version.");
 static_assert(RE_NOTEMPTY == PCRE2_NOTEMPTY, "Update RE_NOTEMPTY for current PCRE2 version.");
 
+static_assert(RE_ERROR_NOMATCH == PCRE2_ERROR_NOMATCH, "Update RE_ERROR_NOMATCH for current PCRE2 version.");
+static_assert(RE_ERROR_NULL == PCRE2_ERROR_NULL, "Update RE_ERROR_NULL for current PCRE2 version.");
+
 //----------------------------------------------------------------------------
 namespace
 {


### PR DESCRIPTION
Add REErrors enum to Regex.h to encapsulate PCRE2 error codes, allowing users to check for specific error conditions without needing to include pcre2.h directly. For now, the enum includes RE_ERROR_NOMATCH (-1) for when no match is found and RE_ERROR_NULL (-51) for when NULL code or subject is passed.