### PR TITLE
Fix a build error in UnixEvent.cc due to insufficient header inclusion

### DIFF
--- a/src/iocore/eventsystem/UnixEvent.cc
+++ b/src/iocore/eventsystem/UnixEvent.cc
@@ -30,6 +30,7 @@
 
 #include "iocore/eventsystem/Event.h"
 #include "iocore/eventsystem/EThread.h"
+#include "tscore/ink_stack_trace.h"
 
 ClassAllocator<Event> eventAllocator("eventAllocator", 256);
 


### PR DESCRIPTION
I'm not sure what introduced the error and how it passed CI builds.

```
/Users/mkitajo/src/gh.c/trafficserver/src/iocore/eventsystem/UnixEvent.cc:115:15: error: use of undeclared identifier 'ink_backtrace'
  115 |   _location = ink_backtrace(3);
      |               ^
1 error generated.
```