### PR TITLE
Fix null pointer dereference in traffic_crashlog

### DIFF
--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -109,6 +109,11 @@ crashlog_write_backtrace(FILE *fp, pid_t pid, const crashlog_target &)
     return false;
   }
 
+  if (trace == nullptr) {
+    fprintf(fp, "Unable to retrieve backtrace: trace is null\n");
+    return false;
+  }
+
   fprintf(fp, "%s", trace);
   free(trace);
   return true;


### PR DESCRIPTION
## Summary
- Fix ASAN SEGV in `crashlog_write_backtrace()` when `ServerBacktrace()` returns 0 but leaves `trace` pointer null
- This occurs when the target process has already exited before crashlog can retrieve the backtrace
- Added null check before calling `fprintf()` with the trace pointer

## Root Cause
Introduced in PR #10811 which moved backtrace logging from traffic_manager to traffic_crashlog but didn't account for `trace` being null.

## Test plan
- [x] Build with ASAN (`cmake --preset dev-asan`)
- [x] Create invalid remap.config to trigger crash
- [x] Verify traffic_crashlog no longer crashes with ASAN SEGV
- [x] Verify crash log contains "Unable to retrieve backtrace: trace is null" message