### PR TITLE
Require and call destructors on ClassAllocated objects

### DIFF
--- a/include/iocore/eventsystem/Event.h
+++ b/include/iocore/eventsystem/Event.h
@@ -289,7 +289,7 @@ public:
 //
 // Event Allocator
 //
-extern ClassAllocator<Event> eventAllocator;
+extern ClassAllocator<Event, false> eventAllocator;
 
 inline void
 Event::free()

--- a/include/iocore/eventsystem/IOBuffer.h
+++ b/include/iocore/eventsystem/IOBuffer.h
@@ -251,7 +251,7 @@ public:
   IOBufferData &operator=(const IOBufferData &) = delete;
 };
 
-extern ClassAllocator<IOBufferData> ioDataAllocator;
+extern ClassAllocator<IOBufferData, false> ioDataAllocator;
 
 /**
   A linkable portion of IOBufferData. IOBufferBlock is a chainable
@@ -494,7 +494,7 @@ public:
   IOBufferBlock &operator=(const IOBufferBlock &) = delete;
 };
 
-extern ClassAllocator<IOBufferBlock> ioBlockAllocator;
+extern ClassAllocator<IOBufferBlock, false> ioBlockAllocator;
 
 /** A class for holding a chain of IO buffer blocks.
     This class is intended to be used as a member variable for other classes that

--- a/include/iocore/eventsystem/Lock.h
+++ b/include/iocore/eventsystem/Lock.h
@@ -247,7 +247,7 @@ public:
 };
 
 // The ClassAllocator for ProxyMutexes
-extern ClassAllocator<ProxyMutex> mutexAllocator;
+extern ClassAllocator<ProxyMutex, false> mutexAllocator;
 
 inline bool
 Mutex_trylock(

--- a/include/iocore/utils/OneWayMultiTunnel.h
+++ b/include/iocore/utils/OneWayMultiTunnel.h
@@ -131,4 +131,4 @@ struct OneWayMultiTunnel : public OneWayTunnel {
   VIO              *vioTargets[ONE_WAY_MULTI_TUNNEL_LIMIT];
 };
 
-extern ClassAllocator<OneWayMultiTunnel> OneWayMultiTunnelAllocator;
+extern ClassAllocator<OneWayMultiTunnel, false> OneWayMultiTunnelAllocator;

--- a/include/proxy/http/Http1ClientSession.h
+++ b/include/proxy/http/Http1ClientSession.h
@@ -130,4 +130,4 @@ public:
   Http1ClientTransaction trans;
 };
 
-extern ClassAllocator<Http1ClientSession, true> http1ClientSessionAllocator;
+extern ClassAllocator<Http1ClientSession> http1ClientSessionAllocator;

--- a/include/proxy/http/Http1ServerSession.h
+++ b/include/proxy/http/Http1ServerSession.h
@@ -105,7 +105,7 @@ private:
   Http1ServerTransaction trans;
 };
 
-extern ClassAllocator<Http1ServerSession, true> httpServerSessionAllocator;
+extern ClassAllocator<Http1ServerSession> httpServerSessionAllocator;
 
 ////////////////////////////////////////////
 // INLINE

--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -187,7 +187,7 @@ class HttpSM : public Continuation, public PluginUserArgs<TS_USER_ARGS_TXN>
 
 public:
   HttpSM();
-  void         cleanup();
+  ~HttpSM() override;
   virtual void destroy();
 
   static HttpSM   *allocate();

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -860,8 +860,10 @@ public:
       free_internal_msg_buffer();
       ats_free(internal_msg_buffer_type);
 
-      ParentConfig::release(parent_params);
-      parent_params = nullptr;
+      if (parent_params != nullptr) {
+        ParentConfig::release(parent_params);
+        parent_params = nullptr;
+      }
 
       hdr_info.client_request.destroy();
       hdr_info.client_response.destroy();

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -850,6 +850,8 @@ public:
       //      memset((void *)&host_db_info, 0, sizeof(host_db_info));
     }
 
+    ~State() { destroy(); }
+
     void
     destroy()
     {
@@ -878,7 +880,6 @@ public:
       url_map.clear();
       arena.reset();
       unmapped_url.clear();
-      dns_info.~ResolveInfo();
       outbound_conn_track_state.clear();
 
       delete[] ranges;

--- a/include/proxy/http/PreWarmManager.h
+++ b/include/proxy/http/PreWarmManager.h
@@ -229,7 +229,7 @@ private:
   Event          *_retry_event      = nullptr;
 };
 
-extern ClassAllocator<PreWarmSM> preWarmSMAllocator;
+extern ClassAllocator<PreWarmSM, false> preWarmSMAllocator;
 
 /**
    @class PreWarmQueue

--- a/include/proxy/http/PreWarmManager.h
+++ b/include/proxy/http/PreWarmManager.h
@@ -138,8 +138,7 @@ class PreWarmSM;
 class PreWarmManager;
 class SNIConfigParams;
 
-extern ClassAllocator<PreWarmSM> preWarmSMAllocator;
-extern PreWarmManager            prewarmManager;
+extern PreWarmManager prewarmManager;
 
 /**
    @class PreWarmSM
@@ -229,6 +228,8 @@ private:
   IOBufferReader *_write_buf_reader = nullptr;
   Event          *_retry_event      = nullptr;
 };
+
+extern ClassAllocator<PreWarmSM> preWarmSMAllocator;
 
 /**
    @class PreWarmQueue

--- a/include/proxy/http2/Http2ClientSession.h
+++ b/include/proxy/http2/Http2ClientSession.h
@@ -79,4 +79,4 @@ private:
   IpEndpoint cached_local_addr;
 };
 
-extern ClassAllocator<Http2ClientSession, true> http2ClientSessionAllocator;
+extern ClassAllocator<Http2ClientSession> http2ClientSessionAllocator;

--- a/include/proxy/http2/Http2ServerSession.h
+++ b/include/proxy/http2/Http2ServerSession.h
@@ -103,4 +103,4 @@ private:
   bool in_session_table = false;
 };
 
-extern ClassAllocator<Http2ServerSession> http2ServerSessionAllocator;
+extern ClassAllocator<Http2ServerSession, false> http2ServerSessionAllocator;

--- a/include/proxy/http2/Http2Stream.h
+++ b/include/proxy/http2/Http2Stream.h
@@ -287,7 +287,7 @@ private:
   Event *_write_vio_event   = nullptr;
 };
 
-extern ClassAllocator<Http2Stream, true> http2StreamAllocator;
+extern ClassAllocator<Http2Stream> http2StreamAllocator;
 
 ////////////////////////////////////////////////////
 // INLINE

--- a/include/proxy/http3/Http3Frame.h
+++ b/include/proxy/http3/Http3Frame.h
@@ -175,10 +175,10 @@ using Http3FrameUPtr        = std::unique_ptr<Http3Frame, Http3FrameDeleterFunc>
 using Http3DataFrameUPtr    = std::unique_ptr<Http3DataFrame, Http3FrameDeleterFunc>;
 using Http3HeadersFrameUPtr = std::unique_ptr<Http3HeadersFrame, Http3FrameDeleterFunc>;
 
-extern ClassAllocator<Http3Frame>         http3FrameAllocator;
-extern ClassAllocator<Http3DataFrame>     http3DataFrameAllocator;
-extern ClassAllocator<Http3HeadersFrame>  http3HeadersFrameAllocator;
-extern ClassAllocator<Http3SettingsFrame> http3SettingsFrameAllocator;
+extern ClassAllocator<Http3Frame, false>         http3FrameAllocator;
+extern ClassAllocator<Http3DataFrame, false>     http3DataFrameAllocator;
+extern ClassAllocator<Http3HeadersFrame, false>  http3HeadersFrameAllocator;
+extern ClassAllocator<Http3SettingsFrame, false> http3SettingsFrameAllocator;
 
 class Http3FrameDeleter
 {

--- a/include/tscore/Allocator.h
+++ b/include/tscore/Allocator.h
@@ -39,7 +39,6 @@
 
 #pragma once
 
-#include <concepts>
 #include <cstdlib>
 #include <utility>
 #include "tscore/ink_queue.h"
@@ -330,8 +329,7 @@ using Allocator = FreelistAllocator;
   Allocator for Class objects.
 
 */
