### PR TITLE
Fix ProxyProtocol double destructor call in HttpTransact::State

### DIFF
--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -889,8 +889,6 @@ public:
       ranges      = nullptr;
       range_setup = RangeSetup_t::NONE;
 
-      // This avoids a potential leak since sometimes this class is not destructed (ClassAllocated via HttpSM)
-      pp_info.~ProxyProtocol();
       return;
     }
 


### PR DESCRIPTION
This PR fixes a build failure on Fedora 42 with GCC 15 introduced by PR #12680.

## Problem
PR #12680 added an explicit destructor call `pp_info.~ProxyProtocol();` in `HttpTransact::State::destroy()` with a comment claiming it prevents a memory leak. However, since `pp_info` is a regular member variable (not allocated with placement new), it will be automatically destroyed when the `State` object is destroyed. The explicit destructor call causes undefined behavior (double destruction), which GCC 15 now correctly detects as an error:

```
error: 'std::__cxx11::basic_string<char>::_M_dataplus._M_p' is used uninitialized [-Werror=uninitialized]
```

## Solution
Remove the explicit destructor call. The `ProxyProtocol` member with its `std::string` member will be properly cleaned up automatically through RAII.

## Testing
This fix allows the Fedora 42 build to succeed.

Fixes the issue introduced in #12680