### PR TITLE
Use malloc allocated buffers for h2 headers if enabled

### DIFF
--- a/include/proxy/http2/Http2CommonSession.h
+++ b/include/proxy/http2/Http2CommonSession.h
@@ -60,7 +60,11 @@ enum class Http2SsnMilestone {
   LAST_ENTRY,
 };
 
+#if TS_USE_MALLOC_ALLOCATOR
+size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = BUFFER_SIZE_INDEX_FOR_XMALLOC_SIZE(4096);
+#else
 size_t const HTTP2_HEADER_BUFFER_SIZE_INDEX = BUFFER_SIZE_INDEX_4K;
+#endif
 
 /**
    @startuml

--- a/include/proxy/http2/Http2Stream.h
+++ b/include/proxy/http2/Http2Stream.h
@@ -209,10 +209,14 @@ private:
   Http2StreamState _state      = Http2StreamState::HTTP2_STREAM_STATE_IDLE;
   int64_t          _http_sm_id = -1;
 
-  HTTPHdr   _receive_header;
+  HTTPHdr _receive_header;
+#if TS_USE_MALLOC_ALLOCATOR
+  MIOBuffer _receive_buffer{BUFFER_SIZE_INDEX_FOR_XMALLOC_SIZE(4096)};
+#else
   MIOBuffer _receive_buffer{BUFFER_SIZE_INDEX_4K};
-  VIO       read_vio;
-  VIO       write_vio;
+#endif
+  VIO read_vio;
+  VIO write_vio;
 
   History<HISTORY_DEFAULT_SIZE>                                                           _history;
   Milestones<Http2StreamMilestone, static_cast<size_t>(Http2StreamMilestone::LAST_ENTRY)> _milestones;


### PR DESCRIPTION
Internal testing shows this change increased performance on high RPS setups enough to warrant a code change.  I've conditioned this change on the existing `ENABLE_MALLOC_ALLOCATOR` build flag so that it's opt-in.