### PR TITLE
Fix nonnull warning in uri_signing unit tests

### DIFF
--- a/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
+++ b/plugins/experimental/uri_signing/unit_tests/uri_signing_test.cc
@@ -227,13 +227,11 @@ jws_parsing_helper(const char *uri, const char *paramName, const char *expected_
     resp = true;
     if (expected_strip != nullptr) {
       if (strcmp(uri_strip, expected_strip) != 0) {
-        cjose_jws_release(jws);
         resp = false;
       }
     } else {
       // expected_strip == nullptr means we expect uri_strip to be empty
       if (uri_strip[0] != '\0') {
-        cjose_jws_release(jws);
         resp = false;
       }
     }


### PR DESCRIPTION
Fixes Fedora 41 gcc release build failure.

Add `nullptr` check before `strcmp` to satisfy GCC's `-Werror=nonnull` warning. The `expected_strip` parameter can be `nullptr` in some test cases (lines 325, 330, 362, 371, 376), so we need to check for null before passing to `strcmp`.

**Error:**
```
error: argument 2 null where non-null expected [-Werror=nonnull]
  228 |     if (strcmp(uri_strip, expected_strip) != 0) {
```

**Affected Builds:**
- Fedora 41 gcc release
