### PR TITLE
Fix proxy-verifier path for non-worktree repositories

### DIFF
--- a/cmake/proxy-verifier.cmake
+++ b/cmake/proxy-verifier.cmake
@@ -47,6 +47,9 @@ if(NOT GIT_RESULT EQUAL 0)
   message(FATAL_ERROR "Failed to determine git common directory")
 endif()
 
+# Convert to absolute path (handles relative .git from regular non-worktree clones).
+get_filename_component(GIT_COMMON_DIR "${GIT_COMMON_DIR}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
+
 # Download proxy-verifier to git common directory.
 set(PV_ARCHIVE ${GIT_COMMON_DIR}/proxy-verifier/proxy-verifier.tar.gz)
 file(


### PR DESCRIPTION
The git rev-parse --git-common-dir command added in #12686 returns an absolute path to the relevant .git direcotry for worktrees. Unfortunately, it does a relative path for "regular" non-worktree clones. Without converting to an absolute path, PROXY_VERIFIER_PATH becomes relative and fails to resolve correctly when passed to autest. This adds get_filename_component to ensure GIT_COMMON_DIR is always absolute, fixing the issue for both repository types.