### PR TITLE
Transfer-Encoding:chunked log field fix

### DIFF
--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -635,6 +635,7 @@ public:
     bool            trust_response_cl          = false;
     ResponseError_t response_error             = ResponseError_t::NO_RESPONSE_HEADER_ERROR;
     bool            extension_method           = false;
+    std::string     server_response_transfer_encoding; ///< Storage for logging.
 
     _HeaderInfo() {}
   };

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -5850,6 +5850,9 @@ HttpTransact::initialize_state_variables_from_response(State *s, HTTPHdr *incomi
           new_enc_val = new_enc_iter.get_next(&new_enc_len);
         }
 
+        // Store the original Transfer-Encoding value for logging before we delete it.
+        s->hdr_info.server_response_transfer_encoding.assign(field->value_get().data(), field->value_get().length());
+
         // We're done with the old field since we copied out everything
         //   we needed
         incoming_response->field_delete(field);

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -3246,6 +3246,34 @@ LogAccess::marshal_http_header_field(LogField::Container container, char *field,
     }
   }
 
+  // The Transfer-Encoding:chunked value may have been removed from the header
+  // during processing, but we store it for logging purposes.
+  if (valid_field == false && container == LogField::SSH && strcmp(field, "Transfer-Encoding") == 0) {
+    const std::string &stored_te = m_http_sm->t_state.hdr_info.server_response_transfer_encoding;
+    if (!stored_te.empty()) {
+      valid_field = true;
+      actual_len  = stored_te.length();
+      str         = const_cast<char *>(stored_te.data());
+
+      int running_len = actual_len + 1; // +1 for null terminator
+      padded_len      = padded_length(running_len);
+
+      if (buf) {
+        memcpy(buf, str, actual_len);
+        buf[actual_len]  = '\0';
+        buf             += running_len;
+
+#ifdef DEBUG
+        int pad_len = padded_len - running_len;
+        for (int i = 0; i < pad_len; i++) {
+          *buf = '$';
+          buf++;
+        }
+#endif
+      }
+    }
+  }
+
   if (valid_field == false) {
     padded_len = INK_MIN_ALIGN;
     if (buf) {

--- a/tests/gold_tests/logging/gold/field-test.gold
+++ b/tests/gold_tests/logging/gold/field-test.gold
@@ -1,3 +1,3 @@
-application/json,%20application/json
-application/jason,%20application/json
-application/json
+Transfer-Encoding:Chunked Content-Type:application/json,%20application/json
+Transfer-Encoding:- Content-Type:application/jason,%20application/json
+Transfer-Encoding:- Content-Type:application/json


### PR DESCRIPTION
When an origin server returns Transfer-Encoding:chunked, ATS removes
this header during response processing to handle dechunking. This
prevented the original header value from being logged via
%<{Transfer-Encoding}ssh>. This fix stores the original
Transfer-Encoding value before deletion and uses the stored value if
requested via the ssh field.

Fixes: #6261
