### PR TITLE
fedora:43 autest updates

### DIFF
--- a/tests/gold_tests/h2/trickle_client.py
+++ b/tests/gold_tests/h2/trickle_client.py
@@ -17,7 +17,6 @@
 #  limitations under the License.
 
 import argparse
-from email.message import EmailMessage as HttpHeaders
 import logging
 import math
 import socket
@@ -252,11 +251,7 @@ def send_http2_request_to_server(hostname: str, port: int, cert_file: str, write
     :return: 0 if the request was successful, 1 otherwise.
     """
 
-    request_headers = HttpHeaders()
-    request_headers.add_header(':method', 'GET')
-    request_headers.add_header(':path', '/some/path')
-    request_headers.add_header(':authority', hostname)
-    request_headers.add_header(':scheme', 'https')
+    request_headers = {':method': 'GET', ':path': '/some/path', ':authority': hostname, ':scheme': 'https'}
 
     scheme = request_headers[':scheme']
     replay_server = f"127.0.0.1:{port}"

--- a/tests/gold_tests/tls/tls_check_dual_cert_selection_plugin.test.py
+++ b/tests/gold_tests/tls/tls_check_dual_cert_selection_plugin.test.py
@@ -90,7 +90,7 @@ tr.Processes.Default.StartBefore(dns)
 tr.Processes.Default.StartBefore(Test.Processes.ts, ready=When.PortOpen(ts.Variables.ssl_port))
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (ECDSA|ecdsa_)", "Should select EC cert")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # Should receive a RSA cert
@@ -100,7 +100,7 @@ tr.Processes.Default.Command = "echo foo | openssl s_client  -CAfile signer.pem 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (RSA-PSS|rsa_pss_)", "Should select RSA cert")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
 # Should receive a EC cert
@@ -110,7 +110,7 @@ tr.Processes.Default.Command = "echo foo | openssl s_client  -CAfile signer.pem 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (ECDSA|ecdsa_)", "Should select EC cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
@@ -121,7 +121,7 @@ tr.Processes.Default.Command = "echo foo | openssl s_client  -CAfile signer.pem 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (RSA-PSS|rsa_pss_)", "Should select RSA cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
@@ -132,7 +132,7 @@ tr.Processes.Default.Command = "echo foo | openssl s_client  -CAfile signer.pem 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (RSA-PSS|rsa_pss_)", "Should select RSA cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
@@ -143,7 +143,7 @@ tr.Processes.Default.Command = "echo foo | openssl s_client  -CAfile signer.pem 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (ECDSA|ecdsa_)", "Should select EC cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?group.com", "Should select a group SAN")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
@@ -169,7 +169,7 @@ tr.DelayStart = 4
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (RSA-PSS|rsa_pss_)", "Should select RSA cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?foo.com", "Should select foo.com")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("unable to verify the first certificate", "Different signer")
 
@@ -179,7 +179,7 @@ tr.Processes.Default.Command = "echo foo | openssl s_client -CAfile signer2.pem 
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: RSA-PSS", "Should select RSA cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (RSA-PSS|rsa_pss_)", "Should select RSA cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?foo.com", "Should select foo.com")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")
 
@@ -190,6 +190,6 @@ tr.Processes.Default.Command = "echo foo | openssl s_client -CAfile signer.pem  
 tr.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: ECDSA", "Should select EC cert")
+tr.Processes.Default.Streams.All += Testers.ContainsExpression("Peer signature type: (ECDSA|ecdsa_)", "Should select EC cert")
 tr.Processes.Default.Streams.All += Testers.ContainsExpression("CN ?= ?foo.com", "Should select foo.com")
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression("unable to verify the first certificate", "Correct signer")


### PR DESCRIPTION
This updates two autests that were failing on fedora:43:

* Python 3.14: The http2_write_threshold trickle python scripts did not work on the newer Python 3.14, which is bit more strict about possibly uninitialized variables. fedora:43 uses Python 3.14 instead of the Python 3.13 of fedora:42. This tweaks the scripts to make Python 3.14 happy.
* openssl 3.5 s_client output: The tls_check_dual_cert_selection_plugin expected different output from s_client. fedora:42 used openssl 3.2, fedora:43 has openssl 3.5. This updates the regex expectations for cert information to match for both versions.