### PR TITLE
Find dot cmd for docs build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,8 @@ if(ENABLE_DOCS)
     COMPONENTS Runtime
     REQUIRED
   )
+
+  find_program(GRAPHVIZ_DOT dot REQUIRED)
 endif()
 
 if(ENABLE_AUTEST)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -57,6 +57,7 @@ set(UML_FILES
     uml/extras/config-data.plantuml
     uml/extras/txn_box_config_schema.plantuml
 )
+
 # unfortunately, sphinx can't look else for files than its source directory
 # so these files must be create in the source tree
 foreach(UML ${UML_FILES})
@@ -64,8 +65,8 @@ foreach(UML ${UML_FILES})
   list(APPEND SVG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/uml/images/${uml_name}.svg)
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/uml/images/${uml_name}.svg
-    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_JAR} -o ${CMAKE_CURRENT_SOURCE_DIR}/uml/images -tsvg
-            ${CMAKE_CURRENT_SOURCE_DIR}/${UML}
+    COMMAND ${Java_JAVA_EXECUTABLE} -jar ${PLANTUML_JAR} -o ${CMAKE_CURRENT_SOURCE_DIR}/uml/images -tsvg -graphvizdot
+            ${GRAPHVIZ_DOT} ${CMAKE_CURRENT_SOURCE_DIR}/${UML}
     DEPENDS ${UML}
     VERBATIM
   )


### PR DESCRIPTION
PlantUML uses `/usr/bin/dot` as default it makes error in some env.

This changes find the `dot` program and set it for`-graphvizdot` option of `plantuml`.