### PR TITLE
Update format string for formatting chrono duration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -151,7 +151,7 @@ JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
-LineEnding:      LF
+LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1

--- a/src/iocore/eventsystem/Watchdog.cc
+++ b/src/iocore/eventsystem/Watchdog.cc
@@ -57,12 +57,16 @@ Monitor::~Monitor()
 void
 Monitor::monitor_loop() const
 {
+  // this ensures `long long` duration for older compilers to match format specifiers
+  using printable_micro = std::chrono::duration<long long, std::micro>;
+  using printable_milli = std::chrono::duration<long long, std::milli>;
+
   // Divide by a floating point 2 to avoid truncation to zero.
   auto sleep_time = _timeout / 2.0;
   ink_release_assert(sleep_time.count() > 0);
   Dbg(dbg_ctl_watchdog, "Starting watchdog with timeout %lld ms on %zu threads.  sleep_time = %lld us",
-      std::chrono::duration_cast<std::chrono::duration<long long, std::milli>>(_timeout).count(), _threads.size(),
-      std::chrono::duration_cast<std::chrono::duration<long long, std::micro>>(sleep_time).count());
+      std::chrono::duration_cast<printable_milli>(_timeout).count(), _threads.size(),
+      std::chrono::duration_cast<printable_micro>(sleep_time).count());
 
   ink_set_thread_name("[WATCHDOG]");
 
@@ -92,7 +96,7 @@ Monitor::monitor_loop() const
         if (warned_seq < seq) {
           // Warn once per loop iteration
           Warning("Watchdog: [ET_NET %zu] has been awake for %lld ms", i,
-                  std::chrono::duration_cast<std::chrono::duration<long long, std::milli>>(awake_duration).count());
+                  std::chrono::duration_cast<printable_milli>(awake_duration).count());
           t->heartbeat_state.warned_seq.store(seq, std::memory_order_relaxed);
         }
       }


### PR DESCRIPTION
Newer clang compilers want `%lld` for `long long` and `%ld` for `long` and will warn otherwise.  Unfortunately, there isn't a way to use the `PRI*` macros to produce `lld` on 64 bit word systems.

