### PR TITLE
autest: --thread-limit 1 by default for Proxy Verifier

### DIFF
--- a/tests/gold_tests/autest-site/verifier_client.test.ext
+++ b/tests/gold_tests/autest-site/verifier_client.test.ext
@@ -34,6 +34,7 @@ def _configure_client(
         ca_cert='',
         verbose=True,
         other_args='',
+        run_parallel=False,
         context=None):
     """
     Configure the process for running the verifier-client.
@@ -70,7 +71,7 @@ def _configure_client(
         # Create a copy of the replay directory in the run directory.
         run_replay_path = os.path.join(client_dir, os.path.basename(replay_path))
         process.Setup.Copy(replay_path, run_replay_path, CopyLogic.SoftFiles)
-        command += " {} ".format(run_replay_path)
+        command += f" {run_replay_path} "
 
     if not http_ports:
         http_ports = [8080]
@@ -103,12 +104,12 @@ def _configure_client(
             ssl_cert = os.path.join(obj.Variables["AtsTestToolsDir"], "proxy-verifier", "ssl", "client.pem")
 
             if not os.path.isfile(ssl_cert):
-                raise ValueError("Tried to use '{}' for --client-cert, but it is not "
-                                 "a valid file.".format(ssl_cert))
+                raise ValueError(f"Tried to use '{ssl_cert}' for --client-cert, but it is not "
+                                 "a valid file.")
         if ssl_cert:
             run_ssl_cert = os.path.join(client_dir, os.path.basename(ssl_cert))
             process.Setup.Copy(ssl_cert, run_ssl_cert, CopyLogic.SoftFiles)
-            command += ' --client-cert "{}" '.format(run_ssl_cert)
+            command += f' --client-cert "{run_ssl_cert}" '
 
             tls_secrets_log_filename = "tls_secrets.txt"
             tls_secrets_log_path = os.path.join(client_dir, tls_secrets_log_filename)
@@ -119,21 +120,26 @@ def _configure_client(
             ca_cert = os.path.join(obj.Variables["AtsTestToolsDir"], "proxy-verifier", "ssl", "ca.pem")
 
             if not os.path.isfile(ca_cert):
-                raise ValueError("Tried to use '{}' for --ca-certs, but it is not "
-                                 "a valid file.".format(ca_cert))
+                raise ValueError(f"Tried to use '{ca_cert}' for --ca-certs, but it is not "
+                                 "a valid file.")
         if ca_cert:
             run_ca_cert = os.path.join(client_dir, os.path.basename(ca_cert))
             process.Setup.Copy(ca_cert, run_ca_cert, CopyLogic.SoftFiles)
-            command += ' --ca-certs "{}" '.format(run_ca_cert)
+            command += f' --ca-certs "{run_ca_cert}" '
 
     if verbose:
         command += ' --verbose diag '
 
     if other_args:
-        command += " {}".format(other_args)
+        command += f" {other_args}"
 
     if keys is not None:
-        command += " --keys {}".format(keys)
+        command += f" --keys {keys}"
+
+    # Generally we prefer the deterministic behavior of a single thread where
+    # each connection is processed sequentially.
+    if not run_parallel and 'thread-limit' not in command:
+        command += " --thread-limit 1"
 
     process.Command = command
     process.ReturnCode = 0
@@ -154,6 +160,7 @@ def AddVerifierClientProcess(
         ca_cert='',
         verbose=True,
         other_args='',
+        run_parallel=False,
         context=None):
     """
     Set the Default process of the test run to a verifier-client Process.
