### PR TITLE
Plugins: Remove duplicate CRLF after TSHttpHdrPrint

### DIFF
--- a/plugins/background_fetch/background_fetch.cc
+++ b/plugins/background_fetch/background_fetch.cc
@@ -400,7 +400,6 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
     if ((data->vc = TSHttpConnectWithPluginId(reinterpret_cast<sockaddr *>(&data->client_ip), PLUGIN_NAME, 0)) != nullptr) {
       TSHttpHdrPrint(data->mbuf, data->hdr_loc, data->req_io_buf);
       // We never send a body with the request. ToDo: Do we ever need to support that ?
-      TSIOBufferWrite(data->req_io_buf, "\r\n", 2);
 
       data->r_vio = TSVConnRead(data->vc, contp, data->resp_io_buf, INT64_MAX);
       data->w_vio = TSVConnWrite(data->vc, contp, data->req_io_buf_reader, TSIOBufferReaderAvail(data->req_io_buf_reader));

--- a/plugins/experimental/cache_fill/background_fetch.cc
+++ b/plugins/experimental/cache_fill/background_fetch.cc
@@ -280,7 +280,6 @@ cont_bg_fetch(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
     if ((data->vc = TSHttpConnectWithPluginId(reinterpret_cast<sockaddr *>(&data->client_ip), PLUGIN_NAME, 0)) != nullptr) {
       TSHttpHdrPrint(data->mbuf, data->hdr_loc, data->req_io_buf);
       // We never send a body with the request. ToDo: Do we ever need to support that ?
-      TSIOBufferWrite(data->req_io_buf, "\r\n", 2);
 
       data->r_vio = TSVConnRead(data->vc, contp, data->resp_io_buf, INT64_MAX);
       data->w_vio = TSVConnWrite(data->vc, contp, data->req_io_buf_reader, TSIOBufferReaderAvail(data->req_io_buf_reader));

--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -620,7 +620,6 @@ fetch_resource(TSCont contp, TSEvent, void *)
   add_trailing_parameter(state->req_info->http_hdr_buf, state->req_info->http_hdr_loc);
   // copy all the headers into a buffer
   TSHttpHdrPrint(state->req_info->http_hdr_buf, state->req_info->http_hdr_loc, state->req_io_buf);
-  TSIOBufferWrite(state->req_io_buf, "\r\n", 2);
 
   // setup place to store body data
   if (state->sie_body) {

--- a/plugins/prefetch/fetch.cc
+++ b/plugins/prefetch/fetch.cc
@@ -707,7 +707,6 @@ BgFetch::handler(TSCont contp, TSEvent event, void * /* edata ATS_UNUSED */)
     if ((fetch->vc = TSHttpConnect(reinterpret_cast<sockaddr *>(&fetch->client_ip))) != nullptr) {
       TSHttpHdrPrint(fetch->_mbuf, fetch->_headerLoc, fetch->req_io_buf);
       // We never send a body with the request. ToDo: Do we ever need to support that ?
-      TSIOBufferWrite(fetch->req_io_buf, "\r\n", 2);
 
       fetch->r_vio = TSVConnRead(fetch->vc, contp, fetch->resp_io_buf, INT64_MAX);
       fetch->w_vio = TSVConnWrite(fetch->vc, contp, fetch->req_io_buf_reader, TSIOBufferReaderAvail(fetch->req_io_buf_reader));


### PR DESCRIPTION
The TSHttpHdrPrint function already appends the final CRLF sequence (\r\n\r\n) to terminate HTTP headers, as confirmed by tracing through the implementation (InkAPI.cc -> HTTPHdr::print -> http_hdr_print -> mime_hdr_print). Several plugins were incorrectly adding an additional TSIOBufferWrite with \r\n after calling TSHttpHdrPrint, which resulted in malformed HTTP requests with an extra blank line. On keep-alive connections, this extra CRLF would be interpreted as the start of a second request, causing ATS to log ERR_INVALID_REQ errors when it attempted to parse the incomplete request. This fix removes the unnecessary TSIOBufferWrite calls from the stale_response, background_fetch, cache_fill, and prefetch plugins.

---

See where mime_hdr_print appends the final CRLF here :
https://github.com/apache/trafficserver/blob/07dd1438594e4e9fc285236e02dbc954241a197a/src/proxy/hdrs/MIME.cc#L2619

All of these places make the headers end in CRLF+CRLF+CRLF, instead of just CRLF+CRLF. Most of them are one off internal headers, and therefore the extra CRLF in the buffer just gets dropped. But it is incorrect to add them and if things get changed so another transaction happens after it, these extra bytes will cause problems.