### PR TITLE
doc: fix regex_remap overridable config syntax description

### DIFF
--- a/doc/admin-guide/plugins/regex_remap.en.rst
+++ b/doc/admin-guide/plugins/regex_remap.en.rst
@@ -139,11 +139,22 @@ remap.config. The following options are available ::
     @connect_timeout=<nnn>      - Connect timeouts (in ms)
     @dns_timeout=<nnn>          - Connect timeouts (in ms)
 
-    @overridable-config=<value> - see :ref:`ts-overridable-config`
-
     @caseless                   - Make regular expressions case insensitive
     @lowercase_substitutions    - Turn on (enable) lower case substitutions
-		@strategy                   - Specify a strategy from strategies.yaml. "null" or "" will clear the strategy.
+    @strategy                   - Specify a strategy from strategies.yaml. "null" or "" will clear the strategy.
+
+In addition to the options listed above, you can override any configuration
+variable from ``records.yaml`` on a per-rule basis. When a regex rule matches,
+any overridable configuration specified in that rule will be applied to the
+transaction. The syntax is ``@<config-name>=<value>``, for example ::
+
+    @proxy.config.url_remap.pristine_host_hdr=0
+    @proxy.config.http.cache.http=1
+
+These configuration overrides support integer, floating point, and string values,
+and will be automatically converted to the appropriate type. See
+:ref:`ts-overridable-config` for the complete list of configuration variables
+that can be overridden.
 
 
 This can be useful to force a particular response for some URLs, e.g. ::
@@ -156,3 +167,7 @@ Or, to force a 302 redirect ::
 
 Setting the status to 301 or 302 will force the new URL to be used
 as a redirect (Location:).
+
+You can also combine multiple options, including overridable configs ::
+
+    ^/(.*)?$            https://example.com/sitemaps/$1 @proxy.config.url_remap.pristine_host_hdr=0 @status=301


### PR DESCRIPTION
The documentation incorrectly suggested using
@overridable-config=<value> syntax for overriding configuration
variables. No such overridable-config option exists. The correct syntax
is to use the config name directly with @<config-name>=<value> (e.g.,
@proxy.config.url_remap.pristine_host_hdr=0). This commit removes the
incorrect reference and adds an example.

---

## For Review

The rendered doc can be seen here:
https://ci.trafficserver.apache.org/job/Github_Builds/job/docs/7939/artifact/output/12663/docbuild/html/admin-guide/plugins/regex_remap.en.html