### PR TITLE
Skip lua_proxy_protocol test if curl command is old

### DIFF
--- a/tests/gold_tests/pluginTest/lua/lua_proxy_protocol.test.py
+++ b/tests/gold_tests/pluginTest/lua/lua_proxy_protocol.test.py
@@ -25,7 +25,7 @@ Test Lua plugin PROXY protocol API
 
 Test.SkipUnless(
     Condition.PluginExists('tslua.so'),
-    Condition.HasCurlVersion("8.2.0"),
+    Condition.HasCurlOption("--haproxy-clientip"),
 )
 
 Test.ContinueOnFail = True

--- a/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py
+++ b/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py
@@ -24,7 +24,7 @@ Test TS API to get PROXY protocol info
 
 Test.SkipUnless(
     Condition.HasProgram("nghttp", "Nghttp need to be installed on system for this test to work"),
-    Condition.HasCurlVersion("8.2.0"),
+    Condition.HasCurlOption("--haproxy-clientip"),
 )
 Test.ContinueOnFail = True
 


### PR DESCRIPTION
`--haproxy-clientip` flag for curl command is only available version 8.2.0 or above.

We have the check on test_TSVConnPPInfo.
https://github.com/apache/trafficserver/blob/163056e768a147822d0e2810b48fc1d15ccf0097/tests/gold_tests/pluginTest/tsapi/test_TSVConnPPInfo.test.py#L25-L28