### PR TITLE
Fix convert2yaml.py to handle files without trailing newline

### DIFF
--- a/tests/gold_tests/records/gold/no_newline.yaml
+++ b/tests/gold_tests/records/gold/no_newline.yaml
@@ -1,0 +1,3 @@
+records:
+  http:
+    negative_caching_enabled: 0

--- a/tests/gold_tests/records/legacy_config/no_newline.config
+++ b/tests/gold_tests/records/legacy_config/no_newline.config
@@ -1,0 +1,1 @@
+CONFIG proxy.config.http.negative_caching_enabled INT 0

--- a/tests/gold_tests/records/records_config_to_yaml.test.py
+++ b/tests/gold_tests/records/records_config_to_yaml.test.py
@@ -56,3 +56,12 @@ tr.Processes.Default.Command = f'python3 convert2yaml.py -f override_map.config 
 tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
     "We cannot continue with 'proxy.config.ssl.client.verify.server' at line '3' as an existing YAML map will be overridden.",
     "Error should be present")
+
+file_suffix = file_suffix + 1
+
+tr = Test.AddTestRun("Test config file without trailing newline")
+tr.Setup.Copy(os.path.join(Test.Variables.RepoDir, "tools/records/convert2yaml.py"))
+tr.Setup.Copy('legacy_config/no_newline.config')
+tr.Processes.Default.Command = f'python3 convert2yaml.py -f no_newline.config --output generated{file_suffix}.yaml --yaml --mute'
+f = tr.Disk.File(f"generated{file_suffix}.yaml")
+f.Content = "gold/no_newline.yaml"

--- a/tools/records/convert2yaml.py
+++ b/tools/records/convert2yaml.py
@@ -273,8 +273,8 @@ def handle_file_input(args):
             elif args.node and name.startswith("proxy.node."):
                 name = name[len("proxy."):]
 
-            # Build the object
-            add_object(config, name, value[:-1], type, track_info)
+            # Build the object (use rstrip to handle files without trailing newline)
+            add_object(config, name, value.rstrip('\n'), type, track_info)
             idx = idx + 1
 
     ts = {}


### PR DESCRIPTION
The script was using `value[:-1]` to strip the trailing newline, which incorrectly truncates the last character if the file doesn't end with a newline. Changed to `value.rstrip('\n')` which properly handles both cases.

Added test case for config files without trailing newlines.