### PR TITLE
Fix format specifier for ip_source bitfield in header_rewrite

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <cctype>
+#include <cinttypes>
 #include <sstream>
 #include <array>
 #include <atomic>
@@ -1768,7 +1769,7 @@ getClientAddr(TSHttpTxn txnp, int txn_private_slot)
     TSHttpTxnVerifiedAddrGet(txnp, &addr);
     break;
   default:
-    Dbg(pi_dbg_ctl, "Unknown IP source (%d) was specified", private_data.ip_source);
+    Dbg(pi_dbg_ctl, "Unknown IP source (%" PRIu64 ") was specified", static_cast<uint64_t>(private_data.ip_source));
     addr = TSHttpTxnClientAddrGet(txnp);
     break;
   }


### PR DESCRIPTION
## Description
Fix build failures on Ubuntu 20.04 in header_rewrite.

## Changes
1. **header_rewrite**: Fix format specifier for ip_source bitfield
   - Changed from %d to %u with explicit cast to unsigned int
   - Ensures cross-platform compatibility (Ubuntu and Fedora have different bitfield promotion rules)

## Testing
- Verified build succeeds on Ubuntu 20.04 with gcc and -Werror
- Fixes CI failures in:
  - https://ci.trafficserver.apache.org/job/master/job/os_build/46610/ (Ubuntu)