### PR TITLE
cookie_remap: set_sendto_headers

### DIFF
--- a/tests/gold_tests/pluginTest/cookie_remap/configs/set_sendto_headers_config.yaml
+++ b/tests/gold_tests/pluginTest/cookie_remap/configs/set_sendto_headers_config.yaml
@@ -1,0 +1,56 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Test configuration for set_sendto_headers functionality
+# Tests setting various headers including Host header
+
+# Test 1: Simple Host header setting with exists operation
+op:
+  cookie: SessionID
+  operation: exists
+  sendto: http://backend.com:$BACKEND_PORT/app
+  set_sendto_headers:
+    - Host: backend.com
+    - X-Custom-Header: custom-value
+
+# Test 2: Using regex capture groups in headers
+op:
+  cookie: UserTier
+  operation: regex
+  regex: (premium|standard)
+  sendto: http://$1.service.com:$SERVICE_PORT/api
+  set_sendto_headers:
+    - Host: $1.service.com
+    - X-User-Tier: $1
+
+# Test 3: Using path variables
+op:
+  cookie: Debug
+  operation: exists
+  sendto: http://debug.com:$DEBUG_PORT/debug
+  set_sendto_headers:
+    - X-Original-Path: $path
+    - X-Debug-Mode: enabled
+
+# Test 4: Multiple headers without Host (should preserve pristine host)
+op:
+  cookie: NoHost
+  operation: exists
+  sendto: http://nohost.com:$NOHOST_PORT/test
+  set_sendto_headers:
+    - X-Custom-1: value1
+    - X-Custom-2: value2
+

--- a/tests/gold_tests/pluginTest/cookie_remap/set_sendto_headers.replay.yaml
+++ b/tests/gold_tests/pluginTest/cookie_remap/set_sendto_headers.replay.yaml
@@ -1,0 +1,177 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+  # Test 1: Simple Host header setting with exists operation
+  - transactions:
+      - client-request:
+          method: GET
+          url: /app/test
+          version: '1.1'
+          headers:
+            fields:
+              - [Host, example.com]
+              - [Cookie, SessionID=abc123]
+              - [uuid, test1-simple-host]
+
+        server-response:
+          status: 200
+          reason: OK
+          headers:
+            fields:
+              - [Content-Length, '0']
+
+        proxy-request:
+          headers:
+            fields:
+              - [Host, {value: backend.com, as: prefix}]
+              - [X-Custom-Header, {value: custom-value, as: equal}]
+
+  # Test 2: Using regex capture groups - premium tier
+  - transactions:
+      - client-request:
+          method: GET
+          url: /api/data
+          version: '1.1'
+          headers:
+            fields:
+              - [Host, example.com]
+              - [Cookie, UserTier=premium]
+              - [uuid, test2-regex-premium]
+
+        server-response:
+          status: 200
+          reason: OK
+          headers:
+            fields:
+              - [Content-Length, '0']
+
+        proxy-request:
+          headers:
+            fields:
+              - [Host, {value: premium.service.com, as: prefix}]
+              - [X-User-Tier, {value: premium, as: equal}]
+
+  # Test 3: Using regex capture groups - standard tier
+  - transactions:
+      - client-request:
+          method: GET
+          url: /api/data
+          version: '1.1'
+          headers:
+            fields:
+              - [Host, example.com]
+              - [Cookie, UserTier=standard]
+              - [uuid, test3-regex-standard]
+
+        server-response:
+          status: 200
+          reason: OK
+          headers:
+            fields:
+              - [Content-Length, '0']
+
+        proxy-request:
+          headers:
+            fields:
+              - [Host, {value: standard.service.com, as: prefix}]
+              - [X-User-Tier, {value: standard, as: equal}]
+
+  # Test 4: Using path variables
+  - transactions:
+      - client-request:
+          method: GET
+          url: /debug/path/to/resource
+          version: '1.1'
+          headers:
+            fields:
+              - [Host, example.com]
+              - [Cookie, Debug=true]
+              - [uuid, test4-path-vars]
+
+        server-response:
+          status: 200
+          reason: OK
+          headers:
+            fields:
+              - [Content-Length, '0']
+
+        proxy-request:
+          headers:
+            fields:
+              - [X-Original-Path, {value: debug/path/to/resource, as: equal}]
+              - [X-Debug-Mode, {value: enabled, as: equal}]
+
+  # Test 5: Multiple headers without Host (should preserve pristine host)
+  - transactions:
+      - client-request:
+          method: GET
+          url: /test/endpoint
+          version: '1.1'
+          headers:
+            fields:
+              - [Host, example.com]
+              - [Cookie, NoHost=yes]
+              - [uuid, test5-no-host]
+
+        server-response:
+          status: 200
+          reason: OK
+          headers:
+            fields:
+              - [Content-Length, '0']
+
+        proxy-request:
+          headers:
+            fields:
+              - [Host, {value: example.com, as: equal}]
+              - [X-Custom-1, {value: value1, as: equal}]
+              - [X-Custom-2, {value: value2, as: equal}]
+
+  # Test 6: No matching cookie - verify headers are NOT set on non-sendto path.
+  - transactions:
+      - client-request:
+          method: GET
+          url: /nomatch/endpoint
+          version: '1.1'
+          headers:
+            fields:
+              - [Host, example.com]
+              - [Cookie, UnknownCookie=value]
+              - [uuid, test6-no-match]
+
+        server-response:
+          status: 200
+          reason: OK
+          headers:
+            fields:
+              - [Content-Length, '0']
+
+        proxy-request:
+          headers:
+            fields:
+              - [Host, {value: example.com, as: equal}]
+              # Verify that set_sendto_headers are NOT present on non-sendto path
+              - [X-Custom-Header, {as: absent}]
+              - [X-User-Tier, {as: absent}]
+              - [X-Original-Path, {as: absent}]
+              - [X-Debug-Mode, {as: absent}]
+              - [X-Custom-1, {as: absent}]
+              - [X-Custom-2, {as: absent}]
+

