### PR TITLE
various worktree fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,25 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# Detect git common directory (works for both regular repos and worktrees).
+if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
+  execute_process(
+    COMMAND git rev-parse --git-common-dir
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMON_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GIT_RESULT
+    ERROR_QUIET
+  )
+  if(GIT_RESULT EQUAL 0 AND GIT_COMMON_DIR)
+    # Convert to absolute path if relative.
+    if(NOT IS_ABSOLUTE ${GIT_COMMON_DIR})
+      get_filename_component(GIT_COMMON_DIR "${CMAKE_SOURCE_DIR}/${GIT_COMMON_DIR}" ABSOLUTE)
+    endif()
+    message(STATUS "Git common directory: ${GIT_COMMON_DIR}")
+  endif()
+endif()
+
 # Options
 include(AutoOptionHelpers)
 find_package(PkgConfig)
@@ -748,8 +767,6 @@ if(ENABLE_BENCHMARKS)
   add_subdirectory(tools/benchmark)
 endif()
 
-set(GIT_COMMON_DIR git rev-parse --git-common-dir)
-
 add_custom_target(
   clang-format-install
   COMMAND ${CMAKE_SOURCE_DIR}/tools/clang-format.sh --install
@@ -813,10 +830,12 @@ add_custom_target(
   COMMENT "formatting all files"
 )
 
-if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/.git)
-  file(TIMESTAMP ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit PRE_COMMIT_BEFORE)
-  configure_file(${CMAKE_SOURCE_DIR}/tools/git/pre-commit ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit COPYONLY)
-  file(TIMESTAMP ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit PRE_COMMIT_AFTER)
+# Install pre-commit hook if this is a git repository (including worktrees).
+if(GIT_COMMON_DIR)
+  set(PRE_COMMIT_HOOK "${GIT_COMMON_DIR}/hooks/pre-commit")
+  file(TIMESTAMP ${PRE_COMMIT_HOOK} PRE_COMMIT_BEFORE)
+  configure_file(${CMAKE_SOURCE_DIR}/tools/git/pre-commit ${PRE_COMMIT_HOOK} COPYONLY)
+  file(TIMESTAMP ${PRE_COMMIT_HOOK} PRE_COMMIT_AFTER)
   if(NOT PRE_COMMIT_BEFORE STREQUAL PRE_COMMIT_AFTER)
     message(STATUS "Installing github hook")
   endif()

--- a/cmake/proxy-verifier.cmake
+++ b/cmake/proxy-verifier.cmake
@@ -35,16 +35,9 @@ if(NOT PROXY_VERIFIER_HASH)
   message(FATAL_ERROR "PROXY_VERIFIER_HASH Required")
 endif()
 
-# Detect the git common directory (works for both regular repos and worktrees).
-execute_process(
-  COMMAND git rev-parse --git-common-dir
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_COMMON_DIR
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE GIT_RESULT
-)
-if(NOT GIT_RESULT EQUAL 0)
-  message(FATAL_ERROR "Failed to determine git common directory")
+# GIT_COMMON_DIR is set by the top-level CMakeLists.txt.
+if(NOT GIT_COMMON_DIR)
+  message(FATAL_ERROR "GIT_COMMON_DIR not set. This should be set by the top-level CMakeLists.txt")
 endif()
 
 # Download proxy-verifier to git common directory.

--- a/doc/ext/plantuml_fetch.sh
+++ b/doc/ext/plantuml_fetch.sh
@@ -27,7 +27,7 @@ function main() {
   set -e # exit on error
   PACKAGE="plantuml-${PKGDATE}"
   JAR="plantuml.jar"
-  ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/doc-tools}
+  ROOT=${ROOT:-$(git rev-parse --git-common-dir)/doc-tools}
 
   URL=${URL:-https://ci.trafficserver.apache.org/bintray/${PACKAGE}.${PKG_EXT}}
   TAR=${TAR:-tar}

--- a/doc/ext/traffic-server.cmake.in.py
+++ b/doc/ext/traffic-server.cmake.in.py
@@ -468,9 +468,9 @@ class TrafficServerDomain(Domain):
 REPO_ROOT = '@PROJECT_SOURCE_DIR@'
 ts_version = '@TS_VERSION_STRING@'
 
-# get the current branch the local repository is on
-REPO_GIT_DIR = os.path.join(REPO_ROOT, ".git")
-git_branch = subprocess.check_output(['git', '--git-dir', REPO_GIT_DIR, 'rev-parse', '--abbrev-ref', 'HEAD'])
+# Get the current branch the local repository is on.
+# Run git from the repository root to work with both normal repos and worktrees.
+git_branch = subprocess.check_output(['git', '-C', REPO_ROOT, 'rev-parse', '--abbrev-ref', 'HEAD'])
 
 
 def make_github_link(name, rawtext, text, lineno, inliner, options=None, content=None):

--- a/doc/ext/traffic-server.py
+++ b/doc/ext/traffic-server.py
@@ -464,12 +464,11 @@ if match:
 else:
     release = 'x.y.z'
 
-# get the current branch the local repository is on
-REPO_GIT_DIR = os.path.join(REPO_ROOT, ".git")
-
+# Get the current branch the local repository is on.
+# Run git from the repository root to work with both normal repos and worktrees.
 try:
     git_branch = subprocess.check_output(
-        ['git', '--git-dir', REPO_GIT_DIR, 'rev-parse', '--abbrev-ref', 'HEAD'], stderr=subprocess.DEVNULL, text=True).strip()
+        ['git', '-C', REPO_ROOT, 'rev-parse', '--abbrev-ref', 'HEAD'], stderr=subprocess.DEVNULL, text=True).strip()
 except (subprocess.CalledProcessError, FileNotFoundError):
     git_branch = 'master'
 


### PR DESCRIPTION
Fix pre-commit hook installation in a worktree. This also fixes a handful of doc generation references to the .git directory to work in worktrees as well.