### PR TITLE
Cleanup: Remove unused handlers of HttpSM

### DIFF
--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -357,11 +357,8 @@ private:
   int state_read_client_request_header(int event, void *data);
   int state_watch_for_client_abort(int event, void *data);
   int state_read_push_response_header(int event, void *data);
-  int state_pre_resolve(int event, void *data);
   int state_hostdb_lookup(int event, void *data);
   int state_hostdb_reverse_lookup(int event, void *data);
-  int state_mark_os_down(int event, void *data);
-  int state_auth_callback(int event, void *data);
   int state_add_to_list(int event, void *data);
   int state_remove_from_list(int event, void *data);
 

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2356,13 +2356,6 @@ HttpSM::process_hostdb_info(HostDBRecord *record)
   }
 }
 
-int
-HttpSM::state_pre_resolve(int event, void * /* data ATS_UNUSED */)
-{
-  STATE_ENTER(&HttpSM::state_hostdb_lookup, event);
-  return 0;
-}
-
 //////////////////////////////////////////////////////////////////////////////
 //
 //  HttpSM::state_hostdb_lookup()
@@ -2431,31 +2424,6 @@ HttpSM::state_hostdb_reverse_lookup(int event, void *data)
   }
 
   return 0;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-//
-//  HttpSM:state_mark_os_down()
-//
-//////////////////////////////////////////////////////////////////////////////
-int
-HttpSM::state_mark_os_down(int event, void *data)
-{
-  STATE_ENTER(&HttpSM::state_mark_os_down, event);
-
-  if (event == EVENT_HOST_DB_LOOKUP && data) {
-    auto r = static_cast<HostDBRecord *>(data);
-
-    // Look for the entry we need mark down in the round robin
-    ink_assert(t_state.current.server != nullptr);
-    ink_assert(t_state.dns_info.looking_up == ResolveInfo::ORIGIN_SERVER);
-    if (auto *info = r->find(&t_state.dns_info.addr.sa); info != nullptr) {
-      info->mark_down(ts_clock::now());
-    }
-  }
-  // We either found our entry or we did not.  Either way find
-  //  the entry we should use now
-  return state_hostdb_lookup(event, data);
 }
 
 /////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Two HostDB related handers are not used.
```
int state_pre_resolve(int event, void *data);
int state_mark_os_down(int event, void *data);
```

This handler is declared but doesn't have definition.
```
int state_auth_callback(int event, void *data);
```
