### PR TITLE
Fix stats_over_http compilation with Clang 16 and earlier

### DIFF
--- a/plugins/stats_over_http/stats_over_http.cc
+++ b/plugins/stats_over_http/stats_over_http.cc
@@ -485,7 +485,10 @@ csv_out_stat(TSRecordType /* rec_type ATS_UNUSED */, void *edata, int /* registe
 static
 // Remove this check when we drop support for pre-13 GCC versions.
 #if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
+// Clang <= 16 doesn't fully support constexpr std::string.
+#if !defined(__clang__) || __clang_major__ > 16
   constexpr
+#endif
 #endif
   std::string
   sanitize_metric_name_for_prometheus(std::string_view name)
@@ -1133,6 +1136,8 @@ config_handler(TSCont cont, TSEvent /* event ATS_UNUSED */, void * /* edata ATS_
 #ifdef DEBUG
 // Remove this check when we drop support for pre-13 GCC versions.
 #if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
+// Clang <= 16 doesn't fully support constexpr std::string.
+#if !defined(__clang__) || __clang_major__ > 16
 constexpr void
 test_sanitize_metric_name_for_prometheus()
 {
@@ -1204,5 +1209,6 @@ test_sanitize_metric_name_for_prometheus()
   static_assert(sanitize_metric_name_for_prometheus("foo [[[bar]]]") == "foo____bar___");
   static_assert(sanitize_metric_name_for_prometheus("foo@#$%bar") == "foo____bar");
 }
+#endif // !defined(__clang__) || __clang_major__ > 16
 #endif // defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
 #endif // DEBUG


### PR DESCRIPTION
Clang 16 and earlier don't fully support constexpr std::string operations even when __cpp_lib_constexpr_string is defined, causing static_assert failures in the compile-time tests for sanitize_metric_name_for_prometheus().

This fix uses nested ifdefs to clearly separate the feature detection from the compiler version check, disabling the constexpr optimization and compile-time tests for Clang <= 16 while keeping them enabled for GCC 13+ and future Clang versions (17+) that may have proper support.

**Testing:**
- ✅ Compiles successfully with Clang 16 on Rocky Linux 9
- ✅ All tests pass including test_cache_Update_Header
- ✅ No linter errors
- ✅ Logic is clear and future-proof