--- a/tests/gold_tests/pluginTest/cookie_remap/set_sendto_headers.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/set_sendto_headers.test.py
@@ -1,0 +1,148 @@
+'''
+Verify cookie_remap plugin's set_sendto_headers functionality.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Test cookie_remap plugin's set_sendto_headers functionality. Verifies that:
+1. Headers can be set dynamically based on cookie rules
+2. Host header setting automatically disables pristine host header
+3. Regex capture groups work in header values ($1, $2, etc.)
+4. Path variables work in header values ($path, etc.)
+5. Multiple headers can be set simultaneously
+6. Headers are ONLY set on sendto path, NOT on non-matching (else) path
+'''
+Test.SkipUnless(Condition.PluginExists('cookie_remap.so'))
+Test.ContinueOnFail = True
+
+
+class TestSetSendtoHeaders:
+    """
+    Test the set_sendto_headers feature of cookie_remap plugin.
+
+    This test verifies that:
+    1. Simple header setting works (including Host)
+    2. Regex capture groups are substituted correctly in header values
+    3. Path variables are substituted correctly in header values
+    4. Multiple headers can be set
+    5. When Host header is set, pristine_host_hdr is automatically disabled
+    6. When Host header is NOT set, pristine_host_hdr behavior is preserved
+    7. Headers are ONLY set on sendto path (not on non-matching requests)
+    """
+
+    def __init__(self):
+        """Initialize the test by setting up servers and ATS configuration."""
+        self.replay_file = 'set_sendto_headers.replay.yaml'
+        self._setupDns()
+        self._setupServers()
+        self._setupTS()
+        self._setupClient()
+
+    def _setupDns(self):
+        """Configure the DNS server."""
+        self._dns = Test.MakeDNServer("dns", default='127.0.0.1')
+
+    def _setupServers(self):
+        """
+        Configure the origin servers using proxy-verifier.
+
+        Creates multiple servers to simulate different backend services.
+        """
+        # Server for simple host header test
+        self._server_backend = Test.MakeVerifierServerProcess("server_backend", self.replay_file)
+        self._server_backend.Streams.All += Testers.ContainsExpression(
+            'backend.com', 'Host header should be backend.com for test 1')
+        self._server_backend.Streams.All += Testers.ContainsExpression('custom-value', 'X-Custom-Header should be set for test 1')
+
+        # Server for regex capture group tests (premium and standard)
+        self._server_service = Test.MakeVerifierServerProcess("server_service", self.replay_file)
+        self._server_service.Streams.All += Testers.ContainsExpression(
+            'premium.service.com', 'Host header should be premium.service.com for premium tier')
+        self._server_service.Streams.All += Testers.ContainsExpression(
+            'standard.service.com', 'Host header should be standard.service.com for standard tier')
+
+        # Server for path variable test
+        self._server_debug = Test.MakeVerifierServerProcess("server_debug", self.replay_file)
+
+        # Server for no-host test (pristine host preserved)
+        self._server_nohost = Test.MakeVerifierServerProcess("server_nohost", self.replay_file)
+        self._server_nohost.Streams.All += Testers.ContainsExpression(
+            'example.com', 'Host header should be example.com (pristine) when Host not set in set_sendto_headers')
+
+        # Server for non-matching cookie test (verifies headers are NOT set on non-sendto path)
+        self._server_nomatch = Test.MakeVerifierServerProcess("server_nomatch", self.replay_file)
+        self._server_nomatch.Streams.All += Testers.ExcludesExpression(
+            'X-Custom-Header', 'Custom headers should NOT be present on non-sendto path')
+        self._server_nomatch.Streams.All += Testers.ExcludesExpression(
+            'X-User-Tier', 'Custom headers should NOT be present on non-sendto path')
+
+    def _setupTS(self):
+        """Configure Traffic Server with cookie_remap plugin."""
+        ts = Test.MakeATSProcess("ts", enable_cache=False)
+        self._ts = ts
+
+        # Enable debug logging for cookie_remap and enable pristine_host_hdr
+        # (simulating production environment)
+        ts.Disk.records_config.update(
+            {
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'cookie_remap|http',
+                'proxy.config.dns.nameservers': f"127.0.0.1:{self._dns.Variables.Port}",
+                'proxy.config.dns.resolv_conf': 'NULL',
+                'proxy.config.url_remap.pristine_host_hdr': 1,
+            })
+
+        # Read and configure the cookie_remap configuration file
+        config_filename = 'set_sendto_headers_config.yaml'
+        config_path = os.path.join(Test.TestDirectory, f"configs/{config_filename}")
+        with open(config_path, 'r') as config_file:
+            config_content = config_file.read()
+
+        # Replace port placeholders
+        config_content = config_content.replace("$BACKEND_PORT", str(self._server_backend.Variables.http_port))
+        config_content = config_content.replace("$SERVICE_PORT", str(self._server_service.Variables.http_port))
+        config_content = config_content.replace("$DEBUG_PORT", str(self._server_debug.Variables.http_port))
+        config_content = config_content.replace("$NOHOST_PORT", str(self._server_nohost.Variables.http_port))
+        config_content = config_content.replace("$NOMATCH_PORT", str(self._server_nomatch.Variables.http_port))
+
+        ts.Disk.File(ts.Variables.CONFIGDIR + f"/{config_filename}", id="cookie_config")
+        ts.Disk.cookie_config.WriteOn(config_content)
+
+        # Configure remap rule with cookie_remap plugin
+        # The default target should point to the nomatch server for testing
+        ts.Disk.remap_config.AddLine(
+            f'map http://example.com http://127.0.0.1:{self._server_nomatch.Variables.http_port} '
+            f'@plugin=cookie_remap.so @pparam=config/{config_filename}')
+
+    def _setupClient(self):
+        """Setup the client for the test."""
+        tr = Test.AddTestRun('Test cookie_remap set_sendto_headers functionality')
+
+        p = tr.AddVerifierClientProcess('client', self.replay_file, http_ports=[self._ts.Variables.port])
+        p.StartBefore(self._dns)
+        p.StartBefore(self._ts)
+        p.StartBefore(self._server_backend)
+        p.StartBefore(self._server_service)
+        p.StartBefore(self._server_debug)
+        p.StartBefore(self._server_nohost)
+        p.StartBefore(self._server_nomatch)
+
+
+# Execute the test
+TestSetSendtoHeaders()


### PR DESCRIPTION
This adds a new set_sendto_headers configuration option that allows setting arbitrary HTTP headers (including the Host header) on requests to sendto destinations when cookie rules match. Header values support dynamic substitution of regex capture groups ($1, $2, etc.) and path variables ($path, $cr_req_url, etc.). When the Host header is set via this option, pristine_host_hdr is automatically disabled for that transaction.