### PR TITLE
Fix DbgCtl use-after-free shutdown crash via leaky singleton

### DIFF
--- a/ci/asan_leak_suppression/regression.txt
+++ b/ci/asan_leak_suppression/regression.txt
@@ -19,5 +19,8 @@ leak:RegressionTest_HostDBProcessor
 leak:RegressionTest_DNS
 leak:RegressionTest_UDPNet_echo
 leak:HttpConfig::startup
+# DbgCtl leaky singleton pattern - intentional, see issue #12776.
+leak:DbgCtl::_new_reference
+leak:_new_reference
 # libswoc
 leak:MemArena::make_block

--- a/include/tsutil/DbgCtl.h
+++ b/include/tsutil/DbgCtl.h
@@ -67,12 +67,10 @@ public:
   //
   DbgCtl() : _ptr{&_No_tag_dummy()} {}
 
-  ~DbgCtl()
-  {
-    if (_ptr != &_No_tag_dummy()) {
-      _rm_reference();
-    }
-  }
+  // Default destructor: the registry uses a "leaky singleton" pattern to avoid
+  // use-after-free crashes during shutdown due to undefined static destruction
+  // order. See issue #12776.
+  ~DbgCtl() = default;
 
   // No copying. Only moving from a tagged to a tagless instance allowed.
   //
@@ -152,8 +150,6 @@ private:
   }
 
   static const _TagData *_new_reference(char const *tag);
-
-  static void _rm_reference();
 
   class _RegistryAccessor;
 

--- a/plugins/esi/test/CMakeLists.txt
+++ b/plugins/esi/test/CMakeLists.txt
@@ -22,6 +22,11 @@ macro(ADD_ESI_TEST NAME)
   add_executable(${NAME} print_funcs.cc ${ARGN})
   target_link_libraries(${NAME} PRIVATE esitest)
   add_catch2_test(NAME ${NAME}_esi COMMAND $<TARGET_FILE:${NAME}>)
+  # Use ASan leak suppression for intentional DbgCtl leaks (issue #12776)
+  set_tests_properties(
+    ${NAME}_esi PROPERTIES ENVIRONMENT
+                           "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/esi_test_leak_suppression.txt"
+  )
 endmacro()
 
 add_esi_test(test_docnode docnode_test.cc)

--- a/plugins/esi/test/esi_test_leak_suppression.txt
+++ b/plugins/esi/test/esi_test_leak_suppression.txt
@@ -1,0 +1,5 @@
+# ESI unit test leak suppressions
+# DbgCtl leaky singleton pattern - intentional, see issue #12776
+leak:DbgCtl::_new_reference
+leak:_new_reference
+


### PR DESCRIPTION
The DbgCtl registry was experiencing use-after-free crashes during program shutdown, particularly visible in CI regression tests. The root cause was the undefined destruction order of static objects in C++.

Problem:
- DbgCtl objects can be static or thread-local with lifetimes spanning program execution
- When one compilation unit's DbgCtl destructs and triggers registry cleanup, other compilation units may still have DbgCtl objects with pointers into that registry
- Thread exit order is also unpredictable, causing similar issues when thread-local DbgCtl objects destruct

This implements the "leaky singleton" pattern where the registry is:
- Created on first use
- Never destroyed (destructor is now = default)
- Memory (~20KB) reclaimed by OS at process exit

Fixes: #12776