### PR TITLE
Fix false positive -Wrestrict warning in HttpUserAgent.h with GCC 12

### DIFF
--- a/include/proxy/http/HttpUserAgent.h
+++ b/include/proxy/http/HttpUserAgent.h
@@ -178,7 +178,7 @@ HttpUserAgent::set_txn(ProxyTransaction *txn, TransactionMilestones &milestones)
     if (auto group{tbs->get_tls_group()}; !group.empty()) {
       m_conn_info.security_group = group;
     } else {
-      m_conn_info.security_group = "-";
+      m_conn_info.security_group = '-';
     }
 
     if (!m_conn_info.tcp_reused) {


### PR DESCRIPTION
GCC 12 produces a false positive -Wrestrict warning when assigning the string literal \"-\" to std::string in HttpUserAgent::set_txn(). Change to use char literal '-' instead of string literal \"-\" to avoid the warning, similar to commit 355a9ee34d.

This fixes build #47293 failure on Debian 12 with GCC 12.2.0.

https://ci.trafficserver.apache.org/job/master/job/os_build/47293/consoleFull