### PR TITLE
Fix false positive -Wrestrict warning in test_ja4.cc with GCC 12

### DIFF
--- a/plugins/experimental/ja4_fingerprint/test_ja4.cc
+++ b/plugins/experimental/ja4_fingerprint/test_ja4.cc
@@ -230,16 +230,7 @@ TEST_CASE("JA4")
           "when we create a JA4 fingerprint, "
           "then indices [8,9] thereof should contain \"aa\".")
   {
-    // Suppress false positive -Wrestrict warning in GCC 12 when optimizing
-    // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wrestrict"
-#endif
-    TLS_summary.ALPN = "a";
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+    TLS_summary.ALPN = 'a';
     CHECK("aa" == call_JA4(TLS_summary).substr(8, 2));
   }
 


### PR DESCRIPTION
Suppress false positive compiler warning when assigning single character string literal to std::string. This is a known GCC 12 bug that triggers when the optimizer inlines string operations with 1-character strings.

The warning shows nonsensical memory access values (exabytes at negative offsets) which confirms it's a compiler analysis bug, not a real issue.

Fixes build failure on Debian 12 with GCC 12 in Release mode.

See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329