-template <std::destructible C, bool Destruct_on_free_ = true, typename BaseAllocator = Allocator>
-class ClassAllocator : public BaseAllocator
+template <class C, bool Destruct_on_free_ = true, typename BaseAllocator = Allocator> class ClassAllocator : public BaseAllocator
 {
 public:
   using Value_type                   = C;

--- a/plugins/experimental/memcache/tsmemcache.cc
+++ b/plugins/experimental/memcache/tsmemcache.cc
@@ -37,7 +37,7 @@
 #define REALTIME_MAXDELTA       60 * 60 * 24 * 30
 #define STRCMP_REST(_c, _s, _e) (((_e) - (_s)) < (int)sizeof(_c) || STRCMP(_s, _c) || !isspace((_s)[sizeof(_c) - 1]))
 
-ClassAllocator<MC> theMCAllocator("MC");
+ClassAllocator<MC, false> theMCAllocator("MC");
 
 static time_t base_day_time;
 

--- a/plugins/header_rewrite/matcher_tests.cc
+++ b/plugins/header_rewrite/matcher_tests.cc
@@ -83,7 +83,7 @@ TSHttpTxnServerRespGet(TSHttpTxn, TSMBuffer *, TSMLoc *)
   return TS_SUCCESS;
 }
 
-ClassAllocator<ProxyMutex> mutexAllocator("mutexAllocator");
+ClassAllocator<ProxyMutex, false> mutexAllocator("mutexAllocator");
 
 TEST_CASE("Matcher", "[plugins][header_rewrite]")
 {

--- a/src/api/APIHooks.cc
+++ b/src/api/APIHooks.cc
@@ -30,7 +30,7 @@
 #include "iocore/eventsystem/ProxyAllocator.h"
 #include "iocore/eventsystem/Thread.h"
 
-static ClassAllocator<APIHook> apiHookAllocator("apiHookAllocator");
+static ClassAllocator<APIHook, false> apiHookAllocator("apiHookAllocator");
 
 APIHook *
 APIHooks::head() const

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -129,7 +129,7 @@ static ts::Metrics &global_api_metrics = ts::Metrics::instance();
 ConfigUpdateCbTable *global_config_cbs = nullptr;
 
 // Fetchpages SM
-extern ClassAllocator<FetchSM> FetchSMAllocator;
+extern ClassAllocator<FetchSM, false> FetchSMAllocator;
 
 /* From proxy/http/HttpProxyServerMain.c: */
 extern bool ssl_register_protocol(const char *, Continuation *);
@@ -139,12 +139,12 @@ extern SSLSessionCache *session_cache; // declared extern in P_SSLConfig.h
 // External converters.
 extern MgmtConverter const &HttpDownServerCacheTimeConv;
 
-extern HttpSessionAccept                 *plugin_http_accept;
-extern HttpSessionAccept                 *plugin_http_transparent_accept;
-extern thread_local PluginThreadContext  *pluginThreadContext;
-extern ClassAllocator<INKContInternal>    INKContAllocator;
-extern ClassAllocator<INKVConnInternal>   INKVConnAllocator;
-static ClassAllocator<MIMEFieldSDKHandle> mHandleAllocator("MIMEFieldSDKHandle");
+extern HttpSessionAccept                        *plugin_http_accept;
+extern HttpSessionAccept                        *plugin_http_transparent_accept;
+extern thread_local PluginThreadContext         *pluginThreadContext;
+extern ClassAllocator<INKContInternal, false>    INKContAllocator;
+extern ClassAllocator<INKVConnInternal, false>   INKVConnAllocator;
+static ClassAllocator<MIMEFieldSDKHandle, false> mHandleAllocator("MIMEFieldSDKHandle");
 
 // forward declarations
 TSReturnCode sdk_sanity_check_null_ptr(void const *ptr);

--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -8831,7 +8831,7 @@ std::array<std::string_view, TS_CONFIG_LAST_ENTRY> SDK_Overridable_Configs = {
 };
 // clang-format on
 
-extern ClassAllocator<HttpSM> httpSMAllocator;
+extern ClassAllocator<HttpSM, false> httpSMAllocator;
 
 REGRESSION_TEST(SDK_API_OVERRIDABLE_CONFIGS)(RegressionTest *test, int /* atype ATS_UNUSED */, int *pstatus)
 {

--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -8831,7 +8831,7 @@ std::array<std::string_view, TS_CONFIG_LAST_ENTRY> SDK_Overridable_Configs = {
 };
 // clang-format on
 
-extern ClassAllocator<HttpSM, false> httpSMAllocator;
+extern ClassAllocator<HttpSM> httpSMAllocator;
 
 REGRESSION_TEST(SDK_API_OVERRIDABLE_CONFIGS)(RegressionTest *test, int /* atype ATS_UNUSED */, int *pstatus)
 {

--- a/src/api/InkContInternal.cc
+++ b/src/api/InkContInternal.cc
@@ -40,7 +40,7 @@
 #include "iocore/eventsystem/ProxyAllocator.h"
 #include "iocore/eventsystem/VConnection.h"
 
-ClassAllocator<INKContInternal> INKContAllocator("INKContAllocator");
+ClassAllocator<INKContInternal, false> INKContAllocator("INKContAllocator");
 
 namespace
 {

--- a/src/api/InkVConnInternal.cc
+++ b/src/api/InkVConnInternal.cc
@@ -26,7 +26,7 @@
 #include "ts/InkAPIPrivateIOCore.h"
 #include "tscore/ink_atomic.h"
 
-ClassAllocator<INKVConnInternal> INKVConnAllocator("INKVConnAllocator");
+ClassAllocator<INKVConnInternal, false> INKVConnAllocator("INKVConnAllocator");
 
 INKVConnInternal::INKVConnInternal() : INKContInternal(), m_read_vio(), m_write_vio(), m_output_vc(nullptr)
 {

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -24,7 +24,7 @@
 #include "cripts/Context.hpp"
 
 // Freelist management. These are here to avoid polluting the Context includes with ATS core includes.
-ClassAllocator<cripts::Context> criptContextAllocator("cripts::Context");
+ClassAllocator<cripts::Context, false> criptContextAllocator("cripts::Context");
 
 namespace cripts
 {

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -24,7 +24,7 @@
 #include "cripts/Context.hpp"
 
 // Freelist management. These are here to avoid polluting the Context includes with ATS core includes.
-ClassAllocator<cripts::Context, false> criptContextAllocator("cripts::Context");
+ClassAllocator<cripts::Context> criptContextAllocator("cripts::Context");
 
 namespace cripts
 {

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -85,21 +85,21 @@ int     cache_config_persist_bad_disks             = false;
 
 // Globals
 
-CacheStatsBlock                         cache_rsb;
-Cache                                  *theCache = nullptr;
-std::vector<std::unique_ptr<CacheDisk>> gdisks;
-int                                     gndisks                      = 0;
-Cache                                  *caches[NUM_CACHE_FRAG_TYPES] = {nullptr};
-CacheSync                              *cacheDirSync                 = nullptr;
-Store                                   theCacheStore;
-StripeSM                              **gstripes  = nullptr;
-std::atomic<int>                        gnstripes = 0;
-ClassAllocator<CacheVC>                 cacheVConnectionAllocator("cacheVConnection");
-ClassAllocator<CacheEvacuateDocVC>      cacheEvacuateDocVConnectionAllocator("cacheEvacuateDocVC");
-ClassAllocator<EvacuationBlock>         evacuationBlockAllocator("evacuationBlock");
-ClassAllocator<CacheRemoveCont>         cacheRemoveContAllocator("cacheRemoveCont");
-ClassAllocator<EvacuationKey>           evacuationKeyAllocator("evacuationKey");
-std::unordered_set<std::string>         known_bad_disks;
+CacheStatsBlock                           cache_rsb;
+Cache                                    *theCache = nullptr;
+std::vector<std::unique_ptr<CacheDisk>>   gdisks;
+int                                       gndisks                      = 0;
+Cache                                    *caches[NUM_CACHE_FRAG_TYPES] = {nullptr};
+CacheSync                                *cacheDirSync                 = nullptr;
+Store                                     theCacheStore;
+StripeSM                                **gstripes  = nullptr;
+std::atomic<int>                          gnstripes = 0;
+ClassAllocator<CacheVC, false>            cacheVConnectionAllocator("cacheVConnection");
+ClassAllocator<CacheEvacuateDocVC, false> cacheEvacuateDocVConnectionAllocator("cacheEvacuateDocVC");
+ClassAllocator<EvacuationBlock, false>    evacuationBlockAllocator("evacuationBlock");
+ClassAllocator<CacheRemoveCont, false>    cacheRemoveContAllocator("cacheRemoveCont");
+ClassAllocator<EvacuationKey, false>      evacuationKeyAllocator("evacuationKey");
+std::unordered_set<std::string>           known_bad_disks;
 
 namespace
 {

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -59,7 +59,7 @@ DbgCtl dbg_ctl_dir_lookaside{"dir_lookaside"};
 
 // Globals
 
-ClassAllocator<OpenDirEntry> openDirEntryAllocator("openDirEntry");
+ClassAllocator<OpenDirEntry, false> openDirEntryAllocator("openDirEntry");
 
 // OpenDir
 

--- a/src/iocore/cache/CacheEvacuateDocVC.h
+++ b/src/iocore/cache/CacheEvacuateDocVC.h
@@ -48,7 +48,7 @@ public:
   int evacuateReadHead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */);
 };
 
-extern ClassAllocator<CacheEvacuateDocVC> cacheEvacuateDocVConnectionAllocator;
+extern ClassAllocator<CacheEvacuateDocVC, false> cacheEvacuateDocVConnectionAllocator;
 
 inline CacheEvacuateDocVC *
 new_CacheEvacuateDocVC(Continuation *cont)

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -138,9 +138,9 @@ struct CacheRemoveCont : public Continuation {
 };
 
 // Global Data
-extern ClassAllocator<CacheVC>            cacheVConnectionAllocator;
-extern ClassAllocator<CacheEvacuateDocVC> cacheEvacuateDocVConnectionAllocator;
-extern CacheSync                         *cacheDirSync;
+extern ClassAllocator<CacheVC, false>            cacheVConnectionAllocator;
+extern ClassAllocator<CacheEvacuateDocVC, false> cacheEvacuateDocVConnectionAllocator;
+extern CacheSync                                *cacheDirSync;
 // Function Prototypes
 int                 cache_write(CacheVC *, CacheHTTPInfoVector *);
 int                 get_alternate_index(CacheHTTPInfoVector *cache_vector, CacheKey key);
@@ -411,7 +411,7 @@ next_rand(unsigned int *p)
   return seed;
 }
 
-extern ClassAllocator<CacheRemoveCont> cacheRemoveContAllocator;
+extern ClassAllocator<CacheRemoveCont, false> cacheRemoveContAllocator;
 
 inline CacheRemoveCont *
 new_CacheRemoveCont()

--- a/src/iocore/cache/PreservationTable.h
+++ b/src/iocore/cache/PreservationTable.h
@@ -197,8 +197,8 @@ PreservationTable::evac_bucket_valid(off_t bucket) const
   return (bucket >= 0 && bucket < evacuate_size);
 }
 
-extern ClassAllocator<EvacuationBlock> evacuationBlockAllocator;
-extern ClassAllocator<EvacuationKey>   evacuationKeyAllocator;
+extern ClassAllocator<EvacuationBlock, false> evacuationBlockAllocator;
+extern ClassAllocator<EvacuationKey, false>   evacuationKeyAllocator;
 
 inline EvacuationBlock *
 new_EvacuationBlock()

--- a/src/iocore/cache/RamCacheCLFUS.cc
+++ b/src/iocore/cache/RamCacheCLFUS.cc
@@ -173,7 +173,7 @@ RamCacheCLFUSCompressor::mainEvent(int /* event ATS_UNUSED */, Event *e)
   return EVENT_CONT;
 }
 
-ClassAllocator<RamCacheCLFUSEntry> ramCacheCLFUSEntryAllocator("RamCacheCLFUSEntry");
+ClassAllocator<RamCacheCLFUSEntry, false> ramCacheCLFUSEntryAllocator("RamCacheCLFUSEntry");
 
 static const int bucket_sizes[] = {127,      251,      509,       1021,      2039,      4093,       8191,      16381,   32749,
                                    65521,    131071,   262139,    524287,    1048573,   2097143,    4194301,   8388593, 16777213,

--- a/src/iocore/cache/RamCacheLRU.cc
+++ b/src/iocore/cache/RamCacheLRU.cc
@@ -89,7 +89,7 @@ RamCacheLRU::size() const
   return s;
 }
 
-ClassAllocator<RamCacheLRUEntry> ramCacheLRUEntryAllocator("RamCacheLRUEntry");
+ClassAllocator<RamCacheLRUEntry, false> ramCacheLRUEntryAllocator("RamCacheLRUEntry");
 
 static const int bucket_sizes[] = {8191,    16381,   32749,    65521,    131071,   262139,    524287,    1048573,   2097143,
                                    4194301, 8388593, 16777213, 33554393, 67108859, 134217689, 268435399, 536870909, 1073741827};

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -247,10 +247,10 @@ private:
 
 // Global Data
 
-extern StripeSM                   **gstripes;
-extern std::atomic<int>             gnstripes;
-extern ClassAllocator<OpenDirEntry> openDirEntryAllocator;
-extern unsigned short              *vol_hash_table;
+extern StripeSM                          **gstripes;
+extern std::atomic<int>                    gnstripes;
+extern ClassAllocator<OpenDirEntry, false> openDirEntryAllocator;
+extern unsigned short                     *vol_hash_table;
 
 // inline Functions
 

--- a/src/iocore/cache/unit_tests/stub.cc
+++ b/src/iocore/cache/unit_tests/stub.cc
@@ -56,7 +56,7 @@ TSIOBufferReaderConsume(TSIOBufferReader /* readerp ATS_UNUSED */, int64_t /* nb
 }
 
 #include "proxy/FetchSM.h"
-ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+ClassAllocator<FetchSM, false> FetchSMAllocator("unusedFetchSMAllocator");
 bool
 FetchSM::is_initialized()
 {

--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -90,11 +90,11 @@ is_addr_query(int qtype)
 }
 } // namespace
 
-DNSProcessor             dnsProcessor;
-ClassAllocator<DNSEntry> dnsEntryAllocator("dnsEntryAllocator");
+DNSProcessor                    dnsProcessor;
+ClassAllocator<DNSEntry, false> dnsEntryAllocator("dnsEntryAllocator");
 // Users are expected to free these entries in short order!
 // We could page align this buffer to enable page flipping for recv...
-ClassAllocator<HostEnt> dnsBufAllocator("dnsBufAllocator", 2);
+ClassAllocator<HostEnt, false> dnsBufAllocator("dnsBufAllocator", 2);
 
 //
 // Function Prototypes

--- a/src/iocore/dns/SplitDNS.cc
+++ b/src/iocore/dns/SplitDNS.cc
@@ -48,7 +48,7 @@ static const char modulePrefix[] = "[SplitDNS]";
 
 ConfigUpdateHandler<SplitDNSConfig> *SplitDNSConfig::splitDNSUpdate = nullptr;
 
-static ClassAllocator<DNSRequestData> DNSReqAllocator("DNSRequestDataAllocator");
+static ClassAllocator<DNSRequestData, false> DNSReqAllocator("DNSRequestDataAllocator");
 
 /* --------------------------------------------------------------
    used by a lot of protocols. We do not have dest ip in most

--- a/src/iocore/eventsystem/IOBuffer.cc
+++ b/src/iocore/eventsystem/IOBuffer.cc
@@ -583,7 +583,7 @@ IOBufferReader::reset()
 //      inline functions definitions
 //
 ////////////////////////////////////////////////////////////////
-extern ClassAllocator<MIOBuffer> ioAllocator;
+extern ClassAllocator<MIOBuffer, false> ioAllocator;
 
 MIOBuffer::MIOBuffer(int64_t default_size_index)
 {
@@ -1001,12 +1001,12 @@ MeteredAllocator<FreelistAllocator> ioBufAllocator[DEFAULT_BUFFER_SIZES];
 #else
 FreelistAllocator ioBufAllocator[DEFAULT_BUFFER_SIZES];
 #endif
-ClassAllocator<MIOBuffer>     ioAllocator("ioAllocator", DEFAULT_BUFFER_NUMBER);
-ClassAllocator<IOBufferData>  ioDataAllocator("ioDataAllocator", DEFAULT_BUFFER_NUMBER);
-ClassAllocator<IOBufferBlock> ioBlockAllocator("ioBlockAllocator", DEFAULT_BUFFER_NUMBER);
-int64_t                       default_large_iobuffer_size = DEFAULT_LARGE_BUFFER_SIZE;
-int64_t                       default_small_iobuffer_size = DEFAULT_SMALL_BUFFER_SIZE;
-int64_t                       max_iobuffer_size           = DEFAULT_BUFFER_SIZES - 1;
+ClassAllocator<MIOBuffer, false>     ioAllocator("ioAllocator", DEFAULT_BUFFER_NUMBER);
+ClassAllocator<IOBufferData, false>  ioDataAllocator("ioDataAllocator", DEFAULT_BUFFER_NUMBER);
+ClassAllocator<IOBufferBlock, false> ioBlockAllocator("ioBlockAllocator", DEFAULT_BUFFER_NUMBER);
+int64_t                              default_large_iobuffer_size = DEFAULT_LARGE_BUFFER_SIZE;
+int64_t                              default_small_iobuffer_size = DEFAULT_SMALL_BUFFER_SIZE;
+int64_t                              max_iobuffer_size           = DEFAULT_BUFFER_SIZES - 1;
 
 //
 // Initialization

--- a/src/iocore/eventsystem/Lock.cc
+++ b/src/iocore/eventsystem/Lock.cc
@@ -31,7 +31,7 @@
 #include "iocore/eventsystem/Lock.h"
 #include "tsutil/DbgCtl.h"
 
-ClassAllocator<ProxyMutex> mutexAllocator("mutexAllocator");
+ClassAllocator<ProxyMutex, false> mutexAllocator("mutexAllocator");
 
 namespace
 {

--- a/src/iocore/eventsystem/ProtectedQueue.cc
+++ b/src/iocore/eventsystem/ProtectedQueue.cc
@@ -42,7 +42,7 @@
 //
 // #define EAGER_SIGNALLING
 
-extern ClassAllocator<Event> eventAllocator;
+extern ClassAllocator<Event, false> eventAllocator;
 
 void
 ProtectedQueue::enqueue(Event *e)

--- a/src/iocore/eventsystem/UnixEvent.cc
+++ b/src/iocore/eventsystem/UnixEvent.cc
@@ -31,7 +31,7 @@
 #include "iocore/eventsystem/Event.h"
 #include "iocore/eventsystem/EThread.h"
 
-ClassAllocator<Event> eventAllocator("eventAllocator", 256);
+ClassAllocator<Event, false> eventAllocator("eventAllocator", 256);
 
 void
 Event::schedule_imm(int acallback_event)

--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -72,7 +72,7 @@ static swoc::file::path hostdb_hostfile_path;
 int                     hostdb_disable_reverse_lookup = 0;
 int                     hostdb_max_iobuf_index        = BUFFER_SIZE_INDEX_32K;
 
-ClassAllocator<HostDBContinuation> hostDBContAllocator("hostDBContAllocator");
+ClassAllocator<HostDBContinuation, false> hostDBContAllocator("hostDBContAllocator");
 
 namespace
 {

--- a/src/iocore/hostdb/P_RefCountCache.h
+++ b/src/iocore/hostdb/P_RefCountCache.h
@@ -115,7 +115,7 @@ public:
 };
 
 // Since the hashing values are all fixed size, we can simply use a classAllocator to avoid mallocs
-extern ClassAllocator<PriorityQueueEntry<RefCountCacheHashEntry *>> expiryQueueEntry;
+extern ClassAllocator<PriorityQueueEntry<RefCountCacheHashEntry *>, false> expiryQueueEntry;
 
 struct RefCountCacheLinkage {
   using key_type   = uint64_t const;

--- a/src/iocore/hostdb/RefCountCache.cc
+++ b/src/iocore/hostdb/RefCountCache.cc
@@ -22,9 +22,9 @@
 #include "P_RefCountCache.h"
 
 // Since the hashing values are all fixed size, we can simply use a classAllocator to avoid mallocs
-static ClassAllocator<RefCountCacheHashEntry> refCountCacheHashingValueAllocator("refCountCacheHashingValueAllocator");
+static ClassAllocator<RefCountCacheHashEntry, false> refCountCacheHashingValueAllocator("refCountCacheHashingValueAllocator");
 
-ClassAllocator<PriorityQueueEntry<RefCountCacheHashEntry *>> expiryQueueEntry("expiryQueueEntry");
+ClassAllocator<PriorityQueueEntry<RefCountCacheHashEntry *>, false> expiryQueueEntry("expiryQueueEntry");
 
 RefCountCacheHashEntry *
 RefCountCacheHashEntry::alloc()

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -49,7 +49,7 @@
 // bytes
 #define MAX_OCSP_GET_ENCODED_LENGTH 255 // maximum of 254 bytes + \0
 
-extern ClassAllocator<FetchSM> FetchSMAllocator;
+extern ClassAllocator<FetchSM, false> FetchSMAllocator;
 
 // clang-format off
 #pragma GCC diagnostic push

--- a/src/iocore/net/P_QUICNet.h
+++ b/src/iocore/net/P_QUICNet.h
@@ -74,4 +74,4 @@ get_QUICPollCont(EThread *t)
   return static_cast<QUICPollCont *>(ETHREAD_GET_PTR(t, quic_NetProcessor.quicPollCont_offset));
 }
 
-extern ClassAllocator<QUICPollEvent> quicPollEventAllocator;
+extern ClassAllocator<QUICPollEvent, false> quicPollEventAllocator;

--- a/src/iocore/net/P_QUICNetVConnection.h
+++ b/src/iocore/net/P_QUICNetVConnection.h
@@ -236,4 +236,4 @@ private:
   bool _is_cert_verified  = false;
 };
 
-extern ClassAllocator<QUICNetVConnection> quicNetVCAllocator;
+extern ClassAllocator<QUICNetVConnection, false> quicNetVCAllocator;

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -438,4 +438,4 @@ private:
 
 using SSLNetVConnHandler = int (SSLNetVConnection::*)(int, void *);
 
-extern ClassAllocator<SSLNetVConnection> sslNetVCAllocator;
+extern ClassAllocator<SSLNetVConnection, false> sslNetVCAllocator;

--- a/src/iocore/net/P_Socks.h
+++ b/src/iocore/net/P_Socks.h
@@ -125,4 +125,4 @@ struct SocksEntry : public Continuation {
 
 using SocksEntryHandler = int (SocksEntry::*)(int, void *);
 
-extern ClassAllocator<SocksEntry> socksAllocator;
+extern ClassAllocator<SocksEntry, false> socksAllocator;

--- a/src/iocore/net/P_UDPIOEvent.h
+++ b/src/iocore/net/P_UDPIOEvent.h
@@ -100,7 +100,7 @@ private:
   int                bytesTransferred = 0; // actual bytes transferred
 };
 
-extern ClassAllocator<UDPIOEvent> UDPIOEventAllocator;
+extern ClassAllocator<UDPIOEvent, false> UDPIOEventAllocator;
 TS_INLINE void
 UDPIOEvent::free(UDPIOEvent *e)
 {

--- a/src/iocore/net/P_UnixNetVConnection.h
+++ b/src/iocore/net/P_UnixNetVConnection.h
@@ -251,7 +251,7 @@ private:
   std::shared_ptr<ConnectionTracker::Group> conn_track_group;
 };
 
-extern ClassAllocator<UnixNetVConnection> netVCAllocator;
+extern ClassAllocator<UnixNetVConnection, false> netVCAllocator;
 
 using NetVConnHandler = int (UnixNetVConnection::*)(int, void *);
 

--- a/src/iocore/net/QUICNet.cc
+++ b/src/iocore/net/QUICNet.cc
@@ -30,7 +30,7 @@
 #include "tscore/ink_atomic.h"
 #include <quiche.h>
 
-ClassAllocator<QUICPollEvent> quicPollEventAllocator("quicPollEvent");
+ClassAllocator<QUICPollEvent, false> quicPollEventAllocator("quicPollEvent");
 
 void
 QUICPollEvent::init(QUICConnection *con, UDPPacket *packet)

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -50,7 +50,7 @@ DbgCtl dbg_ctl_v_quic_net{"v_quic_net"};
 #define QUICConDebug(fmt, ...)  Dbg(dbg_ctl_quic_net, "[%s] " fmt, this->cids().data(), ##__VA_ARGS__)
 #define QUICConVDebug(fmt, ...) Dbg(dbg_ctl_v_quic_net, "[%s] " fmt, this->cids().data(), ##__VA_ARGS__)
 
-ClassAllocator<QUICNetVConnection> quicNetVCAllocator("quicNetVCAllocator");
+ClassAllocator<QUICNetVConnection, false> quicNetVCAllocator("quicNetVCAllocator");
 
 QUICNetVConnection::QUICNetVConnection()
 {

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -74,7 +74,7 @@ using namespace std::literals;
 #define SSL_WAIT_FOR_ASYNC         12
 #define SSL_RESTART                13
 
-ClassAllocator<SSLNetVConnection> sslNetVCAllocator("sslNetVCAllocator");
+ClassAllocator<SSLNetVConnection, false> sslNetVCAllocator("sslNetVCAllocator");
 
 namespace
 {

--- a/src/iocore/net/Socks.cc
+++ b/src/iocore/net/Socks.cc
@@ -38,7 +38,7 @@
 
 using namespace swoc::literals;
 
-ClassAllocator<SocksEntry> socksAllocator("socksAllocator");
+ClassAllocator<SocksEntry, false> socksAllocator("socksAllocator");
 
 namespace
 {

--- a/src/iocore/net/UDPIOEvent.cc
+++ b/src/iocore/net/UDPIOEvent.cc
@@ -24,4 +24,4 @@
 #include "tscore/Allocator.h"
 #include "P_UDPIOEvent.h"
 
-ClassAllocator<UDPIOEvent> UDPIOEventAllocator("UDPIOEventAllocator");
+ClassAllocator<UDPIOEvent, false> UDPIOEventAllocator("UDPIOEventAllocator");

--- a/src/iocore/net/UnixNetVConnection.cc
+++ b/src/iocore/net/UnixNetVConnection.cc
@@ -38,7 +38,7 @@
 #define STATE_FROM_VIO(_x) ((NetState *)(((char *)(_x)) - STATE_VIO_OFFSET))
 
 // Global
-ClassAllocator<UnixNetVConnection> netVCAllocator("netVCAllocator");
+ClassAllocator<UnixNetVConnection, false> netVCAllocator("netVCAllocator");
 
 namespace
 {

--- a/src/iocore/net/UnixUDPNet.cc
+++ b/src/iocore/net/UnixUDPNet.cc
@@ -64,8 +64,8 @@
 
 using UDPNetContHandler = int (UDPNetHandler::*)(int, void *);
 
-ClassAllocator<UDPPacket> udpPacketAllocator("udpPacketAllocator");
-EventType                 ET_UDP;
+ClassAllocator<UDPPacket, false> udpPacketAllocator("udpPacketAllocator");
+EventType                        ET_UDP;
 
 namespace
 {
@@ -746,7 +746,7 @@ private:
   ink_hrtime           timeout_interval = 0;
 };
 
-ClassAllocator<UDPReadContinuation> udpReadContAllocator("udpReadContAllocator");
+ClassAllocator<UDPReadContinuation, false> udpReadContAllocator("udpReadContAllocator");
 
 UDPReadContinuation::UDPReadContinuation(Event *completionToken)
   : Continuation(nullptr),

--- a/src/iocore/net/libinknet_stub.cc
+++ b/src/iocore/net/libinknet_stub.cc
@@ -26,7 +26,7 @@
 AppVersionInfo appVersionInfo;
 
 #include "proxy/FetchSM.h"
-ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+ClassAllocator<FetchSM, false> FetchSMAllocator("unusedFetchSMAllocator");
 bool
 FetchSM::is_initialized()
 {

--- a/src/iocore/utils/OneWayMultiTunnel.cc
+++ b/src/iocore/utils/OneWayMultiTunnel.cc
@@ -37,7 +37,7 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-ClassAllocator<OneWayMultiTunnel> OneWayMultiTunnelAllocator("OneWayMultiTunnelAllocator");
+ClassAllocator<OneWayMultiTunnel, false> OneWayMultiTunnelAllocator("OneWayMultiTunnelAllocator");
 
 OneWayMultiTunnel::OneWayMultiTunnel() : OneWayTunnel()
 {

--- a/src/iocore/utils/OneWayTunnel.cc
+++ b/src/iocore/utils/OneWayTunnel.cc
@@ -43,7 +43,7 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-ClassAllocator<OneWayTunnel> OneWayTunnelAllocator("OneWayTunnelAllocator");
+ClassAllocator<OneWayTunnel, false> OneWayTunnelAllocator("OneWayTunnelAllocator");
 
 namespace
 {

--- a/src/proxy/FetchSM.cc
+++ b/src/proxy/FetchSM.cc
@@ -32,7 +32,7 @@
 #define DEBUG_TAG             "FetchSM"
 #define FETCH_LOCK_RETRY_TIME HRTIME_MSECONDS(10)
 
-ClassAllocator<FetchSM> FetchSMAllocator("FetchSMAllocator");
+ClassAllocator<FetchSM, false> FetchSMAllocator("FetchSMAllocator");
 
 namespace
 {

--- a/src/proxy/ProxyTransaction.cc
+++ b/src/proxy/ProxyTransaction.cc
@@ -32,7 +32,7 @@ DbgCtl dbg_ctl_http_txn{"http_txn"};
 
 #define HttpTxnDebug(fmt, ...) SsnDbg(this, dbg_ctl_http_txn, fmt, __VA_ARGS__)
 
-extern ClassAllocator<HttpSM> httpSMAllocator;
+extern ClassAllocator<HttpSM, false> httpSMAllocator;
 
 ProxyTransaction::ProxyTransaction(ProxySession *session) : VConnection(nullptr), _proxy_ssn(session) {}
 

--- a/src/proxy/ProxyTransaction.cc
+++ b/src/proxy/ProxyTransaction.cc
@@ -32,7 +32,7 @@ DbgCtl dbg_ctl_http_txn{"http_txn"};
 
 #define HttpTxnDebug(fmt, ...) SsnDbg(this, dbg_ctl_http_txn, fmt, __VA_ARGS__)
 
-extern ClassAllocator<HttpSM, false> httpSMAllocator;
+extern ClassAllocator<HttpSM> httpSMAllocator;
 
 ProxyTransaction::ProxyTransaction(ProxySession *session) : VConnection(nullptr), _proxy_ssn(session) {}
 

--- a/src/proxy/hdrs/HTTP.cc
+++ b/src/proxy/hdrs/HTTP.cc
@@ -1936,7 +1936,7 @@ HTTPHdrImpl::check_strings(HeapCheck *heaps, int num_heaps)
   }
 }
 
-ClassAllocator<HTTPCacheAlt> httpCacheAltAllocator("httpCacheAltAllocator");
+ClassAllocator<HTTPCacheAlt, false> httpCacheAltAllocator("httpCacheAltAllocator");
 
 /*-------------------------------------------------------------------------
   -------------------------------------------------------------------------*/

--- a/src/proxy/http/Http1ClientSession.cc
+++ b/src/proxy/http/Http1ClientSession.cc
@@ -59,7 +59,7 @@ ink_mutex debug_cs_list_mutex;
 
 #endif /* USE_HTTP_DEBUG_LISTS */
 
-ClassAllocator<Http1ClientSession, true> http1ClientSessionAllocator("http1ClientSessionAllocator");
+ClassAllocator<Http1ClientSession> http1ClientSessionAllocator("http1ClientSessionAllocator");
 
 namespace
 {

--- a/src/proxy/http/Http1ServerSession.cc
+++ b/src/proxy/http/Http1ServerSession.cc
@@ -36,7 +36,7 @@
 #include "proxy/http/HttpSessionManager.h"
 #include "proxy/http/HttpSM.h"
 
-ClassAllocator<Http1ServerSession, true> httpServerSessionAllocator("httpServerSessionAllocator");
+ClassAllocator<Http1ServerSession> httpServerSessionAllocator("httpServerSessionAllocator");
 
 namespace
 {

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -251,11 +251,8 @@ HttpSM::get_server_connect_timeout()
 
 HttpSM::HttpSM() : Continuation(nullptr), vc_table(this) {}
 
-void
-HttpSM::cleanup()
+HttpSM::~HttpSM()
 {
-  t_state.destroy();
-  api_hooks.clear();
   http_parser_clear(&http_parser);
 
   HttpConfig::release(t_state.http_config_param);
@@ -280,7 +277,6 @@ HttpSM::cleanup()
 void
 HttpSM::destroy()
 {
-  cleanup();
   THREAD_FREE(this, httpSMAllocator, this_thread());
 }
 

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -176,7 +176,7 @@ do_outbound_proxy_protocol(MIOBuffer *miob, NetVConnection *vc_out, NetVConnecti
   return len;
 }
 
-ClassAllocator<HttpSM, false> httpSMAllocator("httpSMAllocator");
+ClassAllocator<HttpSM> httpSMAllocator("httpSMAllocator");
 
 void
 initialize_thread_for_connecting_pools(EThread *thread)

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -176,7 +176,7 @@ do_outbound_proxy_protocol(MIOBuffer *miob, NetVConnection *vc_out, NetVConnecti
   return len;
 }
 
-ClassAllocator<HttpSM> httpSMAllocator("httpSMAllocator");
+ClassAllocator<HttpSM, false> httpSMAllocator("httpSMAllocator");
 
 void
 initialize_thread_for_connecting_pools(EThread *thread)

--- a/src/proxy/http/PreWarmManager.cc
+++ b/src/proxy/http/PreWarmManager.cc
@@ -39,8 +39,8 @@
 #define PreWarmSMDbg(fmt, ...)  Dbg(dbg_ctl_prewarm_sm, "[%p] " fmt, this, ##__VA_ARGS__);
 #define PreWarmSMVDbg(fmt, ...) Dbg(dbg_ctl_v_prewarm_sm, "[%p] " fmt, this, ##__VA_ARGS__);
 
-ClassAllocator<PreWarmSM> preWarmSMAllocator("preWarmSMAllocator");
-PreWarmManager            prewarmManager;
+ClassAllocator<PreWarmSM, false> preWarmSMAllocator("preWarmSMAllocator");
+PreWarmManager                   prewarmManager;
 
 namespace
 {

--- a/src/proxy/http/remap/RemapPlugins.cc
+++ b/src/proxy/http/remap/RemapPlugins.cc
@@ -26,7 +26,7 @@
 
 namespace
 {
-ClassAllocator<RemapPlugins> pluginAllocator("RemapPluginsAlloc");
+ClassAllocator<RemapPlugins, false> pluginAllocator("RemapPluginsAlloc");
 
 DbgCtl dbg_ctl_url_rewrite{"url_rewrite"};
 

--- a/src/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
+++ b/src/proxy/http/remap/unit-tests/nexthop_test_stubs.cc
@@ -32,11 +32,10 @@
 #include "proxy/http/HttpSM.h"
 #include "nexthop_test_stubs.h"
 
+int ParentConfig::m_id = 0;
+
 HttpSM::HttpSM() : Continuation(nullptr), vc_table(this) {}
-void
-HttpSM::cleanup()
-{
-}
+HttpSM::~HttpSM() {}
 void
 HttpSM::destroy()
 {

--- a/src/proxy/http/remap/unit-tests/plugin_stub.cc
+++ b/src/proxy/http/remap/unit-tests/plugin_stub.cc
@@ -25,4 +25,4 @@
 #include "proxy/http/remap/PluginFactory.h"
 
 thread_local PluginThreadContext *pluginThreadContext;
-ClassAllocator<ProxyMutex>        mutexAllocator("mutexAllocator");
+ClassAllocator<ProxyMutex, false> mutexAllocator("mutexAllocator");

--- a/src/proxy/http2/Http2ClientSession.cc
+++ b/src/proxy/http2/Http2ClientSession.cc
@@ -29,7 +29,7 @@
 #include "iocore/net/TLSSNISupport.h"
 #include "iocore/net/TLSEarlyDataSupport.h"
 
-ClassAllocator<Http2ClientSession, true> http2ClientSessionAllocator("http2ClientSessionAllocator");
+ClassAllocator<Http2ClientSession> http2ClientSessionAllocator("http2ClientSessionAllocator");
 
 namespace
 {

--- a/src/proxy/http2/Http2ServerSession.cc
+++ b/src/proxy/http2/Http2ServerSession.cc
@@ -29,7 +29,7 @@
 #include "proxy/http2/Http2CommonSessionInternal.h"
 #include "proxy/http/HttpSessionManager.h"
 
-ClassAllocator<Http2ServerSession> http2ServerSessionAllocator("http2ServerSessionAllocator");
+ClassAllocator<Http2ServerSession, false> http2ServerSessionAllocator("http2ServerSessionAllocator");
 
 static int
 send_connection_event(Continuation *cont, int event, void *edata)

--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -49,7 +49,7 @@ DbgCtl dbg_ctl_http2_stream{"http2_stream"};
 #define Http2StreamDebug(fmt, ...) \
   SsnDbg(_proxy_ssn, dbg_ctl_http2_stream, "[%" PRId64 "] [%u] " fmt, _proxy_ssn->connection_id(), this->get_id(), ##__VA_ARGS__);
 
-ClassAllocator<Http2Stream, true> http2StreamAllocator("http2StreamAllocator");
+ClassAllocator<Http2Stream> http2StreamAllocator("http2StreamAllocator");
 
 Http2Stream::Http2Stream(ProxySession *session, Http2StreamId sid, ssize_t initial_peer_rwnd, ssize_t initial_local_rwnd,
                          bool registered_stream)

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -27,10 +27,10 @@
 #include "proxy/http3/Http3Frame.h"
 #include "proxy/http3/Http3Config.h"
 
-ClassAllocator<Http3Frame>         http3FrameAllocator("http3FrameAllocator");
-ClassAllocator<Http3DataFrame>     http3DataFrameAllocator("http3DataFrameAllocator");
-ClassAllocator<Http3HeadersFrame>  http3HeadersFrameAllocator("http3HeadersFrameAllocator");
-ClassAllocator<Http3SettingsFrame> http3SettingsFrameAllocator("http3SettingsFrameAllocator");
+ClassAllocator<Http3Frame, false>         http3FrameAllocator("http3FrameAllocator");
+ClassAllocator<Http3DataFrame, false>     http3DataFrameAllocator("http3DataFrameAllocator");
+ClassAllocator<Http3HeadersFrame, false>  http3HeadersFrameAllocator("http3HeadersFrameAllocator");
+ClassAllocator<Http3SettingsFrame, false> http3SettingsFrameAllocator("http3SettingsFrameAllocator");
 
 namespace
 {

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -314,8 +314,8 @@ HttpSM::init(bool from_early_data)
   ink_abort("do not call stub");
 }
 
-ClassAllocator<HttpSM> httpSMAllocator("httpSMAllocator");
-HttpAPIHooks          *http_global_hooks;
+ClassAllocator<HttpSM, false> httpSMAllocator("httpSMAllocator");
+HttpAPIHooks                 *http_global_hooks;
 
 HttpVCTable::HttpVCTable(HttpSM *) {}
 
@@ -345,7 +345,7 @@ PreWarmManager::reconfigure()
 PreWarmManager prewarmManager;
 
 #include "proxy/FetchSM.h"
-ClassAllocator<FetchSM> FetchSMAllocator("unusedFetchSMAllocator");
+ClassAllocator<FetchSM, false> FetchSMAllocator("unusedFetchSMAllocator");
 bool
 FetchSM::is_initialized()
 {

--- a/src/traffic_quic/traffic_quic.cc
+++ b/src/traffic_quic/traffic_quic.cc
@@ -314,8 +314,8 @@ HttpSM::init(bool from_early_data)
   ink_abort("do not call stub");
 }
 
-ClassAllocator<HttpSM, false> httpSMAllocator("httpSMAllocator");
-HttpAPIHooks                 *http_global_hooks;
+ClassAllocator<HttpSM> httpSMAllocator("httpSMAllocator");
+HttpAPIHooks          *http_global_hooks;
 
 HttpVCTable::HttpVCTable(HttpSM *) {}
 

--- a/src/traffic_server/SocksProxy.cc
+++ b/src/traffic_server/SocksProxy.cc
@@ -138,7 +138,7 @@ private:
   int           recursion = 0;
 };
 
-ClassAllocator<SocksProxy> socksProxyAllocator("socksProxyAllocator");
+ClassAllocator<SocksProxy, false> socksProxyAllocator("socksProxyAllocator");
 
 void
 SocksProxy::init(NetVConnection *netVC)

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -172,6 +172,7 @@ if(BUILD_TESTING)
     unit_tests/test_scoped_resource.cc
     unit_tests/test_Version.cc
     unit_tests/test_ArgParser_MutexGroup.cc
+    unit_tests/test_Allocator.cc
   )
   target_link_libraries(
     test_tscore

--- a/src/tscore/unit_tests/test_Allocator.cc
+++ b/src/tscore/unit_tests/test_Allocator.cc
@@ -105,7 +105,7 @@ struct CleanupTracker {
 
 TEST_CASE("ClassAllocator basic allocation", "[libts][allocator]")
 {
-  ClassAllocator<SimplePOD> allocator("test_simple_pod");
+  ClassAllocator<SimplePOD, false> allocator("test_simple_pod");
 
   SECTION("Allocate and free simple POD")
   {
@@ -232,7 +232,7 @@ TEST_CASE("ClassAllocator with RAII types", "[libts][allocator]")
 
 TEST_CASE("ClassAllocator with complex types", "[libts][allocator]")
 {
-  ClassAllocator<ComplexObject> allocator("test_complex");
+  ClassAllocator<ComplexObject, false> allocator("test_complex");
 
   SECTION("Complex object with std::string")
   {

--- a/src/tscore/unit_tests/test_Allocator.cc
+++ b/src/tscore/unit_tests/test_Allocator.cc
@@ -232,7 +232,7 @@ TEST_CASE("ClassAllocator with RAII types", "[libts][allocator]")
 
 TEST_CASE("ClassAllocator with complex types", "[libts][allocator]")
 {
-  ClassAllocator<ComplexObject, false> allocator("test_complex");
+  ClassAllocator<ComplexObject> allocator("test_complex");
 
   SECTION("Complex object with std::string")
   {

--- a/src/tscore/unit_tests/test_Allocator.cc
+++ b/src/tscore/unit_tests/test_Allocator.cc
@@ -1,0 +1,330 @@
+/** @file
+
+    Allocator tests.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "tscore/Allocator.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+
+// Counter to track constructor/destructor calls
+static int g_construct_count = 0;
+static int g_destruct_count  = 0;
+
+// Simple POD type
+struct SimplePOD {
+  int    x;
+  double y;
+  void  *ptr;
+};
+
+// Type with non-trivial destructor that tracks calls
+// Must be at least sizeof(void*) for ClassAllocator
+struct TrackedObject {
+  int   value;
+  void *padding; // Ensure size >= sizeof(void*)
+
+  TrackedObject(int v = 0) : value(v), padding(nullptr) { g_construct_count++; }
+
+  ~TrackedObject() { g_destruct_count++; }
+};
+
+// Type with resource management (RAII)
+struct ResourceHolder {
+  std::unique_ptr<int> resource;
+  bool                *destroyed_flag;
+
+  ResourceHolder(int val, bool *flag) : resource(std::make_unique<int>(val)), destroyed_flag(flag) {}
+
+  ~ResourceHolder()
+  {
+    if (destroyed_flag) {
+      *destroyed_flag = true;
+    }
+  }
+};
+
+// Type with complex state
+struct ComplexObject {
+  std::string name;
+  int         id;
+  double      data[10];
+
+  ComplexObject(std::string n, int i) : name(std::move(n)), id(i)
+  {
+    for (int j = 0; j < 10; ++j) {
+      data[j] = i * j;
+    }
+  }
+
+  ~ComplexObject() = default;
+};
+
+// Type with explicit cleanup
+struct CleanupTracker {
+  int *counter;
+
+  explicit CleanupTracker(int *c) : counter(c)
+  {
+    if (counter) {
+      (*counter)++;
+    }
+  }
+
+  ~CleanupTracker()
+  {
+    if (counter) {
+      (*counter)--;
+    }
+  }
+
+  // Delete copy operations to ensure proper lifecycle
+  CleanupTracker(const CleanupTracker &)            = delete;
+  CleanupTracker &operator=(const CleanupTracker &) = delete;
+};
+
+TEST_CASE("ClassAllocator basic allocation", "[libts][allocator]")
+{
+  ClassAllocator<SimplePOD> allocator("test_simple_pod");
+
+  SECTION("Allocate and free simple POD")
+  {
+    SimplePOD *obj = allocator.alloc();
+    REQUIRE(obj != nullptr);
+
+    obj->x   = 42;
+    obj->y   = 3.14;
+    obj->ptr = nullptr;
+
+    REQUIRE(obj->x == 42);
+    REQUIRE(obj->y == 3.14);
+
+    allocator.free(obj);
+  }
+
+  SECTION("Allocate multiple objects")
+  {
+    constexpr int            count = 10;
+    std::vector<SimplePOD *> objects;
+
+    for (int i = 0; i < count; ++i) {
+      SimplePOD *obj = allocator.alloc();
+      REQUIRE(obj != nullptr);
+      obj->x = i;
+      objects.push_back(obj);
+    }
+
+    for (int i = 0; i < count; ++i) {
+      REQUIRE(objects[i]->x == i);
+    }
+
+    for (auto *obj : objects) {
+      allocator.free(obj);
+    }
+  }
+}
+
+TEST_CASE("ClassAllocator destructor calls", "[libts][allocator]")
+{
+  SECTION("Destructor called on free")
+  {
+    g_construct_count = 0;
+    g_destruct_count  = 0;
+
+    ClassAllocator<TrackedObject> allocator("test_tracked");
+
+    TrackedObject *obj = allocator.alloc(42);
+    REQUIRE(obj != nullptr);
+    REQUIRE(obj->value == 42);
+    REQUIRE(g_construct_count == 1);
+    REQUIRE(g_destruct_count == 0);
+
+    allocator.free(obj);
+    REQUIRE(g_destruct_count == 1);
+  }
+
+  SECTION("Multiple destructor calls")
+  {
+    g_construct_count = 0;
+    g_destruct_count  = 0;
+
+    ClassAllocator<TrackedObject> allocator("test_tracked_multi");
+
+    constexpr int                count = 5;
+    std::vector<TrackedObject *> objects;
+
+    for (int i = 0; i < count; ++i) {
+      objects.push_back(allocator.alloc(i));
+    }
+
+    REQUIRE(g_construct_count == count);
+    REQUIRE(g_destruct_count == 0);
+
+    for (auto *obj : objects) {
+      allocator.free(obj);
+    }
+
+    REQUIRE(g_destruct_count == count);
+  }
+}
+
+TEST_CASE("ClassAllocator with RAII types", "[libts][allocator]")
+{
+  ClassAllocator<ResourceHolder> allocator("test_resource_holder");
+
+  SECTION("RAII cleanup on free")
+  {
+    bool destroyed = false;
+
+    ResourceHolder *obj = allocator.alloc(123, &destroyed);
+    REQUIRE(obj != nullptr);
+    REQUIRE(obj->resource != nullptr);
+    REQUIRE(*obj->resource == 123);
+    REQUIRE(destroyed == false);
+
+    allocator.free(obj);
+    REQUIRE(destroyed == true);
+  }
+
+  SECTION("Multiple RAII objects")
+  {
+    constexpr int                 count                  = 3;
+    bool                          destroyed_flags[count] = {false, false, false};
+    std::vector<ResourceHolder *> objects;
+
+    for (int i = 0; i < count; ++i) {
+      objects.push_back(allocator.alloc(i * 100, &destroyed_flags[i]));
+    }
+
+    for (int i = 0; i < count; ++i) {
+      REQUIRE(destroyed_flags[i] == false);
+    }
+
+    for (auto *obj : objects) {
+      allocator.free(obj);
+    }
+
+    for (int i = 0; i < count; ++i) {
+      REQUIRE(destroyed_flags[i] == true);
+    }
+  }
+}
+
+TEST_CASE("ClassAllocator with complex types", "[libts][allocator]")
+{
+  ClassAllocator<ComplexObject> allocator("test_complex");
+
+  SECTION("Complex object with std::string")
+  {
+    ComplexObject *obj = allocator.alloc("test_object", 7);
+    REQUIRE(obj != nullptr);
+    REQUIRE(obj->name == "test_object");
+    REQUIRE(obj->id == 7);
+    REQUIRE(obj->data[5] == 35.0); // 7 * 5
+
+    allocator.free(obj);
+    // If destructor isn't called, this would leak the std::string
+  }
+
+  SECTION("Multiple complex objects")
+  {
+    std::vector<ComplexObject *> objects;
+    std::string prefix = "this needs to be long to avoid short string optimizations, hopefully this is enough: obj_";
+
+    for (int i = 0; i < 5; ++i) {
+      objects.push_back(allocator.alloc(prefix + std::to_string(i), i));
+    }
+
+    for (int i = 0; i < 5; ++i) {
+      REQUIRE(objects[i]->name == prefix + std::to_string(i));
+      REQUIRE(objects[i]->id == i);
+    }
+
+    for (auto *obj : objects) {
+      allocator.free(obj);
+    }
+  }
+}
+
+TEST_CASE("ClassAllocator cleanup tracking", "[libts][allocator]")
+{
+  ClassAllocator<CleanupTracker> allocator("test_cleanup");
+
+  SECTION("Cleanup counter decremented on free")
+  {
+    int counter = 0;
+
+    CleanupTracker *obj = allocator.alloc(&counter);
+    REQUIRE(obj != nullptr);
+    REQUIRE(counter == 1);
+
+    allocator.free(obj);
+    REQUIRE(counter == 0);
+  }
+
+  SECTION("Multiple cleanup objects")
+  {
+    int                           counter = 0;
+    std::vector<CleanupTracker *> objects;
+
+    for (int i = 0; i < 10; ++i) {
+      objects.push_back(allocator.alloc(&counter));
+    }
+
+    REQUIRE(counter == 10);
+
+    for (auto *obj : objects) {
+      allocator.free(obj);
+    }
+
+    REQUIRE(counter == 0);
+  }
+}
+
+TEST_CASE("ClassAllocator constructor forwarding", "[libts][allocator]")
+{
+  ClassAllocator<ComplexObject> allocator("test_forwarding");
+
+  SECTION("Perfect forwarding of constructor arguments")
+  {
+    std::string    name = "forwarded";
+    ComplexObject *obj  = allocator.alloc(name, 99);
+
+    REQUIRE(obj != nullptr);
+    REQUIRE(obj->name == "forwarded");
+    REQUIRE(obj->id == 99);
+
+    allocator.free(obj);
+  }
+
+  SECTION("Move semantics")
+  {
+    ComplexObject *obj = allocator.alloc(std::string("moved"), 42);
+
+    REQUIRE(obj != nullptr);
+    REQUIRE(obj->name == "moved");
+    REQUIRE(obj->id == 42);
+
+    allocator.free(obj);
+  }
+}

--- a/tools/benchmark/benchmark_ProxyAllocator.cc
+++ b/tools/benchmark/benchmark_ProxyAllocator.cc
@@ -52,7 +52,7 @@ struct BItem {
 } // namespace
 
 // THREAD_ALLOC/FREE requires allocators be global variables and are named after one of the defined ProxyAllocator members
-ClassAllocator<BItem> ioAllocator("io");
+ClassAllocator<BItem, false> ioAllocator("io");
 
 #define OLD_THREAD_FREE(_p, _a, _t)                                                                \
   do {                                                                                             \


### PR DESCRIPTION
This removes the flag to call the destructor on ClassAllocator objects.  ClassAllocator now requires that objects have a noexcept destructor that it can call on all objects.  This is much safer than the explicit flag and should not add any overhead for trivially destructed types.  I've added unit tests for this and also ran ASAN to make sure that the tests don't report memory leaks.

The unit tests were written by Claude, other code is my own.