### PR TITLE
Cripts: tighten context cleanup

### DIFF
--- a/include/cripts/Urls.hpp
+++ b/include/cripts/Urls.hpp
@@ -654,9 +654,14 @@ namespace Client
     void operator=(const self_type &) = delete;
 
     // We must not release the bufp etc. since it comes from the RRI structure
+    // However, we still need to clear cached data in query and path components
     void
     Reset() override
     {
+      query.Reset();
+      path.Reset();
+      _initialized = false;
+      _modified    = false;
     }
 
     static self_type &_get(cripts::Context *context);

--- a/src/cripts/Context.cc
+++ b/src/cripts/Context.cc
@@ -69,6 +69,7 @@ Context::Factory(TSHttpTxn txn_ptr, TSHttpSsn ssn_ptr, TSRemapRequestInfo *rri_p
 void
 Context::Release()
 {
+  reset(); // Clear mloc handles before freeing
   THREAD_FREE(this, criptContextAllocator, this_thread());
 }
 

--- a/src/cripts/Urls.cc
+++ b/src/cripts/Urls.cc
@@ -197,7 +197,7 @@ Url::Path::Reset()
   Component::Reset();
 
   _segments.clear();
-  _storage  = "";
+  _storage.clear();
   _size     = 0;
   _modified = false;
 }
@@ -402,7 +402,7 @@ Url::Query::Reset()
 
   _ordered.clear();
   _hashed.clear();
-  _storage  = "";
+  _storage.clear();
   _size     = 0;
   _modified = false;
 }


### PR DESCRIPTION
There were some missing reset() calls for Cripts::Context that cause state not to be cleaned up between hooks on a single transaction.