### PR TITLE
Fix hanging SDK_API_HttpParentProxySet regression tests

### DIFF
--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -7366,13 +7366,10 @@ parent_proxy_handler(TSCont contp, TSEvent event, void *edata)
         break;
       }
 
-      if (!ptest->parent_routing_enabled()) {
-        rprintf(ptest->regtest, "waiting for configuration\n");
-        TSContScheduleOnPool(contp, 100, TS_THREAD_POOL_NET);
-        break;
-      }
+      // This test uses TSHttpTxnParentProxySet() to dynamically set the parent proxy via
+      // the API, which works regardless of parent.config configuration.
 
-      // Now that the configuration is applied, it is safe to create a request.
+      // Now it is safe to create a request.
       // HTTP_REQUEST_FORMAT11 is a hostname with a no-cache response, so
       // we will need to set the parent to the synserver to get a
       // response.


### PR DESCRIPTION
Remove the check for parent_routing_enabled() in the SDK_API_HttpParentProxySet regression tests. This check has been broken since 2019 when commit 6d1535b193a4 removed the proxy.config.http.parent_proxy_routing_enable configuration variable as redundant.

The ParentEnable field in ParentSelectionPolicy is no longer set by any code (defaults to 0) and is not checked anywhere except this test. The test was waiting indefinitely for parent_routing_enabled() to return true, which would never happen in a default configuration.

The test uses TSHttpTxnParentProxySet() to dynamically set a parent proxy via the API, which works regardless of whether parent routing is configured in parent.config. The check was unnecessary and caused the test to hang at regression level 3 (-R 3).

This allows the SDK_API_HttpParentProxySet_Success and _Fail tests to complete successfully.