### PR TITLE
regex_remap: Document host option // prefix behavior

### DIFF
--- a/doc/admin-guide/plugins/regex_remap.en.rst
+++ b/doc/admin-guide/plugins/regex_remap.en.rst
@@ -217,7 +217,9 @@ a malformed URL with four slashes::
     # redirect.conf:
     ^(.*)$    https:$1    @status=307
 
-This will redirect ``http://example.com/path`` to ``https://example.com/path``.
+This will redirect any plaintext HTTP (``http://``) request for any host to the
+``https://`` equivalent. For instance, a request to ``http://example.com/path``
+would be redirected to ``https://example.com/path``.
 
 **Example: Method-based routing**
 


### PR DESCRIPTION
The host option prepends // to the match string, which can be unintuitive when regex_remap rules. This adds documentation explaining why the // prefix exists (to distinguish hostnames from hostname-like path components) and provides practical examples showing how to write redirect rules correctly using https:$1 instead of https://$1.

Fixes: #12691