### PR TITLE
Rename `Stripte` identifier prefix to `Stripe`

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -990,7 +990,7 @@ Lrestart:
       goto Ldone;
     }
 
-    int    headerlen = ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
+    int    headerlen = ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter));
     size_t dirlen    = stripe->dirlen();
     if (!writepos) {
       // start

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -252,7 +252,7 @@ struct CacheSync : public Continuation {
   CacheSync() : Continuation(new_ProxyMutex()) { SET_HANDLER(&CacheSync::mainEvent); }
 };
 
-struct StripteHeaderFooter {
+struct StripeHeaderFooter {
   unsigned int      magic;
   ts::VersionNumber version;
   time_t            create_time;
@@ -271,14 +271,14 @@ struct StripteHeaderFooter {
 };
 
 struct Directory {
-  char                *raw_dir{nullptr};
-  Dir                 *dir{};
-  StripteHeaderFooter *header{};
-  StripteHeaderFooter *footer{};
-  int                  segments{};
-  off_t                buckets{};
-  size_t               raw_dir_size{0};     // size of raw_dir allocation (for freeing hugepages)
-  bool                 raw_dir_huge{false}; // true if raw_dir was allocated with hugepages
+  char               *raw_dir{nullptr};
+  Dir                *dir{};
+  StripeHeaderFooter *header{};
+  StripeHeaderFooter *footer{};
+  int                 segments{};
+  off_t               buckets{};
+  size_t              raw_dir_size{0};     // size of raw_dir allocation (for freeing hugepages)
+  bool                raw_dir_huge{false}; // true if raw_dir was allocated with hugepages
 
   /* Total number of dir entries.
    */

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -41,7 +41,7 @@ namespace
 
 DbgCtl dbg_ctl_cache_init{"cache_init"};
 
-constexpr int DIRECTORY_FOOTER_SIZE{ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter))};
+constexpr int DIRECTORY_FOOTER_SIZE{ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter))};
 
 int
 compare_ushort(void const *a, void const *b)
@@ -164,9 +164,9 @@ Stripe::_init_directory(std::size_t directory_size, int header_size, int footer_
   }
   this->directory.raw_dir_size = directory_size;
   this->directory.dir          = reinterpret_cast<Dir *>(this->directory.raw_dir + header_size);
-  this->directory.header       = reinterpret_cast<StripteHeaderFooter *>(this->directory.raw_dir);
+  this->directory.header       = reinterpret_cast<StripeHeaderFooter *>(this->directory.raw_dir);
   std::size_t const footer_offset{directory_size - static_cast<std::size_t>(footer_size)};
-  this->directory.footer = reinterpret_cast<StripteHeaderFooter *>(this->directory.raw_dir + footer_offset);
+  this->directory.footer = reinterpret_cast<StripeHeaderFooter *>(this->directory.raw_dir + footer_offset);
 }
 
 Stripe::~Stripe()

--- a/src/iocore/cache/Stripe.h
+++ b/src/iocore/cache/Stripe.h
@@ -167,7 +167,7 @@ Stripe::round_to_approx_size(uint32_t l) const
 inline int
 Stripe::headerlen() const
 {
-  return ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter) + sizeof(uint16_t) * (this->directory.segments - 1));
+  return ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter) + sizeof(uint16_t) * (this->directory.segments - 1));
 }
 
 inline size_t
@@ -175,7 +175,7 @@ Stripe::dirlen() const
 {
   return this->headerlen() +
          ROUND_TO_STORE_BLOCK(((size_t)this->directory.buckets) * DIR_DEPTH * this->directory.segments * SIZEOF_DIR) +
-         ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
+         ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter));
 }
 
 /**

--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -179,7 +179,7 @@ StripeSM::init(bool clear)
   }
 
   init_info           = new StripeInitInfo();
-  int   footerlen     = ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
+  int   footerlen     = ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter));
   off_t footer_offset = this->dirlen() - footerlen;
   // try A
   off_t as = skip;
@@ -222,7 +222,7 @@ StripeSM::handle_dir_clear(int event, void *data)
       /* clear the header for directory B. We don't need to clear the
          whole of directory B. The header for directory B starts at
          skip + len */
-      op->aiocb.aio_nbytes = ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
+      op->aiocb.aio_nbytes = ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter));
       op->aiocb.aio_offset = skip + dir_len;
       ink_assert(ink_aio_write(op));
       return EVENT_DONE;
