### PR TITLE
Clean up certifier SslData destructor

### DIFF
--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -106,8 +106,8 @@ private:
     SslData *prev = nullptr;
     SslData *next = nullptr;
 
-    SslData() = default;
-    ~SslData() { /* Dbg(dbg_ctl, "Deleting ssl data for [%s]", commonName.c_str()); */ }
+    SslData()  = default;
+    ~SslData() = default;
   };
 
   using scoped_SslData = std::unique_ptr<SslLRUList::SslData>;


### PR DESCRIPTION
Remove the commented-out debug statement from the SslData destructor. This statement was commented out in PR #9792 as a stop-gap measure because it was causing crashes during shutdown when accessing the potentially-destroyed dbg_ctl static object. Let's close the associated issue by just removing the commented out debug statement since it is generally considered unsafe to log in a destructor precisely because of its use of static structures which can surface order-dependent issues like the one reported in #9794. That is, not logging in the destructor is the correct solution, so let's just make @maskit's patch official.

Fixes: #9794