### PR TITLE
Fix errno assertion failure in retry_server_connection_not_open

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -3731,6 +3731,20 @@ HttpTransact::handle_response_from_server(State *s)
   case CONNECTION_CLOSED:
   case BAD_INCOMING_RESPONSE:
 
+    // Ensure cause_of_death_errno is set for all error states if not already set.
+    // This prevents the assertion failure in retry_server_connection_not_open.
+    if (s->cause_of_death_errno == -UNKNOWN_INTERNAL_ERROR) {
+      if (s->current.state == PARSE_ERROR || s->current.state == BAD_INCOMING_RESPONSE) {
+        s->set_connect_fail(EBADMSG);
+      } else if (s->current.state == CONNECTION_CLOSED) {
+        s->set_connect_fail(EPIPE);
+      } else {
+        // Generic fallback for OPEN_RAW_ERROR, CONNECTION_ERROR,
+        // STATE_UNDEFINED, and any other unexpected error states.
+        s->set_connect_fail(EIO);
+      }
+    }
+
     if (is_server_negative_cached(s)) {
       max_connect_retries = s->txn_conf->connect_attempts_max_retries_down_server - 1;
     } else {


### PR DESCRIPTION
This ensures that cause_of_death_errno is properly set with appropriate error codes (EBADMSG for protocol errors, EPIPE for closed connections) before retry attempts are made via set_connect_fail() when error states are detected.

Fixes: #12654

---

Converting to a draft because, if this is helpful, it is not sufficient. I still see the same assertion failures on the docs server when running with this patch:

```
Fatal: /home/bneradt/src/trafficserver_10/src/proxy/http/HttpTransact.cc:3846: failed assertion `s->cause_of_death_errno != -UNKNOWN_INTERNAL_ERROR`
```