@@ -184,6 +191,8 @@ def AddVerifierClientProcess(
 
         other_args: (str) Any other arbitrary options to pass to verifier-client.
 
+        run_parallel: (bool) Whether to run the verifier-client in parallel.
+
         context: Any dictionary-like object with keys that match the placeholders
                  in the replay file.
                  Template strings support $-based substitutions in the replay file.
@@ -203,7 +212,8 @@ def AddVerifierClientProcess(
 
     p = run.Processes.Default
     _configure_client(
-        run, p, name, replay_path, http_ports, https_ports, http3_ports, keys, ssl_cert, ca_cert, verbose, other_args, context)
+        run, p, name, replay_path, http_ports, https_ports, http3_ports, keys, ssl_cert, ca_cert, verbose, other_args, run_parallel,
+        context)
     return p
 
 

--- a/tests/gold_tests/cache/background_fill.test.py
+++ b/tests/gold_tests/cache/background_fill.test.py
@@ -167,8 +167,7 @@ sleep 5;
             "pv_client",
             "replay/bg_fill.yaml",
             http_ports=[self.ts['for_pv'].Variables.port],
-            https_ports=[self.ts['for_pv'].Variables.ssl_port],
-            other_args='--thread-limit 1')
+            https_ports=[self.ts['for_pv'].Variables.ssl_port])
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stdout = "gold/background_fill_3_stdout.gold"
         self.__checkProcessAfter(tr)

--- a/tests/gold_tests/cache/cache-auth.test.py
+++ b/tests/gold_tests/cache/cache-auth.test.py
@@ -56,8 +56,7 @@ class AuthDefaultTest:
         tr = Test.AddTestRun(
             "Verify the proper caching behavior for request/response containing auth-related fields when ATS is in default configuration"
         )
