### PR TITLE
HRW: Produce errors when bad mods are used

### DIFF
--- a/plugins/header_rewrite/condition.cc
+++ b/plugins/header_rewrite/condition.cc
@@ -80,17 +80,17 @@ Condition::initialize(Parser &p)
 {
   Statement::initialize(p);
 
-  if (p.mod_exist("OR")) {
-    if (p.mod_exist("AND")) {
+  if (p.consume_mod("OR")) {
+    if (p.consume_mod("AND")) {
       TSError("[%s] Can't have both AND and OR in mods", PLUGIN_NAME);
     } else {
       _mods |= CondModifiers::OR;
     }
-  } else if (p.mod_exist("AND")) {
+  } else if (p.consume_mod("AND")) {
     _mods |= CondModifiers::AND;
   }
 
-  if (p.mod_exist("NOT")) {
+  if (p.consume_mod("NOT")) {
     _mods |= CondModifiers::NOT;
   }
 
@@ -98,25 +98,25 @@ Condition::initialize(Parser &p)
   // strings and regexes.
   int _substr_seen = 0;
 
-  if (p.mod_exist("NOCASE")) {
+  if (p.consume_mod("NOCASE")) {
     _mods |= CondModifiers::MOD_NOCASE;
-  } else if (p.mod_exist("CASE")) {
+  } else if (p.consume_mod("CASE")) {
     // Nothing to do — default is case-sensitive, but still allow this string for clearness.
   }
 
-  if (p.mod_exist("EXT")) {
+  if (p.consume_mod("EXT")) {
     _mods |= CondModifiers::MOD_EXT;
     _substr_seen++;
   }
-  if (p.mod_exist("SUF")) {
+  if (p.consume_mod("SUF")) {
     _mods |= CondModifiers::MOD_SUF;
     _substr_seen++;
   }
-  if (p.mod_exist("PRE")) {
+  if (p.consume_mod("PRE")) {
     _mods |= CondModifiers::MOD_PRE;
     _substr_seen++;
   }
-  if (p.mod_exist("MID")) {
+  if (p.consume_mod("MID")) {
     _mods |= CondModifiers::MOD_MID;
     _substr_seen++;
   }
@@ -125,10 +125,10 @@ Condition::initialize(Parser &p)
     throw std::runtime_error("Only one substring modifier (EXT, SUF, PRE, MID) may be used.");
   }
 
-  // Deal with the "last" modifier as well.
-  if (p.mod_exist("L")) {
+  if (p.consume_mod("L")) {
     _mods |= CondModifiers::MOD_L;
   }
 
   _cond_op = parse_matcher_op(p.get_arg());
+  p.validate_mods();
 }

--- a/plugins/header_rewrite/operator.cc
+++ b/plugins/header_rewrite/operator.cc
@@ -38,17 +38,19 @@ Operator::initialize(Parser &p)
 {
   Statement::initialize(p);
 
-  if (p.mod_exist("L") || p.mod_exist("LAST")) {
+  if (p.consume_mod("L") || p.consume_mod("LAST")) {
     _mods = static_cast<OperModifiers>(_mods | OPER_LAST);
   }
 
-  if (p.mod_exist("QSA")) {
+  if (p.consume_mod("QSA")) {
     _mods = static_cast<OperModifiers>(_mods | OPER_QSA);
   }
 
-  if (p.mod_exist("I") || p.mod_exist("INV")) {
+  if (p.consume_mod("I") || p.consume_mod("INV")) {
     _mods = static_cast<OperModifiers>(_mods | OPER_INV);
   }
+
+  p.validate_mods();
 }
 
 void

--- a/plugins/header_rewrite/parser.h
+++ b/plugins/header_rewrite/parser.h
@@ -195,11 +195,21 @@ public:
     return _val;
   }
 
+  // Check if the modifier exists and consume it from the list.
   bool
-  mod_exist(const std::string &m) const
+  consume_mod(const std::string &m)
   {
-    return std::find(_mods.begin(), _mods.end(), m) != _mods.end();
+    auto it = std::find(_mods.begin(), _mods.end(), m);
+
+    if (it != _mods.end()) {
+      _mods.erase(it);
+      return true;
+    }
+    return false;
   }
+
+  // Validate that all modifiers were consumed; logs error and returns false if not
+  bool validate_mods() const;
 
   bool cond_is_hook(TSHttpHookID &hook) const;
 


### PR DESCRIPTION
This produces errors in the log output, but they are not considered load / reload failures. I.e. ATS will still startup as before. We should fix this in ATS v11.

Before this, configs like this would silently succeed, with the bad modifier ignored:

```
cond %{CLIENT-HEADER:X-Foo} ="foo" [BAD]
```
