### PR TITLE
Fix scheme detection via port for regex remap

### DIFF
--- a/src/proxy/http/remap/UrlRewrite.cc
+++ b/src/proxy/http/remap/UrlRewrite.cc
@@ -1016,7 +1016,7 @@ UrlRewrite::_regexMappingLookup(RegexMappingList &regex_mappings, URL *request_u
   // If the scheme is empty (e.g. because of a CONNECT method), guess it based on port
   // This is equivalent to the logic in UrlMappingPathIndex::_GetTrie().
   if (request_scheme.empty()) {
-    request_scheme = std::string_view{80 ? URL_SCHEME_HTTP : URL_SCHEME_HTTPS};
+    request_scheme = std::string_view{request_port == 80 ? URL_SCHEME_HTTP : URL_SCHEME_HTTPS};
   }
 
   // Loop over the entire linked list, or until we're satisfied


### PR DESCRIPTION
The ternary operator was checking literal 80 instead of request_port == 80, making an accidental tautology that always returned the HTTP scheme. This was introduced in the #12243 URL std::string_view refactor.

---

For reference, here's a link to the previous code:
https://github.com/apache/trafficserver/pull/12243/files#diff-4ba856cb52d86339783fd72f06f834f43ef3c1225c45ec735353fdd7b9aa1da4L1021