### PR TITLE
Remove references to Ubuntu 20.04 and 23.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.trafficserver.apache.org%2Fjob%2Fmaster%2Fjob%2Fosx-m1%2F&label=macOS%20arm64)](https://ci.trafficserver.apache.org/job/master/job/osx-m1/)
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.trafficserver.apache.org%2Fjob%2Fmaster%2Fjob%2Fos-rockylinux_8%2F&label=Rocky%20Linux%208)](https://ci.trafficserver.apache.org/job/master/job/os-rockylinux_8/)
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.trafficserver.apache.org%2Fjob%2Fmaster%2Fjob%2Fos-rockylinux_9%2F&label=Rocky%20Linux%209)](https://ci.trafficserver.apache.org/job/master/job/os-rockylinux_9/)
-[![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.trafficserver.apache.org%2Fjob%2Fmaster%2Fjob%2Fos-ubuntu_20.04%2F&label=Ubuntu%2020.04)](https://ci.trafficserver.apache.org/job/master/job/os-ubuntu_20.04/)
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.trafficserver.apache.org%2Fjob%2Fmaster%2Fjob%2Fos-ubuntu_22.04%2F&label=Ubuntu%2022.04)](https://ci.trafficserver.apache.org/job/master/job/os-ubuntu_22.04/)
-[![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.trafficserver.apache.org%2Fjob%2Fmaster%2Fjob%2Fos-ubuntu_23.04%2F&label=Ubuntu%2023.04)](https://ci.trafficserver.apache.org/job/master/job/os-ubuntu_23.04/)
 
 Traffic Server is a high-performance building block for cloud services.
 It's more than just a caching proxy server; it also has support for


### PR DESCRIPTION
This PR removes references to Ubuntu 20.04 and 23.04 from the repository.

Changes:
- Remove Jenkins build badges for Ubuntu 20.04 and 23.04 from README.md

These Ubuntu versions are EOL or near EOL and are no longer actively tested.