### PR TITLE
tools -  traffic_ctl, traffic_layout: use ArgParse groups to handle mutually exclusive options.

### DIFF
--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -182,7 +182,7 @@ main([[maybe_unused]] int argc, const char **argv)
   auto &drain_cmd = server_command.add_command("drain", "Drain the requests", [&]() { command->execute(); });
   drain_cmd.add_example_usage("traffic_ctl server drain [OPTIONS]");
 
-  // Mutually exclusive drain mode options (auto-creates group)
+  drain_cmd.add_mutex_group("drain_mode", false, "Drain mode options");
   drain_cmd.add_option_to_group("drain_mode", "--no-new-connection", "-N",
                                 "Wait for new connections down to threshold before starting draining");
   drain_cmd.add_option_to_group("drain_mode", "--undo", "-U", "Recover server from the drain mode");

--- a/src/traffic_layout/traffic_layout.cc
+++ b/src/traffic_layout/traffic_layout.cc
@@ -46,7 +46,7 @@ main([[maybe_unused]] int argc, const char **argv)
 
   // info command
   auto &info_cmd = engine.parser.add_command("info", "Show the layout as default", [&]() { engine.info(); });
-  // Mutually exclusive display modes
+  info_cmd.add_mutex_group("display_mode", false, "Display mode options");
   info_cmd.add_option_to_group("display_mode", "--features", "", "Show the compiled features");
   info_cmd.add_option_to_group("display_mode", "--versions", "", "Show various library and other versioning information");
 


### PR DESCRIPTION
Make sure we express the intentions properly, using mutex groups from ArgParse.
~~https://github.com/apache/trafficserver/pull/12621 needs to go in first, I'll leave this as draft till we get the first pr sorted.~~ DONE

traffic_ctl:
```
Usage: traffic_ctl [OPTIONS] CMD [ARGS ...]

Commands ---------------------- Description -----------------------
drain                           Drain the requests

Options ======================= Default ===== Description =============

Group (drain_mode)
  -N, --no-new-connection                     Wait for new connections down to threshold before starting draining
  -U, --undo                                  Recover server from the drain mode
```

traffic_layout:
```
Usage: traffic_layout CMD [OPTIONS]

Commands ---------------------- Description -----------------------
info                            Show the layout as default

Options ======================= Default ===== Description =============
-j, --json                                    Produce output in JSON format (when supported)

Group (display_mode)
  --features                                  Show the compiled features
  --versions                                  Show various library and other versioning information
```

relates to https://github.com/apache/trafficserver/issues/12605