### PR TITLE
Fix Rocky Linux 8 ASAN plugin tests by suppressing dynamic linker leaks

### DIFF
--- a/src/proxy/http/remap/unit-tests/remap_test_dlopen_leak_suppression.txt
+++ b/src/proxy/http/remap/unit-tests/remap_test_dlopen_leak_suppression.txt
@@ -24,3 +24,6 @@
 # PluginDso::load
 leak:PluginDso::load
 leak:call_init
+# On Rocky Linux 8, ASAN reports leaks from the dynamic linker during dlopen
+# These are false positives as we properly call dlclose for each dlopen
+leak:ld-linux-x86-64.so


### PR DESCRIPTION
## Problem
Three unit tests were failing on Rocky Linux 8 with ASAN enabled in CI:
- `test_PluginDso`
- `test_PluginFactory`
- `test_RemapPluginInfo`

The tests were passing all their assertions, but LeakSanitizer was reporting false positive memory leaks from `dlopen` calls, causing the tests to fail.

## Root Cause
On Rocky Linux 8, ASAN's instrumentation of the dynamic linker (`ld-linux-x86-64.so`) causes it to report leaks during plugin initialization via `dlopen`, even though the code properly calls `dlclose()` for each handle.

The leak backtrace shows:
```
#0  operator new
#1  <unknown module>  (plugin_v1.so - global init)
#2  <unknown module>  (plugin_v1.so - init_array)
#3  <unknown module>  (plugin_v1.so - init)
#4  ld-linux-x86-64.so.2  (dynamic linker - call_init)
...
#16 PluginDso::load()
```

## Why Existing Suppressions Didn't Work
The suppression file already had `leak:PluginDso::load`, but it wasn't catching these leaks because:
- **LSAN uses fast unwinding by default**, which only captures ~5 stack frames
- `PluginDso::load` is at frame #16, so it's **not visible** in the fast unwind
- Using `fast_unwind_on_malloc=0` would allow the existing suppression to work, but has significant **performance overhead**.   I also had problems with the test segfaulting with `fast_unwind_on_malloc=0`.

## Solution
Added `leak:ld-linux-x86-64.so` to the suppression file, which catches the leak at frame #4 where the dynamic linker appears in the shallow stack trace.

## Testing
Tested in Rocky Linux 8 Docker container with ASAN enabled:
- ✅ All three tests now pass
- ✅ No performance impact from slow unwinding
- ✅ Tests still properly validate plugin loading/unloading logic

Fixes CI failures: https://ci.trafficserver.apache.org/job/master/job/os_build/46636/console