### PR TITLE
Fix autest.sh.in to preserve autest exit code

### DIFF
--- a/tests/autest.sh.in
+++ b/tests/autest.sh.in
@@ -29,6 +29,7 @@ ${RUNPIPENV} run env autest \
   --build-root ${CMAKE_BINARY_DIR} \
   ${CURL_UDS_FLAG} ${AUTEST_OPTIONS} \
   "$@"
+autest_exit=$?
 
 # Restore tests back to source tree and remove temp dir
 if [ -n "${CURL_UDS_FLAG}" ]; then
@@ -45,3 +46,5 @@ if [ -n "${CURL_UDS_FLAG}" ]; then
     rm -rf "${CMAKE_SKIP_GOLD_DIR}"
   fi
 fi
+
+exit $autest_exit


### PR DESCRIPTION
The trailing if-blocks for restoring UDS test directories were overwriting autest's exit code with 0, causing test failures to be silently ignored in CI.

Now we capture the exit code immediately after autest runs and exit with it at the end of the script.

This was discovered while investigating why PR #12727 was passing CI despite having a failing test.