@@ -566,7 +566,7 @@ Ldone: {
     aio->thread           = AIO_CALLBACK_THREAD_ANY;
     aio->then             = (i < 2) ? &(init_info->vol_aio[i + 1]) : nullptr;
   }
-  int    footerlen = ROUND_TO_STORE_BLOCK(sizeof(StripteHeaderFooter));
+  int    footerlen = ROUND_TO_STORE_BLOCK(sizeof(StripeHeaderFooter));
   size_t dirlen    = this->dirlen();
   int    B         = directory.header->sync_serial & 1;
   off_t  ss        = skip + (B ? dirlen : 0);
@@ -628,14 +628,14 @@ new_DocEvacuator(int nbytes, StripeSM *stripe)
 int
 StripeSM::handle_header_read(int event, void *data)
 {
-  AIOCallback         *op;
-  StripteHeaderFooter *hf[4];
+  AIOCallback        *op;
+  StripeHeaderFooter *hf[4];
   switch (event) {
   case AIO_EVENT_DONE:
     op = static_cast<AIOCallback *>(data);
     for (auto &i : hf) {
       ink_assert(op != nullptr);
-      i = static_cast<StripteHeaderFooter *>(op->aiocb.aio_buf);
+      i = static_cast<StripeHeaderFooter *>(op->aiocb.aio_buf);
       if (!op->ok()) {
         Note("Header read failed: clearing cache directory %s", this->hash_text.get());
         clear_dir_aio();

--- a/src/iocore/cache/unit_tests/test_Stripe.cc
+++ b/src/iocore/cache/unit_tests/test_Stripe.cc
@@ -116,7 +116,7 @@ attach_tmpfile_to_stripe(StripeSM &stripe)
 // We can't return a stripe from this function because the copy
 // and move constructors are deleted.
 static std::FILE *
-init_stripe_for_writing(StripeSM &stripe, StripteHeaderFooter &header, CacheVol &cache_vol)
+init_stripe_for_writing(StripeSM &stripe, StripeHeaderFooter &header, CacheVol &cache_vol)
 {
   stripe.cache_vol                             = &cache_vol;
   cache_rsb.write_bytes                        = ts::Metrics::Counter::createPtr("unit_test.write.bytes");
@@ -200,12 +200,12 @@ TEST_CASE("aggWrite behavior with f.evacuator unset")
 {
   CacheDisk disk;
   init_disk(disk);
-  StripeSM            stripe{&disk, 10, 0};
-  StripteHeaderFooter header;
-  CacheVol            cache_vol;
-  auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};
-  WaitingVC           vc{&stripe};
-  char const         *source = "yay";
+  StripeSM           stripe{&disk, 10, 0};
+  StripeHeaderFooter header;
+  CacheVol           cache_vol;
+  auto              *file{init_stripe_for_writing(stripe, header, cache_vol)};
+  WaitingVC          vc{&stripe};
+  char const        *source = "yay";
   vc.set_test_data(source, 4);
   vc.set_write_len(4);
   vc.set_agg_len(stripe.round_to_approx_size(vc.write_len + vc.header_len + vc.frag_len));
@@ -309,14 +309,14 @@ TEST_CASE("aggWrite behavior with f.evacuator set")
 {
   CacheDisk disk;
   init_disk(disk);
-  StripeSM            stripe{&disk, 10, 0};
-  StripteHeaderFooter header;
-  CacheVol            cache_vol;
-  auto               *file{init_stripe_for_writing(stripe, header, cache_vol)};
-  WaitingVC           vc{&stripe};
-  char               *source = new char[sizeof(Doc) + 4]{};
-  const char         *yay    = "yay";
-  Doc                 doc{};
+  StripeSM           stripe{&disk, 10, 0};
+  StripeHeaderFooter header;
+  CacheVol           cache_vol;
+  auto              *file{init_stripe_for_writing(stripe, header, cache_vol)};
+  WaitingVC          vc{&stripe};
+  char              *source = new char[sizeof(Doc) + 4]{};
+  const char        *yay    = "yay";
+  Doc                doc{};
   doc.magic     = DOC_MAGIC;
   doc.len       = sizeof(Doc) + 4;
   doc.total_len = 4;


### PR DESCRIPTION
The `StripteHeaderFooter` typo was introduced in 14f2d496aa and reported by Leif.