### PR TITLE
Fix DNS error logging to use ERR_DNS_FAIL

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1916,7 +1916,7 @@ HttpTransact::OSDNSLookup(State *s)
       SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
       if (!s->dns_info.record || s->dns_info.record->is_failed()) {
         // Set to internal server error so later logging will pick up SquidLogCode::ERR_DNS_FAIL
-        build_error_response(s, HTTPStatus::INTERNAL_SERVER_ERROR, "Cannot find server.", "connect#dns_failed");
+        build_error_response(s, HTTPStatus::INTERNAL_SERVER_ERROR, "Cannot find server.", Dns_error_body);
         log_msg = "looking up";
       } else {
         build_error_response(s, HTTPStatus::INTERNAL_SERVER_ERROR, "No valid server.", "connect#all_down");


### PR DESCRIPTION
Fixed a pointer comparison bug where the error_body_type string literal was compared by pointer address instead of value. This now passes the Dns_error_body constant directly so the pointer comparison succeeds and DNS errors are correctly logged as ERR_DNS_FAIL.

---

# For Review

* Dns_error_body declared here: https://github.com/apache/trafficserver/blob/0d4f77c0d250ddbadf39a63cfe434b13cf164644/src/proxy/http/HttpTransact.cc#L59
* Used here: https://github.com/apache/trafficserver/blob/0d4f77c0d250ddbadf39a63cfe434b13cf164644/src/proxy/http/HttpTransact.cc#L8058

Note that in the comparison referenced above, it was a pointer comparison rather than a string comparison. Thus it would always fail since the two always pointed to two different string literals. This change makes the pointer comparison work as expected.