### PR TITLE
ASAN: Fix leak with the Stripe raw-dirs allocation

### DIFF
--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -277,6 +277,8 @@ struct Directory {
   StripteHeaderFooter *footer{};
   int                  segments{};
   off_t                buckets{};
+  size_t               raw_dir_size{0};     // size of raw_dir allocation (for freeing hugepages)
+  bool                 raw_dir_huge{false}; // true if raw_dir was allocated with hugepages
 
   /* Total number of dir entries.
    */

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -95,6 +95,7 @@ public:
    * @see START_POS
    */
   Stripe(CacheDisk *disk, off_t blocks, off_t dir_skip, int avg_obj_size = -1, int fragment_size = -1);
+  virtual ~Stripe();
 
   int dir_check();
 

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -191,8 +191,6 @@ TEST_CASE("The behavior of StripeSM::add_writer.")
       CHECK(true == result);
     }
   }
-
-  ats_free(stripe.directory.raw_dir);
 }
 
 // This test case demonstrates how to set up a StripeSM and make
@@ -301,8 +299,6 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
 
     cache_config_enable_checksum = false;
   }
-
-  ats_free(stripe.directory.raw_dir);
 }
 
 // When f.evacuator is set, vc.buf must contain a Doc object including headers
@@ -400,5 +396,4 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
   }
 
   delete[] source;
-  ats_free(stripe.directory.raw_dir);
 }


### PR DESCRIPTION
Since this can be allocated in two ways, we have to also keep track how it was allocated for when the destructor is called.