### PR TITLE
Fix test_net to not depend on system sni.yaml

### DIFF
--- a/src/iocore/net/unit_tests/test_SSLSNIConfig.cc
+++ b/src/iocore/net/unit_tests/test_SSLSNIConfig.cc
@@ -29,6 +29,7 @@
 #define _XSTR(s) _STR(s)
 
 #include "iocore/net/SSLSNIConfig.h"
+#include "records/RecCore.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -173,6 +174,11 @@ TEST_CASE("Test SSLSNIConfig")
 
 TEST_CASE("SNIConfig reconfigure callback is invoked")
 {
+  // Point the config to the test file so reconfigure() doesn't depend on the
+  // system sni.yaml file existing.
+  RecSetRecordString("proxy.config.ssl.servername.filename", _XSTR(LIBINKNET_UNIT_TEST_DIR) "/sni_conf_test.yaml",
+                     REC_SOURCE_EXPLICIT);
+
   int  result{0};
   auto set_result{[&result]() { result = 42; }};
   SNIConfig::set_on_reconfigure_callback(set_result);


### PR DESCRIPTION
Configure proxy.config.ssl.servername.filename to use the unit test's sni_conf_test.yaml before calling SNIConfig::reconfigure(). This ensures the test is self-contained and does not fail when the system-level sni.yaml file does not exist.

Fixes: #12353