### PR TITLE
records: Accept `const char*` in `RecSetRecordString` to avoid const_cast.

### DIFF
--- a/include/records/RecCore.h
+++ b/include/records/RecCore.h
@@ -161,7 +161,7 @@ void Enable_Config_Var(std::string_view const &name, RecContextCb record_cb, Rec
 
 RecErrT RecSetRecordInt(const char *name, RecInt rec_int, RecSourceT source, bool lock = true);
 RecErrT RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool lock = true);
-RecErrT RecSetRecordString(const char *name, const RecString rec_string, RecSourceT source, bool lock = true);
+RecErrT RecSetRecordString(const char *name, RecStringConst rec_string, RecSourceT source, bool lock = true);
 RecErrT RecSetRecordCounter(const char *name, RecCounter rec_counter, RecSourceT source, bool lock = true);
 
 std::optional<RecInt>           RecGetRecordInt(const char *name, bool lock = true);

--- a/src/mgmt/rpc/handlers/config/Configuration.cc
+++ b/src/mgmt/rpc/handlers/config/Configuration.cc
@@ -95,7 +95,7 @@ namespace
         return false;
       }
     } else if constexpr (std::is_same_v<T, std::string>) {
-      if (RecSetRecordString(info.name.c_str(), const_cast<char *>(info.value.c_str()), REC_SOURCE_DEFAULT) != REC_ERR_OKAY) {
+      if (RecSetRecordString(info.name.c_str(), info.value.c_str(), REC_SOURCE_DEFAULT) != REC_ERR_OKAY) {
         return false;
       }
     }

--- a/src/records/P_RecCore.cc
+++ b/src/records/P_RecCore.cc
@@ -230,10 +230,10 @@ RecSetRecordFloat(const char *name, RecFloat rec_float, RecSourceT source, bool 
 }
 
 RecErrT
-RecSetRecordString(const char *name, const RecString rec_string, RecSourceT source, bool lock)
+RecSetRecordString(const char *name, RecStringConst rec_string, RecSourceT source, bool lock)
 {
   RecData data;
-  data.rec_string = rec_string;
+  data.rec_string = const_cast<RecString>(rec_string);
   return RecSetRecord(RECT_NULL, name, RECD_STRING, &data, nullptr, source, lock);
 }
 


### PR DESCRIPTION
Didn't like how the cast was used in the caller, so now the cast is  hidden in one place (implementation detail).

API changed but it's just internal .