### PR TITLE
vscode: associate .test.ext files with Python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "*.test.ext": "python"
+    }
+}
+


### PR DESCRIPTION
This adds a .vscode/settings.json file to make vscode aware that .test.ext files are Python files.