-        tr.AddVerifierClientProcess(
-            "auth-default-client", self.authDefaultReplayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("auth-default-client", self.authDefaultReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -98,8 +97,7 @@ class AuthIgnoredTest:
         tr = Test.AddTestRun(
             "Verify the proper caching behavior for request/response containing auth-related fields when ATS is configured to bypass caching for those"
         )
-        tr.AddVerifierClientProcess(
-            "auth-ignored-client", self.authIgnoredReplayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("auth-ignored-client", self.authIgnoredReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/cache/cache-control.test.py
+++ b/tests/gold_tests/cache/cache-control.test.py
@@ -203,10 +203,7 @@ class RequestCacheControlDefaultTest:
     def runTraffic(self):
         tr = Test.AddTestRun("Verify the proper handling of cache-control directives in requests in default configuration")
         tr.AddVerifierClientProcess(
-            "request-cache-control-default-client",
-            self.requestCacheControlReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "request-cache-control-default-client", self.requestCacheControlReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -256,10 +253,7 @@ class RequestCacheControlHonorClientTest:
             "Verify the proper handling of cache-control directives in requests when ATS is configured to honor client's request to bypass the cache"
         )
         tr.AddVerifierClientProcess(
-            "request-cache-control-honor-client-client",
-            self.requestCacheControlReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "request-cache-control-honor-client-client", self.requestCacheControlReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -304,10 +298,7 @@ class ResponseCacheControlDefaultTest:
     def runTraffic(self):
         tr = Test.AddTestRun("Verify the proper handling of cache-control directives in responses in default configuration")
         tr.AddVerifierClientProcess(
-            "response-cache-control-client-default",
-            self.responseCacheControlReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "response-cache-control-client-default", self.responseCacheControlReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -356,10 +347,7 @@ class ResponseCacheControlIgnoredTest:
             "Verify the proper handling of cache-control directives in responses when ATS is configured to ignore server's request to bypass the cache"
         )
         tr.AddVerifierClientProcess(
-            "response-cache-control-client-ignored",
-            self.responseCacheControlReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "response-cache-control-client-ignored", self.responseCacheControlReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/cache/cache-cookie.test.py
+++ b/tests/gold_tests/cache/cache-cookie.test.py
@@ -48,11 +48,7 @@ class CookieDefaultTest:
 
     def runTraffic(self):
         tr = Test.AddTestRun("Verify the correct caching behavior when ATS is in default configuration")
-        tr.AddVerifierClientProcess(
-            "cookie-default-client",
-            self.cookieDefaultReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("cookie-default-client", self.cookieDefaultReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -91,8 +87,7 @@ class CookieBypassTest:
     def runTraffic(self):
         tr = Test.AddTestRun(
             "Verify the correct caching behavior when ATS is configured to not cache response to cookie for any content type")
-        tr.AddVerifierClientProcess(
-            "cookie-bypass-client", self.cookieBypassReplayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("cookie-bypass-client", self.cookieBypassReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -131,11 +126,7 @@ class CookieImgOnlyTest:
     def runTraffic(self):
         tr = Test.AddTestRun(
             "Verify the correct caching behavior when ATS is configured to cache response to cookie only for image content type")
-        tr.AddVerifierClientProcess(
-            "cookie-img-only-client",
-            self.cookieImgOnlyReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("cookie-img-only-client", self.cookieImgOnlyReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -175,10 +166,7 @@ class CookieAllButTextTest:
         tr = Test.AddTestRun(
             "Verify the correct caching behavior when ATS is configured to cache response to cookie for all but text types")
         tr.AddVerifierClientProcess(
-            "cookie-all-but-text-client",
-            self.cookieAllButTextReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "cookie-all-but-text-client", self.cookieAllButTextReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -222,10 +210,7 @@ class CookieAllButTextWithExcpTest:
             "Verify the correct caching behavior when ATS is configured to cache all content types but text, but with a few exceptions for text types which would also be cached"
         )
         tr.AddVerifierClientProcess(
-            "cookie-all-but-text-with-excp-client",
-            self.cookieAllButTextReplayFile,
-            http_ports=[self.ts.Variables.port],
-            other_args='--thread-limit 1')
+            "cookie-all-but-text-with-excp-client", self.cookieAllButTextReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/bad_chunked_encoding.test.py
@@ -102,11 +102,7 @@ class HTTP10Test:
     def runChunkedTraffic(self):
         tr = Test.AddTestRun()
         tr.AddVerifierClientProcess(
-            "client1",
-            self.chunkedReplayFile,
-            http_ports=[self.ts.Variables.port],
-            https_ports=[self.ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            "client1", self.chunkedReplayFile, http_ports=[self.ts.Variables.port], https_ports=[self.ts.Variables.ssl_port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -162,11 +158,7 @@ class MalformedChunkHeaderTest:
     def runChunkedTraffic(self):
         tr = Test.AddTestRun()
         tr.AddVerifierClientProcess(
-            "client2",
-            self.chunkedReplayFile,
-            http_ports=[self.ts.Variables.port],
-            https_ports=[self.ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            "client2", self.chunkedReplayFile, http_ports=[self.ts.Variables.port], https_ports=[self.ts.Variables.ssl_port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/client_connection/per_client_connection_max.test.py
+++ b/tests/gold_tests/client_connection/per_client_connection_max.test.py
@@ -144,7 +144,11 @@ class PerClientConnectionMaxTest:
         """
         name = f'client{PerClientConnectionMaxTest._client_counter}'
         p = tr.AddVerifierClientProcess(
-            name, self._replay_file, http_ports=[self._ts.Variables.port], https_ports=[self._ts.Variables.ssl_port])
+            name,
+            self._replay_file,
+            http_ports=[self._ts.Variables.port],
+            https_ports=[self._ts.Variables.ssl_port],
+            run_parallel=True)
         PerClientConnectionMaxTest._client_counter += 1
 
         p.StartBefore(self._dns)

--- a/tests/gold_tests/connect/connect.test.py
+++ b/tests/gold_tests/connect/connect.test.py
@@ -149,8 +149,7 @@ class ConnectViaPVTest:
 
     def runTraffic(self):
         tr = Test.AddTestRun("Verify correct handling of CONNECT request")
-        tr.AddVerifierClientProcess(
-            "connect-client", self.connectReplayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("connect-client", self.connectReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -235,8 +234,7 @@ class ConnectViaPVTest2:
 
     def runTraffic(self):
         tr = Test.AddTestRun("Verify correct handling of CONNECT request on HTTP/2")
-        tr.AddVerifierClientProcess(
-            "connect-client2", self.connectReplayFile, https_ports=[self.ts.Variables.ssl_port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("connect-client2", self.connectReplayFile, https_ports=[self.ts.Variables.ssl_port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/h2/h2get_with_body.test.py
+++ b/tests/gold_tests/h2/h2get_with_body.test.py
@@ -55,11 +55,7 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(pv_server)
 tr.Processes.Default.StartBefore(ts)
 tr.AddVerifierClientProcess(
-    "pv_client",
-    "h2get_with_body.yaml",
-    http_ports=[ts.Variables.port],
-    https_ports=[ts.Variables.ssl_port],
-    other_args='--thread-limit 1')
+    "pv_client", "h2get_with_body.yaml", http_ports=[ts.Variables.port], https_ports=[ts.Variables.ssl_port])
 tr.Processes.Default.ReturnCode = 0
 
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(

--- a/tests/gold_tests/h2/http2_close_connection.test.py
+++ b/tests/gold_tests/h2/http2_close_connection.test.py
@@ -51,11 +51,7 @@ tr = Test.AddTestRun()
 tr.Processes.Default.StartBefore(pv_server)
 tr.Processes.Default.StartBefore(ts)
 tr.AddVerifierClientProcess(
-    "pv_client",
-    "http2_close_connection.yaml",
-    http_ports=[ts.Variables.port],
-    https_ports=[ts.Variables.ssl_port],
-    other_args='--thread-limit 1')
+    "pv_client", "http2_close_connection.yaml", http_ports=[ts.Variables.port], https_ports=[ts.Variables.ssl_port])
 tr.Processes.Default.ReturnCode = 0
 
 tr.Processes.Default.Streams.All += Testers.ContainsExpression(

--- a/tests/gold_tests/headers/invalid_range_header.test.py
+++ b/tests/gold_tests/headers/invalid_range_header.test.py
@@ -49,8 +49,7 @@ class InvalidRangeHeaderTest:
 
     def runTraffic(self):
         tr = Test.AddTestRun()
-        tr.AddVerifierClientProcess(
-            "client1", self.invalidRangeRequestReplayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("client1", self.invalidRangeRequestReplayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/pluginTest/access_control/access_control.test.py
+++ b/tests/gold_tests/pluginTest/access_control/access_control.test.py
@@ -67,11 +67,7 @@ class AccessControlTest:
     def run(self):
         tr = Test.AddTestRun("Session Cookie")
         tr.AddVerifierClientProcess(
-            "verifier-client",
-            self.replayFile,
-            http_ports=[self.ts.Variables.port],
-            https_ports=[self.ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            "verifier-client", self.replayFile, http_ports=[self.ts.Variables.port], https_ports=[self.ts.Variables.ssl_port])
         tr.Processes.Default.StartBefore(self.ts)
         tr.Processes.Default.StartBefore(self.server)
         tr.StillRunningAfter = self.ts

--- a/tests/gold_tests/pluginTest/certifier/certifier.test.py
+++ b/tests/gold_tests/pluginTest/certifier/certifier.test.py
@@ -65,11 +65,7 @@ class DynamicCertTest:
     def runHTTPSTraffic(self):
         tr = Test.AddTestRun("Test dynamic generation of certs")
         tr.AddVerifierClientProcess(
-            "client1",
-            self.httpsReplayFile,
-            http_ports=[self.ts.Variables.port],
-            https_ports=[self.ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            "client1", self.httpsReplayFile, http_ports=[self.ts.Variables.port], https_ports=[self.ts.Variables.ssl_port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -144,11 +140,7 @@ class ReuseExistingCertTest:
     def runHTTPSTraffic(self):
         tr = Test.AddTestRun("Test dynamic generation of certs")
         tr.AddVerifierClientProcess(
-            "client2",
-            self.httpsReplayFile,
-            http_ports=[self.ts.Variables.port],
-            https_ports=[self.ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            "client2", self.httpsReplayFile, http_ports=[self.ts.Variables.port], https_ports=[self.ts.Variables.ssl_port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server

--- a/tests/gold_tests/pluginTest/compress/compress-content-type-params.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress-content-type-params.test.py
@@ -57,8 +57,7 @@ class CompressPluginContentTypeParamsTest:
 
     def run(self):
         tr = Test.AddTestRun()
-        tr.AddVerifierClientProcess(
-            "verifier-client", self.replayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("verifier-client", self.replayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.ts)
         tr.Processes.Default.StartBefore(self.server)
         tr.StillRunningAfter = self.ts

--- a/tests/gold_tests/pluginTest/compress/compress-range.test.py
+++ b/tests/gold_tests/pluginTest/compress/compress-range.test.py
@@ -63,8 +63,7 @@ map /cache-true-no-compression/ http://127.0.0.1:{self.server.Variables.http_por
 
     def run(self):
         tr = Test.AddTestRun()
-        tr.AddVerifierClientProcess(
-            "verifier-client", self.replayFile, http_ports=[self.ts.Variables.port], other_args='--thread-limit 1')
+        tr.AddVerifierClientProcess("verifier-client", self.replayFile, http_ports=[self.ts.Variables.port])
         tr.Processes.Default.StartBefore(self.ts)
         tr.Processes.Default.StartBefore(self.server)
         tr.StillRunningAfter = self.ts

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint.test.py
@@ -143,11 +143,7 @@ class JA3FingerprintTest:
         """
         name = f'client{self._client_counter}'
         p = tr.AddVerifierClientProcess(
-            name,
-            self._replay_file,
-            http_ports=[self._ts.Variables.port],
-            https_ports=[self._ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            name, self._replay_file, http_ports=[self._ts.Variables.port], https_ports=[self._ts.Variables.ssl_port])
         JA3FingerprintTest._client_counter += 1
 
         p.StartBefore(self._dns)

--- a/tests/gold_tests/pluginTest/stale_response/stale_response.test.py
+++ b/tests/gold_tests/pluginTest/stale_response/stale_response.test.py
@@ -130,8 +130,7 @@ class TestStaleResponse:
 
         name = f'client_{TestStaleResponse._client_counter}'
         TestStaleResponse._client_counter += 1
-        p = tr.AddVerifierClientProcess(
-            name, self._replay_file, http_ports=[self._ts.Variables.port], other_args='--thread-limit 1')
+        p = tr.AddVerifierClientProcess(name, self._replay_file, http_ports=[self._ts.Variables.port])
         p.StartBefore(self._server)
         p.StartBefore(self._ts)
         p.StillRunningAfter = self._ts

--- a/tests/gold_tests/pluginTest/statichit/statichit.test.py
+++ b/tests/gold_tests/pluginTest/statichit/statichit.test.py
@@ -107,5 +107,5 @@ p.StartBefore(ts)
 p.StillRunningAfter = ts
 
 tr = Test.AddTestRun()
-p = tr.AddVerifierClientProcess('client', 'statichit.replay.yaml', http_ports=[ts.Variables.port], other_args='--thread-limit 1')
+p = tr.AddVerifierClientProcess('client', 'statichit.replay.yaml', http_ports=[ts.Variables.port])
 p.StillRunningAfter = ts

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -143,8 +143,7 @@ tr.AddVerifierClientProcess(
     http_ports=[ts.Variables.port],
     https_ports=[ts.Variables.ssl_port],
     ssl_cert="ssl/server_combined.pem",
-    ca_cert="ssl/signer.pem",
-    other_args='--thread-limit 1')
+    ca_cert="ssl/signer.pem")
 
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_http3.test.py
@@ -97,8 +97,7 @@ ts.Disk.traffic_out.Content += Testers.ContainsExpression(
 replay_file_session_1 = os.path.join(ts_log_dir, "127", "0000000000000000")
 ts.Disk.File(replay_file_session_1, exists=True)
 
-# Execute the first transaction. We limit the threads to 1 so that the sessions
-# are run in serial.
+# Execute the first transaction.
 tr = Test.AddTestRun("Run the test traffic.")
 tr.AddVerifierClientProcess(
     "client",
@@ -107,8 +106,7 @@ tr.AddVerifierClientProcess(
     https_ports=[ts.Variables.ssl_port],
     http3_ports=[ts.Variables.ssl_port],
     ssl_cert="ssl/server_combined.pem",
-    ca_cert="ssl/signer.pem",
-    other_args='--thread-limit 1')
+    ca_cert="ssl/signer.pem")
 
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_response_body.test.py
@@ -83,8 +83,7 @@ tr.AddVerifierClientProcess(
     http_ports=[ts.Variables.port],
     https_ports=[ts.Variables.ssl_port],
     ssl_cert="ssl/server_combined.pem",
-    ca_cert="ssl/signer.pem",
-    other_args='--thread-limit 1')
+    ca_cert="ssl/signer.pem")
 
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/pluginTest/transform/transaction_data_sink.test.py
+++ b/tests/gold_tests/pluginTest/transform/transaction_data_sink.test.py
@@ -79,11 +79,7 @@ class TransactionDataSyncTest:
         tr.Processes.Default.StartBefore(self.nameserver)
         tr.Processes.Default.StartBefore(self.ts)
         tr.AddVerifierClientProcess(
-            "client",
-            self.replay_file,
-            http_ports=[self.ts.Variables.port],
-            https_ports=[self.ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            "client", self.replay_file, http_ports=[self.ts.Variables.port], https_ports=[self.ts.Variables.ssl_port])
 
 
 TransactionDataSyncTest().run()

--- a/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
+++ b/tests/gold_tests/proxy_protocol/proxy_protocol.test.py
@@ -70,8 +70,7 @@ logging:
             "pp-in-client",
             self.replay_file,
             http_ports=[self.ts.Variables.proxy_protocol_port],
-            https_ports=[self.ts.Variables.proxy_protocol_ssl_port],
-            other_args='--thread-limit 1')
+            https_ports=[self.ts.Variables.proxy_protocol_ssl_port])
         tr.Processes.Default.StartBefore(self.server)
         tr.Processes.Default.StartBefore(self.ts)
         tr.StillRunningAfter = self.server
@@ -210,8 +209,7 @@ class ProxyProtocolOutTest:
             f"pp-out-client-{ProxyProtocolOutTest._client_counter}",
             self._pp_out_replay_file,
             http_ports=[self._ts.Variables.port],
-            https_ports=[self._ts.Variables.ssl_port],
-            other_args='--thread-limit 1')
+            https_ports=[self._ts.Variables.ssl_port])
         ProxyProtocolOutTest._client_counter += 1
         self._ts.StartBefore(self._server)
         self._ts.StartBefore(self._dns)

--- a/tests/gold_tests/url/uri.test.py
+++ b/tests/gold_tests/url/uri.test.py
@@ -32,4 +32,4 @@ ts.Disk.remap_config.AddLine('map / http://127.0.0.1:{0}'.format(server.Variable
 tr = Test.AddTestRun("Verify correct URI parsing behavior.")
 tr.Processes.Default.StartBefore(server)
 tr.Processes.Default.StartBefore(ts)
-tr.AddVerifierClientProcess("client", replay_file, http_ports=[ts.Variables.port], other_args='--thread-limit 1')
+tr.AddVerifierClientProcess("client", replay_file, http_ports=[ts.Variables.port])


### PR DESCRIPTION
For production traffic simulation, Proxy Verifier by default runs
through the specified connections in parallel. But for our end to end
tests, that hardly ever makes sense. Rather we want the tests to
deterministically run through each specified connection sequentially.
This patch does so by passing --thread-limit 1 as a default option to
the Proxy Verifier client in the client extension. Many tests were
specifying this already anyway, so this saves some burden on client
configuration for each of the test descriptions.