### PR TITLE
Fix http2 content-length header check (#12747)

### DIFF
--- a/include/proxy/http2/Http2Stream.h
+++ b/include/proxy/http2/Http2Stream.h
@@ -390,11 +390,21 @@ inline bool
 Http2Stream::payload_length_is_valid() const
 {
   uint32_t content_length = _receive_header.get_content_length();
-  if (content_length != 0 && content_length != data_length) {
+  uint64_t mask           = (MIME_PRESENCE_IF_UNMODIFIED_SINCE | MIME_PRESENCE_IF_MODIFIED_SINCE | MIME_PRESENCE_IF_RANGE |
+                   MIME_PRESENCE_IF_MATCH | MIME_PRESENCE_IF_NONE_MATCH);
+
+  // Skip Content-Length check on [RFC 7230] 3.3.2 conditions
+  bool is_payload_precluded =
+    this->is_outbound_connection() && (_send_header.method_get_wksidx() == HTTP_WKSIDX_HEAD ||
+                                       (_send_header.method_get_wksidx() == HTTP_WKSIDX_GET && _send_header.presence(mask) &&
+                                        _receive_header.status_get() == HTTPStatus::NOT_MODIFIED));
+
+  if (content_length != 0 && !is_payload_precluded && content_length != data_length) {
     Warning("Bad payload length content_length=%d data_legnth=%d session_id=%" PRId64, content_length,
             static_cast<int>(data_length), _proxy_ssn->connection_id());
+    return false;
   }
-  return content_length == 0 || content_length == data_length;
+  return true;
 }
 
 inline bool


### PR DESCRIPTION
HEAD method with "Content-Length" header was returning 502 code because header differs from payload length as there is no payload in this case.

See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.6

> A response that is defined to have no payload, as described in [RFC7230], Section 3.3.2, can have a non-zero content-length header field, even though no content is included in DATA frames.



Fixes #12747 

The change fixes the behavior by having `payload_length_is_valid()` return true if `data_length` is 0 meaning that the response has no payload, allowing for non-zero 'Content-Length' in this case as specified in the rfc.