### PR TITLE
Cleanup HttpCacheKey

### DIFF
--- a/include/iocore/cache/CacheDefs.h
+++ b/include/iocore/cache/CacheDefs.h
@@ -129,9 +129,8 @@ enum CacheFragType {
 using CacheKey = CryptoHash;
 
 struct HttpCacheKey {
-  int         hostlen;
-  const char *hostname;
-  CacheKey    hash;
+  std::string_view hostname;
+  CacheKey         hash;
 };
 
 #define CACHE_ALLOW_MULTIPLE_WRITES 1

--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -406,24 +406,21 @@ CacheProcessor::scan(Continuation *cont, std::string_view hostname, int KB_per_s
 Action *
 CacheProcessor::lookup(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type)
 {
-  return lookup(cont, &key->hash, frag_type,
-                std::string_view{key->hostname, static_cast<std::string_view::size_type>(key->hostlen)});
+  return lookup(cont, &key->hash, frag_type, key->hostname);
 }
 
 Action *
 CacheProcessor::open_read(Continuation *cont, const HttpCacheKey *key, CacheHTTPHdr *request, const HttpConfigAccessor *params,
                           CacheFragType type)
 {
-  return caches[type]->open_read(cont, &key->hash, request, params, type,
-                                 std::string_view{key->hostname, static_cast<std::string_view::size_type>(key->hostlen)});
+  return caches[type]->open_read(cont, &key->hash, request, params, type, key->hostname);
 }
 
 Action *
 CacheProcessor::open_write(Continuation *cont, const HttpCacheKey *key, CacheHTTPInfo *old_info, time_t pin_in_cache,
                            CacheFragType type)
 {
-  return caches[type]->open_write(cont, &key->hash, old_info, pin_in_cache, type,
-                                  std::string_view{key->hostname, static_cast<std::string_view::size_type>(key->hostlen)});
+  return caches[type]->open_write(cont, &key->hash, old_info, pin_in_cache, type, key->hostname);
 }
 
 //----------------------------------------------------------------------------
@@ -432,8 +429,7 @@ CacheProcessor::open_write(Continuation *cont, const HttpCacheKey *key, CacheHTT
 Action *
 CacheProcessor::remove(Continuation *cont, const HttpCacheKey *key, CacheFragType frag_type)
 {
-  return caches[frag_type]->remove(cont, &key->hash, frag_type,
-                                   std::string_view{key->hostname, static_cast<std::string_view::size_type>(key->hostlen)});
+  return caches[frag_type]->remove(cont, &key->hash, frag_type, key->hostname);
 }
 
 /** Set the state of a disk programmatically.

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -497,9 +497,7 @@ Cache::generate_key(CryptoHash *hash, CacheURL *url)
 inline void
 Cache::generate_key(HttpCacheKey *key, CacheURL *url, bool ignore_query, cache_generation_t generation)
 {
-  auto host{url->host_get()};
-  key->hostname = host.data();
-  key->hostlen  = static_cast<int>(host.length());
+  key->hostname = url->host_get();
   url->hash_get(&key->hash, ignore_query, generation);
 }
 
@@ -512,9 +510,7 @@ Cache::generate_key92(CryptoHash *hash, CacheURL *url)
 inline void
 Cache::generate_key92(HttpCacheKey *key, CacheURL *url, bool ignore_query, cache_generation_t generation)
 {
-  auto host{url->host_get()};
-  key->hostname = host.data();
-  key->hostlen  = static_cast<int>(host.length());
+  key->hostname = url->host_get();
   url->hash_get92(&key->hash, ignore_query, generation);
 }
 


### PR DESCRIPTION
1. Remove unused `HttpCacheKey::hash2` - I can't find any place uses this `hash2` member. 
2. Use `std::string_view` for `HttpCacheKey::hostname`