### PR TITLE
Catch2: Use CAPTURE and GENERATE

### DIFF
--- a/lib/swoc/unit_tests/test_TextView.cc
+++ b/lib/swoc/unit_tests/test_TextView.cc
@@ -644,6 +644,7 @@ TEST_CASE("TextView tokenizing", "[libswoc][TextView]") {
   TextView src = "alpha,bravo,,charlie";
   auto tokens  = {"alpha", "bravo", "", "charlie"};
   for (auto token : tokens) {
+    CAPTURE(token);
     REQUIRE(src.take_prefix_at(',') == token);
   }
 }

--- a/plugins/experimental/ja4_fingerprint/test_ja4.cc
+++ b/plugins/experimental/ja4_fingerprint/test_ja4.cc
@@ -91,6 +91,7 @@ TEST_CASE("JA4")
       {0xfefc, "d3"}
     };
     for (auto const &[version, expected] : values) {
+      CAPTURE(version, expected);
       TLS_summary.TLS_version = version;
       CHECK(expected == call_JA4(TLS_summary).substr(1, 2));
     }

--- a/plugins/experimental/txn_box/unit_tests/test_accl_utils.cc
+++ b/plugins/experimental/txn_box/unit_tests/test_accl_utils.cc
@@ -44,14 +44,17 @@ TEST_CASE("Basic single char insert/full_match std::string_view")
     };
 
     for (auto const &[k, v] : kv) {
+      CAPTURE(k, v);
       REQUIRE(trie.insert(k, v));
     }
     // try again.
     for (auto const &[k, v] : kv) {
+      CAPTURE(k, v);
       REQUIRE(!trie.insert(k, v));
     }
 
     for (auto const &[k, v] : kv) {
+      CAPTURE(k, v);
       auto [found, value] = trie.full_match(k);
       REQUIRE(found);
       REQUIRE(value == v);
@@ -80,14 +83,17 @@ TEST_CASE("Basic insert/full_match TextView", "")
       {"H", "6"}
     };
     for (auto const &[k, v] : kv) {
+      CAPTURE(k, v);
       REQUIRE(trie.insert(k, v));
     }
     // try again.
     for (auto const &[k, v] : kv) {
+      CAPTURE(k, v);
       REQUIRE(!trie.insert(k, v));
     }
 
     for (auto const &[k, v] : kv) {
+      CAPTURE(k, v);
       auto [found, value] = trie.full_match(k);
       REQUIRE(found);
       REQUIRE(value == v);
@@ -121,16 +127,19 @@ TEST_CASE("Basic Prefix match Test on std::string", "[insert][prefix_match][std:
   StringTree<std::string, std::string>             trie;
   std::vector<std::pair<std::string, std::string>> kvs = generateKVFrom(std::string{"http://www.apache.com/trafficserver"});
   for (auto const &[k, v] : kvs) {
+    CAPTURE(k, v);
     trie.insert(k, v);
   }
 
   // basic check
   for (auto const &[k, v] : kvs) {
+    CAPTURE(k, v);
     auto [found, value] = trie.full_match(k);
     REQUIRE(found);
     REQUIRE(value == v);
   }
   for (auto iter = std::begin(kvs); iter != std::end(kvs); ++iter) {
+    CAPTURE(iter->first);
     auto const &keys = trie.prefix_match(iter->first);
     REQUIRE(std::equal(iter, std::end(kvs), std::begin(keys), std::end(keys)));
   }
@@ -164,6 +173,7 @@ TEST_CASE("Basic Prefix Match Test on a mix case strings", "")
   };
 
   for (auto const &[key, expected] : exp_results) {
+    CAPTURE(key, expected);
     auto const &items = trie.prefix_match(key);
     INFO("Looking for " << key << ", to be found " << expected.size() << "? found " << items.size());
 
@@ -188,6 +198,7 @@ TEST_CASE("Basic Suffix Match Test", "")
   string_tree_map trie;
 
   for (auto const &[k, v] : kv) {
+    CAPTURE(k, v);
     REQUIRE(trie.insert(k, v));
   }
 
@@ -201,6 +212,7 @@ TEST_CASE("Basic Suffix Match Test", "")
   };
 
   for (auto const &[key, expected] : exp_results) {
+    CAPTURE(key, expected);
     auto const &items = trie.suffix_match(key);
     REQUIRE(items.size() == expected.size());
     for (auto const &pair : items) {

--- a/src/iocore/net/unit_tests/test_YamlSNIConfig.cc
+++ b/src/iocore/net/unit_tests/test_YamlSNIConfig.cc
@@ -114,6 +114,8 @@ TEST_CASE("YamlConfig handles bad ports appropriately.")
   std::string filepath;
   swoc::bwprint(filepath, "{}/sni_conf_test_bad_port_{}.yaml", _XSTR(LIBINKNET_UNIT_TEST_DIR), port_str);
 
+  CAPTURE(port_str, filepath);
+
   swoc::Errata      zret{conf.loader(filepath)};
   std::stringstream errorstream;
   errorstream << zret;

--- a/src/proxy/http/unit_tests/test_error_page_selection.cc
+++ b/src/proxy/http/unit_tests/test_error_page_selection.cc
@@ -103,6 +103,7 @@ TEST_CASE("error page selection test", "[http]")
   // (2) for each test, parse accept headers into lists, and test matching
   int count = 0;
   for (const auto &test : tests) {
+    CAPTURE(test.accept_language, test.accept_charset, test.expected_set, test.expected_Q, test.expected_La, test.expected_I);
     float       Q_best;
     int         La_best, Lc_best, I_best;
     const char *set_best;

--- a/src/tscore/unit_tests/test_ink_string.cc
+++ b/src/tscore/unit_tests/test_ink_string.cc
@@ -24,6 +24,8 @@
 #include <tscore/ink_string.h>
 #include <tscore/ParseRules.h>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
 #include <string_view>
 
 //-------------------------------------------------------------------------
@@ -80,14 +82,13 @@ constexpr int64_item int64_tests[] = {
 
 TEST_CASE("ink_fast_ltoa", "[libts][ink_fast_ltoa]")
 {
-  printf("ink_string\n");
+  auto test = GENERATE(from_range(std::begin(int64_tests), std::end(int64_tests)));
+  CAPTURE(test.n, test.s);
   char buffer[21];
-  for (auto const &test : int64_tests) {
-    REQUIRE(ink_atoi64(test.s.data()) == test.n);
-    int length = 0;
-    REQUIRE((length = ink_fast_ltoa(test.n, buffer, sizeof(buffer))) == (int)test.s.length());
-    REQUIRE(std::string_view(buffer, length) == test.s);
-  }
+  REQUIRE(ink_atoi64(test.s.data()) == test.n);
+  int length = 0;
+  REQUIRE((length = ink_fast_ltoa(test.n, buffer, sizeof(buffer))) == (int)test.s.length());
+  REQUIRE(std::string_view(buffer, length) == test.s);
 }
 
 //-------------------------------------------------------------------------
@@ -126,13 +127,13 @@ constexpr int_item int_tests[] = {
 
 TEST_CASE("ink_fast_inta", "[libts][ink_fast_inta]")
 {
+  auto test = GENERATE(from_range(std::begin(int_tests), std::end(int_tests)));
+  CAPTURE(test.n, test.s);
   char buffer[12];
-  for (auto const &test : int_tests) {
-    REQUIRE(ink_atoi(test.s.data()) == test.n);
-    int length = 0;
-    REQUIRE((length = ink_fast_itoa(test.n, buffer, sizeof(buffer))) == (int)test.s.length());
-    REQUIRE(std::string_view(buffer, length) == test.s);
-  }
+  REQUIRE(ink_atoi(test.s.data()) == test.n);
+  int length = 0;
+  REQUIRE((length = ink_fast_itoa(test.n, buffer, sizeof(buffer))) == (int)test.s.length());
+  REQUIRE(std::string_view(buffer, length) == test.s);
 }
 
 //-------------------------------------------------------------------------
@@ -160,11 +161,11 @@ constexpr uint_item uint_tests[] = {
 
 TEST_CASE("ink_fast_uinta", "[libts][ink_fast_uinta]")
 {
+  auto test = GENERATE(from_range(std::begin(uint_tests), std::end(uint_tests)));
+  CAPTURE(test.n, test.s);
   char buffer[12];
-  for (auto const &test : uint_tests) {
-    REQUIRE(ink_atoui(test.s.data()) == test.n);
-    int length = 0;
-    REQUIRE((length = ink_fast_uitoa(test.n, buffer, sizeof(buffer))) == (int)test.s.length());
-    REQUIRE(std::string_view(buffer, length) == test.s);
-  }
+  REQUIRE(ink_atoui(test.s.data()) == test.n);
+  int length = 0;
+  REQUIRE((length = ink_fast_uitoa(test.n, buffer, sizeof(buffer))) == (int)test.s.length());
+  REQUIRE(std::string_view(buffer, length) == test.s);
 }

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -30,6 +30,8 @@
 #include "tscore/ink_defs.h"
 #include "tsutil/Regex.h"
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
 
 struct subject_match_t {
   std::string_view subject;
@@ -97,41 +99,49 @@ TEST_CASE("Regex", "[libts][Regex]")
 {
   // case sensitive test
   for (auto &item : test_data) {
+    CAPTURE(item.regex);
     Regex r;
     REQUIRE(r.compile(item.regex.data()) == true);
 
     for (auto &test : item.tests) {
+      CAPTURE(test.subject, test.match);
       REQUIRE(r.exec(test.subject.data()) == test.match);
     }
   }
 
   // case insensitive test
   for (auto &item : test_data_case_insensitive) {
+    CAPTURE(item.regex);
     Regex r;
     REQUIRE(r.compile(item.regex.data(), RE_CASE_INSENSITIVE) == true);
 
     for (auto &test : item.tests) {
+      CAPTURE(test.subject, test.match);
       REQUIRE(r.exec(test.subject.data()) == test.match);
     }
   }
 
   // case anchored test
   for (auto &item : test_data_anchored) {
+    CAPTURE(item.regex);
     Regex r;
     REQUIRE(r.compile(item.regex.data(), RE_ANCHORED) == true);
 
     for (auto &test : item.tests) {
+      CAPTURE(test.subject, test.match);
       REQUIRE(r.exec(test.subject.data()) == test.match);
     }
   }
 
   // test getting submatches with operator[]
   for (auto &item : submatch_test_data) {
+    CAPTURE(item.regex, item.capture_count);
     Regex r;
     REQUIRE(r.compile(item.regex.data()) == true);
     REQUIRE(r.get_capture_count() == item.capture_count);
 
     for (auto &test : item.tests) {
+      CAPTURE(test.subject, test.count);
       RegexMatches matches;
       REQUIRE(r.exec(test.subject.data(), matches) == test.count);
       REQUIRE(matches.size() == test.count);
@@ -144,11 +154,13 @@ TEST_CASE("Regex", "[libts][Regex]")
 
   // test getting submatches with ovector pointer
   for (auto &item : submatch_test_data) {
+    CAPTURE(item.regex, item.capture_count);
     Regex r;
     REQUIRE(r.compile(item.regex.data()) == true);
     REQUIRE(r.get_capture_count() == item.capture_count);
 
     for (auto &test : item.tests) {
+      CAPTURE(test.subject, test.count);
       RegexMatches matches;
       REQUIRE(r.exec(test.subject.data(), matches) == test.count);
       REQUIRE(matches.size() == test.count);
@@ -838,12 +850,11 @@ std::vector<backref_test_t> backref_test_data{
 
 TEST_CASE("Regex back reference counting", "[libts][Regex][get_backref_max]")
 {
-  // case sensitive test
-  for (auto &item : backref_test_data) {
-    Regex r;
-    REQUIRE(r.compile(item.regex) == item.valid);
-    REQUIRE(r.get_backref_max() == item.backref_max);
-  }
+  auto item = GENERATE(from_range(backref_test_data));
+  CAPTURE(item.regex, item.valid, item.backref_max);
+  Regex r;
+  REQUIRE(r.compile(item.regex) == item.valid);
+  REQUIRE(r.get_backref_max() == item.backref_max);
 }
 
 struct match_context_test_t {
@@ -866,10 +877,9 @@ TEST_CASE("RegexMatchContext", "[libts][Regex][RegexMatchContext]")
   match_context.set_match_limit(2);
   RegexMatches matches;
 
-  // case sensitive test
-  for (auto &item : match_context_test_data) {
-    Regex r;
-    REQUIRE(r.compile(item.regex) == item.valid);
-    REQUIRE(r.exec(item.str, matches, 0, &match_context) == item.rcode);
-  }
+  auto item = GENERATE(from_range(match_context_test_data));
+  CAPTURE(item.regex, item.str, item.valid, item.rcode);
+  Regex r;
+  REQUIRE(r.compile(item.regex) == item.valid);
+  REQUIRE(r.exec(item.str, matches, 0, &match_context) == item.rcode);
 }


### PR DESCRIPTION
Add CAPTURE statements to parameterized tests to improve failure diagnostics. Convert many for-loop based parameterized tests to use GENERATE which provides automatic sectioning, continues running after failures, and produces clearer test output.