### PR TITLE
10.1.x: Fix DNS error logging to use ERR_DNS_FAIL (#12638)

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1927,7 +1927,7 @@ HttpTransact::OSDNSLookup(State *s)
       SET_VIA_STRING(VIA_DETAIL_TUNNEL, VIA_DETAIL_TUNNEL_NO_FORWARD);
       if (!s->dns_info.record || s->dns_info.record->is_failed()) {
         // Set to internal server error so later logging will pick up SQUID_LOG_ERR_DNS_FAIL
-        build_error_response(s, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Cannot find server.", "connect#dns_failed");
+        build_error_response(s, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Cannot find server.", Dns_error_body);
         log_msg = "looking up";
       } else {
         build_error_response(s, HTTP_STATUS_INTERNAL_SERVER_ERROR, "No valid server.", "connect#all_down");


### PR DESCRIPTION
Fixed a pointer comparison bug where the error_body_type string literal was compared by pointer address instead of value. This now passes the Dns_error_body constant directly so the pointer comparison succeeds and DNS errors are correctly logged as ERR_DNS_FAIL.