### PR TITLE
Avoid Stripe Mutex lock contention for RWW

### DIFF
--- a/include/iocore/cache/CacheDefs.h
+++ b/include/iocore/cache/CacheDefs.h
@@ -95,6 +95,7 @@ enum CacheEventType {
   CACHE_EVENT_SCAN_OPERATION_BLOCKED = CACHE_EVENT_EVENTS_START + 23,
   CACHE_EVENT_SCAN_OPERATION_FAILED  = CACHE_EVENT_EVENTS_START + 24,
   CACHE_EVENT_SCAN_DONE              = CACHE_EVENT_EVENTS_START + 25,
+  CACHE_EVENT_OPEN_DIR_RETRY         = CACHE_EVENT_EVENTS_START + 26,
   //////////////////////////
   // Internal error codes //
   //////////////////////////

--- a/include/tsutil/Bravo.h
+++ b/include/tsutil/Bravo.h
@@ -393,7 +393,7 @@ template <typename T = shared_mutex_impl<>, size_t SLOT_SIZE = 256> class recurs
   static constexpr size_t NO_OWNER = SLOT_SIZE;
 
 public:
-  recursive_shared_mutex_impl()  = default;
+  recursive_shared_mutex_impl() { debug_assert(SLOT_SIZE >= DenseThreadId::num_possible_values()); }
   ~recursive_shared_mutex_impl() = default;
 
   // No copying or moving
@@ -448,7 +448,7 @@ public:
   unlock()
   {
     if (--_exclusive_count == 0) {
-      _exclusive_owner.store(NO_OWNER, std::memory_order_relaxed);
+      _exclusive_owner.store(NO_OWNER, std::memory_order_release);
       _mutex.unlock();
     }
   }
@@ -514,10 +514,11 @@ public:
   }
 
   void
-  unlock_shared(const Token /* token */)
+  unlock_shared(const Token token)
   {
     size_t       tid   = DenseThreadId::self();
     ThreadState &state = _thread_states[tid];
+    debug_assert(token == state.cached_token);
     if (--state.shared_count == 0) {
       // Only unlock underlying mutex if we're not holding exclusive lock
       if (_exclusive_owner.load(std::memory_order_relaxed) != tid) {
@@ -529,16 +530,16 @@ public:
 
   // Extensions to check
   bool
-  has_unique_lock()
+  has_unique_lock() const
   {
     return _exclusive_owner.load(std::memory_order_relaxed) == DenseThreadId::self();
   }
 
   bool
-  has_shared_lock()
+  has_shared_lock() const
   {
-    size_t       tid   = DenseThreadId::self();
-    ThreadState &state = _thread_states[tid];
+    size_t             tid   = DenseThreadId::self();
+    const ThreadState &state = _thread_states[tid];
 
     if (state.shared_count > 0) {
       return true;

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -394,11 +394,11 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheFragType type, st
   }
   ink_assert(caches[type] == this);
 
-  StripeSM     *stripe = key_to_stripe(key, hostname);
-  Dir           result, *last_collision = nullptr;
-  ProxyMutex   *mutex = cont->mutex.get();
-  OpenDirEntry *od    = nullptr;
-  CacheVC      *c     = nullptr;
+  StripeSM         *stripe = key_to_stripe(key, hostname);
+  Dir               result, *last_collision = nullptr;
+  ProxyMutex       *mutex = cont->mutex.get();
+  Ptr<OpenDirEntry> od;
+  CacheVC          *c = nullptr;
   {
     CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
     if (!lock.is_locked() || (od = stripe->open_read(key)) || stripe->directory.probe(key, stripe, &result, &last_collision)) {
@@ -596,11 +596,11 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
   }
   ink_assert(caches[type] == this);
 
-  StripeSM     *stripe = key_to_stripe(key, hostname, volume_host_rec);
-  Dir           result, *last_collision = nullptr;
-  ProxyMutex   *mutex = cont->mutex.get();
-  OpenDirEntry *od    = nullptr;
-  CacheVC      *c     = nullptr;
+  StripeSM         *stripe = key_to_stripe(key, hostname, volume_host_rec);
+  Dir               result, *last_collision = nullptr;
+  ProxyMutex       *mutex = cont->mutex.get();
+  Ptr<OpenDirEntry> od;
+  CacheVC          *c = nullptr;
 
   // Read-While-Writer
   // This OpenDirEntry lookup doesn't need stripe mutex lock because OpenDir has own reader-writer lock

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -596,15 +596,14 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
   }
   ink_assert(caches[type] == this);
 
-  StripeSM         *stripe = key_to_stripe(key, hostname, volume_host_rec);
-  Dir               result, *last_collision = nullptr;
-  ProxyMutex       *mutex = cont->mutex.get();
-  Ptr<OpenDirEntry> od;
-  CacheVC          *c = nullptr;
+  StripeSM   *stripe = key_to_stripe(key, hostname, volume_host_rec);
+  Dir         result, *last_collision = nullptr;
+  ProxyMutex *mutex = cont->mutex.get();
+  CacheVC    *c     = nullptr;
 
   // Read-While-Writer
   // This OpenDirEntry lookup doesn't need stripe mutex lock because OpenDir has own reader-writer lock
-  od = stripe->open_read(key);
+  Ptr<OpenDirEntry> od = stripe->open_read(key);
   if (od != nullptr) {
     c     = new_CacheVC_for_read(cont, key, request, params, stripe);
     c->od = od;

--- a/src/iocore/cache/Cache.cc
+++ b/src/iocore/cache/Cache.cc
@@ -112,6 +112,28 @@ DbgCtl dbg_ctl_cache_init{"cache_init"};
 DbgCtl dbg_ctl_cache_hosting{"cache_hosting"};
 DbgCtl dbg_ctl_cache_update{"cache_update"};
 
+CacheVC *
+new_CacheVC_for_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request, const HttpConfigAccessor *params,
+                     StripeSM *stripe)
+{
+  CacheVC *cache_vc = new_CacheVC(cont);
+
+  cache_vc->first_key    = *key;
+  cache_vc->key          = *key;
+  cache_vc->earliest_key = *key;
+  cache_vc->stripe       = stripe;
+  cache_vc->vio.op       = VIO::READ;
+  cache_vc->op_type      = static_cast<int>(CacheOpType::Read);
+  cache_vc->frag_type    = CACHE_FRAG_TYPE_HTTP;
+  cache_vc->params       = params;
+  cache_vc->request.copy_shallow(request);
+
+  ts::Metrics::Gauge::increment(cache_rsb.status[cache_vc->op_type].active);
+  ts::Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[cache_vc->op_type].active);
+
+  return cache_vc;
+}
+
 } // end anonymous namespace
 
 // Global list of the volumes created
@@ -580,20 +602,24 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
   OpenDirEntry *od    = nullptr;
   CacheVC      *c     = nullptr;
 
+  // Read-While-Writer
+  // This OpenDirEntry lookup doesn't need stripe mutex lock because OpenDir has own reader-writer lock
+  od = stripe->open_read(key);
+  if (od != nullptr) {
+    c     = new_CacheVC_for_read(cont, key, request, params, stripe);
+    c->od = od;
+    cont->handleEvent(CACHE_EVENT_OPEN_READ_RWW, nullptr);
+    SET_CONTINUATION_HANDLER(c, &CacheVC::openReadFromWriter);
+    if (c->handleEvent(EVENT_IMMEDIATE, nullptr) == EVENT_DONE) {
+      return ACTION_RESULT_DONE;
+    }
+    return &c->_action;
+  }
+
   {
     CACHE_TRY_LOCK(lock, stripe->mutex, mutex->thread_holding);
-    if (!lock.is_locked() || (od = stripe->open_read(key)) || stripe->directory.probe(key, stripe, &result, &last_collision)) {
-      c            = new_CacheVC(cont);
-      c->first_key = c->key = c->earliest_key = *key;
-      c->stripe                               = stripe;
-      c->vio.op                               = VIO::READ;
-      c->op_type                              = static_cast<int>(CacheOpType::Read);
-      ts::Metrics::Gauge::increment(cache_rsb.status[c->op_type].active);
-      ts::Metrics::Gauge::increment(stripe->cache_vol->vol_rsb.status[c->op_type].active);
-      c->request.copy_shallow(request);
-      c->frag_type = CACHE_FRAG_TYPE_HTTP;
-      c->params    = params;
-      c->od        = od;
+    if (!lock.is_locked() || stripe->directory.probe(key, stripe, &result, &last_collision)) {
+      c = new_CacheVC_for_read(cont, key, request, params, stripe);
     }
     if (!lock.is_locked()) {
       SET_CONTINUATION_HANDLER(c, &CacheVC::openReadStartHead);
@@ -603,9 +629,7 @@ Cache::open_read(Continuation *cont, const CacheKey *key, CacheHTTPHdr *request,
     if (!c) {
       goto Lmiss;
     }
-    if (c->od) {
-      goto Lwriter;
-    }
+
     // hit
     c->dir = c->first_dir = result;
     c->last_collision     = last_collision;
@@ -624,13 +648,6 @@ Lmiss:
   ts::Metrics::Counter::increment(stripe->cache_vol->vol_rsb.status[static_cast<int>(CacheOpType::Read)].failure);
   cont->handleEvent(CACHE_EVENT_OPEN_READ_FAILED, reinterpret_cast<void *>(-ECACHE_NO_DOC));
   return ACTION_RESULT_DONE;
-Lwriter:
-  cont->handleEvent(CACHE_EVENT_OPEN_READ_RWW, nullptr);
-  SET_CONTINUATION_HANDLER(c, &CacheVC::openReadFromWriter);
-  if (c->handleEvent(EVENT_IMMEDIATE, nullptr) == EVENT_DONE) {
-    return ACTION_RESULT_DONE;
-  }
-  return &c->_action;
 Lcallreturn:
   if (c->handleEvent(AIO_EVENT_DONE, nullptr) == EVENT_DONE) {
     return ACTION_RESULT_DONE;

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -67,6 +67,12 @@ DbgCtl dbg_ctl_dir_lookaside{"dir_lookaside"};
 
 ClassAllocator<OpenDirEntry, false> openDirEntryAllocator("openDirEntry");
 
+void
+OpenDirEntry::free()
+{
+  THREAD_FREE(this, openDirEntryAllocator, this_ethread());
+}
+
 // OpenDir
 
 OpenDir::OpenDir(StripeSM *s) : Continuation(new_ProxyMutex()), _stripe(s)
@@ -166,27 +172,26 @@ OpenDir::close_write(CacheVC *cont)
   if (!cont->od->writers.head) {
     unsigned int h = cont->first_key.slice32(0);
     int          b = h % OPEN_DIR_BUCKETS;
-    _bucket[b].remove(cont->od);
+    _bucket[b].remove(cont->od.get());
     _delayed_readers.append(cont->od->readers);
     signal_readers(EVENT_CALL, nullptr);
     cont->od->vector.clear();
-    THREAD_FREE(cont->od, openDirEntryAllocator, cont->mutex->thread_holding);
   }
   cont->od = nullptr;
   return 0;
 }
 
-OpenDirEntry *
+Ptr<OpenDirEntry>
 OpenDir::open_read(const CryptoHash *key) const
 {
   unsigned int h = key->slice32(0);
   int          b = h % OPEN_DIR_BUCKETS;
   for (OpenDirEntry *d = _bucket[b].head; d; d = d->link.next) {
     if (d->writers.head->first_key == *key) {
-      return d;
+      return Ptr<OpenDirEntry>(d);
     }
   }
-  return nullptr;
+  return Ptr<OpenDirEntry>();
 }
 
 //

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -127,13 +127,14 @@ OpenDir::open_write(CacheVC *cont, int allow_if_writers, int max_writers)
 
   1. Direct call from OpenDir::close_write - writer lock is already acquired
   2. Self retry through event system - need to acquire writer lock
+
  */
 int
 OpenDir::signal_readers(int event, Event * /* ATS UNUSED */)
 {
   auto write_op = [&] {
     Queue<CacheVC, Link_CacheVC_opendir_link> newly_delayed_readers;
-    EThread                                  *t = mutex->thread_holding;
+    EThread                                  *t = this_ethread();
     CacheVC                                  *c = nullptr;
     while ((c = _delayed_readers.dequeue())) {
       CACHE_TRY_LOCK(lock, c->mutex, t);
@@ -148,7 +149,7 @@ OpenDir::signal_readers(int event, Event * /* ATS UNUSED */)
       _delayed_readers = newly_delayed_readers;
       EThread *t1      = newly_delayed_readers.head->mutex->thread_holding;
       if (!t1) {
-        t1 = mutex->thread_holding;
+        t1 = t;
       }
       t1->schedule_in(this, HRTIME_MSECONDS(cache_config_mutex_retry_delay), CACHE_EVENT_OPEN_DIR_RETRY);
     }
@@ -158,6 +159,7 @@ OpenDir::signal_readers(int event, Event * /* ATS UNUSED */)
     // self-retry comes from event system
     _stripe->write_op<void>(write_op);
   } else {
+    // direct call
     write_op();
   }
 

--- a/src/iocore/cache/CacheEvacuateDocVC.cc
+++ b/src/iocore/cache/CacheEvacuateDocVC.cc
@@ -100,7 +100,7 @@ CacheEvacuateDocVC::evacuateDocDone(int /* event ATS_UNUSED */, Event * /* e ATS
            doc->hlen, dir_offset(&this->overwrite_dir));
 
       if (dir_compare_tag(&this->overwrite_dir, &doc->first_key)) {
-        OpenDirEntry *cod;
+        Ptr<OpenDirEntry> cod;
         DDbg(dbg_ctl_cache_evac, "evacuating vector: %X %" PRId64, doc->first_key.slice32(0), dir_offset(&this->overwrite_dir));
         if ((cod = this->stripe->open_read(&doc->first_key))) {
           // writer  exists

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -249,8 +249,8 @@ CacheVC::openReadFromWriter(int event, Event *e)
       return openReadStartHead(event, e);
     }
   }
-  OpenDirEntry *cod = od;
-  od                = nullptr;
+  Ptr<OpenDirEntry> cod = od;
+  od                    = nullptr;
   // someone is currently writing the document
   if (write_vc->closed < 0) {
     MUTEX_RELEASE(lock);
@@ -1149,7 +1149,7 @@ CacheVC::openReadStartHead(int event, Event *e)
     // don't want to go through this BS of reading from a writer if
     // its a lookup. In this case lookup will fail while the document is
     // being written to the cache.
-    OpenDirEntry *cod = stripe->open_read(&key);
+    Ptr<OpenDirEntry> cod = stripe->open_read(&key);
     if (cod && !f.read_from_writer_called) {
       if (f.lookup) {
         err = ECACHE_DOC_BUSY;

--- a/src/iocore/cache/CacheVC.h
+++ b/src/iocore/cache/CacheVC.h
@@ -236,9 +236,9 @@ struct CacheVC : public CacheVConnection {
   Ptr<IOBufferBlock>  blocks; // data available to write
   Ptr<IOBufferBlock>  writer_buf;
 
-  OpenDirEntry *od = nullptr;
-  AIOCallback   io;
-  int           alternate_index = CACHE_ALT_INDEX_DEFAULT; // preferred position in vector
+  Ptr<OpenDirEntry> od;
+  AIOCallback       io;
+  int               alternate_index = CACHE_ALT_INDEX_DEFAULT; // preferred position in vector
   LINK(CacheVC, opendir_link);
   // end Region B
 

--- a/src/iocore/cache/P_CacheDir.h
+++ b/src/iocore/cache/P_CacheDir.h
@@ -27,6 +27,7 @@
 #include "iocore/cache/CacheDefs.h"
 #include "iocore/eventsystem/Continuation.h"
 #include "iocore/aio/AIO.h"
+#include "tscore/Ptr.h"
 #include "tscore/Version.h"
 #include "tscore/hugepages.h"
 #include "tsutil/Bravo.h"
@@ -201,7 +202,7 @@ struct Dir {
 // is deleted/inserted into the vector just before writing the vector disk
 // (CacheVC::updateVector).
 LINK_FORWARD_DECLARATION(CacheVC, opendir_link) // forward declaration
-struct OpenDirEntry {
+struct OpenDirEntry : public RefCountObj {
   DLL<CacheVC, Link_CacheVC_opendir_link> writers; // list of all the current writers
   DLL<CacheVC, Link_CacheVC_opendir_link> readers; // list of all the current readers - not used
   CacheHTTPInfoVector                     vector;  // Vector for the http document. Each writer
@@ -219,6 +220,8 @@ struct OpenDirEntry {
   bool     writing_vec;                            // somebody is currently writing the vector
 
   LINK(OpenDirEntry, link);
+
+  void free() override;
 
   bool
   has_multiple_writers()
@@ -239,7 +242,7 @@ public:
   int open_write(CacheVC *c, int allow_if_writers, int max_writers);
   int close_write(CacheVC *c);
   // reader
-  OpenDirEntry *open_read(const CryptoHash *key) const;
+  Ptr<OpenDirEntry> open_read(const CryptoHash *key) const;
 
   // event handler
   int signal_readers(int event, Event *e);

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -382,7 +382,7 @@ CacheVC::do_write_lock_call()
 inline bool
 CacheVC::writer_done()
 {
-  OpenDirEntry *cod = od;
+  Ptr<OpenDirEntry> cod = od;
   if (!cod) {
     cod = stripe->open_read(&first_key);
   }

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -34,6 +34,7 @@
 
 #include "tscore/CryptoHash.h"
 #include "tscore/List.h"
+#include "tsutil/Bravo.h"
 
 #include <atomic>
 
@@ -128,7 +129,6 @@ public:
 
   CacheDisk *disk{};
 
-  OpenDir              open_dir;
   RamCache            *ram_cache = nullptr;
   DLL<EvacuationBlock> lookaside[LOOKASIDE_SIZE];
   CacheEvacuateDocVC  *doc_evacuator = nullptr;
@@ -152,14 +152,15 @@ public:
 
   int recover_data();
 
-  int open_write(CacheVC *cont, int allow_if_writers, int max_writers);
-  int open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers);
-  int close_write(CacheVC *cont);
-  int begin_read(CacheVC *cont) const;
-  // unused read-write interlock code
-  // currently http handles a write-lock failure by retrying the read
+  // OpenDir API
+  int           open_write(CacheVC *cont, int allow_if_writers, int max_writers);
+  int           open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers);
+  int           close_write(CacheVC *cont);
   OpenDirEntry *open_read(const CryptoHash *key) const;
-  int           close_read(CacheVC *cont) const;
+
+  // PreservationTable API
+  int begin_read(CacheVC *cont) const;
+  int close_read(CacheVC *cont) const;
 
   int clear_dir_aio();
   int clear_dir();
@@ -288,8 +289,21 @@ public:
     return this->_preserved_dirs;
   }
 
+  // shared_mutex lock guard helpers
+  template <typename U, typename Func> U read_op(Func) const;
+  template <typename U, typename Func> U write_op(Func);
+
 private:
-  mutable PreservationTable _preserved_dirs;
+  /**
+    Reader-Writer lock to cover OpenDir access.
+    For now, only OpenDir access is covered, but when we clarify other functions as reader or writer, we can use this shared_mutex
+    for them to reduce current heavy lock contention of StripeSM::mutex.
+   */
+  mutable ts::bravo::recursive_shared_mutex _shared_mutex;
+  mutable PreservationTable                 _preserved_dirs;
+
+  // All access to this OpenDir requires _shared_mutex lock guard
+  OpenDir _open_dir;
 
   int _agg_copy(CacheVC *vc);
   int _copy_writer_to_aggregation(CacheVC *vc);
@@ -302,6 +316,24 @@ extern StripeSM                          **gstripes;
 extern std::atomic<int>                    gnstripes;
 extern ClassAllocator<OpenDirEntry, false> openDirEntryAllocator;
 extern unsigned short                     *vol_hash_table;
+
+template <typename U, typename Func>
+U
+StripeSM::read_op(Func read_op) const
+{
+  ts::bravo::shared_lock lock(_shared_mutex);
+
+  return read_op();
+}
+
+template <typename U, typename Func>
+U
+StripeSM::write_op(Func write_op)
+{
+  std::lock_guard lock(_shared_mutex);
+
+  return write_op();
+}
 
 // inline Functions
 
@@ -317,7 +349,9 @@ StripeSM::cancel_trigger()
 inline OpenDirEntry *
 StripeSM::open_read(const CryptoHash *key) const
 {
-  return open_dir.open_read(key);
+  ts::bravo::shared_lock lock(_shared_mutex);
+
+  return _open_dir.open_read(key);
 }
 
 inline int

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -298,6 +298,10 @@ private:
     Reader-Writer lock to cover OpenDir access.
     For now, only OpenDir access is covered, but when we clarify other functions as reader or writer, we can use this shared_mutex
     for them to reduce current heavy lock contention of StripeSM::mutex.
+
+    Lock ordering: stripe mutex must be acquired before _shared_mutex when both are needed
+    (e.g. open_write_lock holds stripe mutex then calls open_write which acquires _shared_mutex).
+    Never acquire stripe mutex while holding _shared_mutex.
    */
   mutable ts::bravo::recursive_shared_mutex _shared_mutex;
   mutable PreservationTable                 _preserved_dirs;
@@ -349,9 +353,7 @@ StripeSM::cancel_trigger()
 inline Ptr<OpenDirEntry>
 StripeSM::open_read(const CryptoHash *key) const
 {
-  ts::bravo::shared_lock lock(_shared_mutex);
-
-  return _open_dir.open_read(key);
+  return read_op<Ptr<OpenDirEntry>>([&]() { return _open_dir.open_read(key); });
 }
 
 inline int

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -153,10 +153,10 @@ public:
   int recover_data();
 
   // OpenDir API
-  int           open_write(CacheVC *cont, int allow_if_writers, int max_writers);
-  int           open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers);
-  int           close_write(CacheVC *cont);
-  OpenDirEntry *open_read(const CryptoHash *key) const;
+  int               open_write(CacheVC *cont, int allow_if_writers, int max_writers);
+  int               open_write_lock(CacheVC *cont, int allow_if_writers, int max_writers);
+  int               close_write(CacheVC *cont);
+  Ptr<OpenDirEntry> open_read(const CryptoHash *key) const;
 
   // PreservationTable API
   int begin_read(CacheVC *cont) const;
@@ -346,7 +346,7 @@ StripeSM::cancel_trigger()
   }
 }
 
-inline OpenDirEntry *
+inline Ptr<OpenDirEntry>
 StripeSM::open_read(const CryptoHash *key) const
 {
   ts::bravo::shared_lock lock(_shared_mutex);

--- a/src/tsutil/unit_tests/test_Bravo.cc
+++ b/src/tsutil/unit_tests/test_Bravo.cc
@@ -227,3 +227,543 @@ TEST_CASE("BRAVO - check with race", "[libts][BRAVO]")
     CHECK(i == 2);
   }
 }
+
+TEST_CASE("Recursive BRAVO - exclusive lock", "[libts][BRAVO]")
+{
+  SECTION("single lock/unlock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+    mutex.unlock();
+  }
+
+  SECTION("recursive lock/unlock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+    mutex.lock();
+    mutex.lock();
+    mutex.unlock();
+    mutex.unlock();
+    mutex.unlock();
+  }
+
+  SECTION("try_lock by owner succeeds")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+    CHECK(mutex.try_lock() == true);
+    mutex.unlock();
+    mutex.unlock();
+  }
+
+  SECTION("try_lock by non-owner fails")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+
+    std::thread t{[&mutex]() { CHECK(mutex.try_lock() == false); }};
+    t.join();
+
+    mutex.unlock();
+  }
+
+  SECTION("recursive try_lock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    CHECK(mutex.try_lock() == true);
+    CHECK(mutex.try_lock() == true);
+    CHECK(mutex.try_lock() == true);
+    mutex.unlock();
+    mutex.unlock();
+    mutex.unlock();
+  }
+
+  SECTION("writer-writer blocking")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    int                               i = 0;
+
+    std::thread t1{[&]() {
+      std::lock_guard<ts::bravo::recursive_shared_mutex> lock(mutex);
+      std::this_thread::sleep_for(100ms);
+      CHECK(++i == 1);
+    }};
+
+    std::thread t2{[&]() {
+      std::this_thread::sleep_for(50ms);
+      std::lock_guard<ts::bravo::recursive_shared_mutex> lock(mutex);
+      CHECK(++i == 2);
+    }};
+
+    t1.join();
+    t2.join();
+
+    CHECK(i == 2);
+  }
+}
+
+TEST_CASE("Recursive BRAVO - shared lock", "[libts][BRAVO]")
+{
+  SECTION("single shared lock/unlock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token{0};
+    mutex.lock_shared(token);
+    mutex.unlock_shared(token);
+  }
+
+  SECTION("recursive shared lock/unlock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token1{0};
+    ts::bravo::Token                  token2{0};
+    ts::bravo::Token                  token3{0};
+    mutex.lock_shared(token1);
+    mutex.lock_shared(token2);
+    mutex.lock_shared(token3);
+    // All tokens should be the same (cached)
+    CHECK(token1 == token2);
+    CHECK(token2 == token3);
+    mutex.unlock_shared(token3);
+    mutex.unlock_shared(token2);
+    mutex.unlock_shared(token1);
+  }
+
+  SECTION("try_lock_shared recursive")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token1{0};
+    ts::bravo::Token                  token2{0};
+    CHECK(mutex.try_lock_shared(token1) == true);
+    CHECK(mutex.try_lock_shared(token2) == true);
+    CHECK(token1 == token2);
+    mutex.unlock_shared(token2);
+    mutex.unlock_shared(token1);
+  }
+
+  SECTION("multiple readers concurrent")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    int                               i = 0;
+
+    std::thread t1{[&]() {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      CHECK(i == 0);
+      std::this_thread::sleep_for(50ms);
+      mutex.unlock_shared(token);
+    }};
+
+    std::thread t2{[&]() {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      CHECK(i == 0);
+      std::this_thread::sleep_for(50ms);
+      mutex.unlock_shared(token);
+    }};
+
+    t1.join();
+    t2.join();
+
+    CHECK(i == 0);
+  }
+
+  SECTION("shared blocks exclusive")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token{0};
+    mutex.lock_shared(token);
+
+    std::thread t{[&mutex]() { CHECK(mutex.try_lock() == false); }};
+    t.join();
+
+    mutex.unlock_shared(token);
+  }
+
+  SECTION("exclusive blocks shared")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+
+    std::thread t{[&mutex]() {
+      ts::bravo::Token token{0};
+      CHECK(mutex.try_lock_shared(token) == false);
+    }};
+    t.join();
+
+    mutex.unlock();
+  }
+}
+
+TEST_CASE("Recursive BRAVO - mixed lock scenarios", "[libts][BRAVO]")
+{
+  SECTION("downgrade: exclusive owner can acquire shared lock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+
+    // While holding exclusive lock, we can acquire shared lock
+    ts::bravo::Token token{0};
+    mutex.lock_shared(token);
+    CHECK(token == 0); // Special token for downgrade
+
+    mutex.unlock_shared(token);
+    mutex.unlock();
+  }
+
+  SECTION("downgrade: try_lock_shared succeeds for exclusive owner")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+
+    ts::bravo::Token token{0};
+    CHECK(mutex.try_lock_shared(token) == true);
+    CHECK(token == 0); // Special token for downgrade
+
+    mutex.unlock_shared(token);
+    mutex.unlock();
+  }
+
+  SECTION("upgrade prevention: try_lock fails when holding shared lock")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token{0};
+    mutex.lock_shared(token);
+
+    // Cannot upgrade: try_lock should fail
+    CHECK(mutex.try_lock() == false);
+
+    mutex.unlock_shared(token);
+  }
+
+  SECTION("downgrade with multiple shared locks")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+
+    ts::bravo::Token token1{0};
+    ts::bravo::Token token2{0};
+    mutex.lock_shared(token1);
+    mutex.lock_shared(token2);
+
+    mutex.unlock_shared(token2);
+    mutex.unlock_shared(token1);
+    mutex.unlock();
+  }
+
+  SECTION("proper unlock ordering: shared then exclusive")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+
+    ts::bravo::Token token{0};
+    mutex.lock_shared(token);
+
+    // Unlock shared first, then exclusive
+    mutex.unlock_shared(token);
+    mutex.unlock();
+
+    // Mutex should be fully unlocked now
+    CHECK(mutex.try_lock() == true);
+    mutex.unlock();
+  }
+
+  SECTION("nested exclusive locks with shared in between")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    mutex.lock();
+    mutex.lock(); // Recursive exclusive
+
+    ts::bravo::Token token{0};
+    mutex.lock_shared(token);
+
+    mutex.unlock_shared(token);
+    mutex.unlock(); // Second exclusive
+    mutex.unlock(); // First exclusive
+
+    // Mutex should be fully unlocked now
+    CHECK(mutex.try_lock() == true);
+    mutex.unlock();
+  }
+}
+
+TEST_CASE("Recursive BRAVO - BRAVO optimizations", "[libts][BRAVO]")
+{
+  SECTION("first shared lock gets token from underlying BRAVO mutex")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token{0};
+    mutex.lock_shared(token);
+    // Token should be set by underlying BRAVO mutex (0 = slow path, >0 = fast path)
+    // We can't guarantee which path is taken, but the lock should succeed
+    mutex.unlock_shared(token);
+  }
+
+  SECTION("recursive shared locks reuse cached token")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    ts::bravo::Token                  token1{0};
+    ts::bravo::Token                  token2{0};
+    ts::bravo::Token                  token3{0};
+
+    mutex.lock_shared(token1);
+    mutex.lock_shared(token2);
+    mutex.lock_shared(token3);
+
+    // All tokens should be identical (cached from first lock)
+    CHECK(token1 == token2);
+    CHECK(token2 == token3);
+
+    mutex.unlock_shared(token3);
+    mutex.unlock_shared(token2);
+    mutex.unlock_shared(token1);
+  }
+
+  SECTION("writer revocation then reader works")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+
+    // First, acquire and release a shared lock to enable read_bias
+    {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      mutex.unlock_shared(token);
+    }
+
+    // Writer acquires lock (triggers revocation)
+    mutex.lock();
+    mutex.unlock();
+
+    // Reader should still work after writer releases
+    {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      mutex.unlock_shared(token);
+    }
+  }
+
+  SECTION("multiple readers then writer then readers")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    std::atomic<int>                  readers_done{0};
+
+    // Start multiple readers
+    std::thread t1{[&]() {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      std::this_thread::sleep_for(50ms);
+      mutex.unlock_shared(token);
+      ++readers_done;
+    }};
+
+    std::thread t2{[&]() {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      std::this_thread::sleep_for(50ms);
+      mutex.unlock_shared(token);
+      ++readers_done;
+    }};
+
+    // Wait for readers to finish
+    t1.join();
+    t2.join();
+    CHECK(readers_done == 2);
+
+    // Writer acquires lock
+    mutex.lock();
+    mutex.unlock();
+
+    // More readers after writer
+    std::thread t3{[&]() {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      mutex.unlock_shared(token);
+      ++readers_done;
+    }};
+
+    std::thread t4{[&]() {
+      ts::bravo::Token token{0};
+      mutex.lock_shared(token);
+      mutex.unlock_shared(token);
+      ++readers_done;
+    }};
+
+    t3.join();
+    t4.join();
+    CHECK(readers_done == 4);
+  }
+
+  SECTION("recursive shared lock with concurrent writer")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    std::atomic<bool>                 writer_done{false};
+
+    // Reader thread with recursive locks
+    std::thread reader{[&]() {
+      ts::bravo::Token token1{0};
+      ts::bravo::Token token2{0};
+      mutex.lock_shared(token1);
+      mutex.lock_shared(token2); // Recursive
+      CHECK(token1 == token2);   // Should be same cached token
+      std::this_thread::sleep_for(100ms);
+      mutex.unlock_shared(token2);
+      mutex.unlock_shared(token1);
+    }};
+
+    // Writer thread tries to acquire after reader starts
+    std::thread writer{[&]() {
+      std::this_thread::sleep_for(50ms);
+      mutex.lock();
+      writer_done = true;
+      mutex.unlock();
+    }};
+
+    reader.join();
+    writer.join();
+    CHECK(writer_done == true);
+  }
+}
+
+TEST_CASE("Recursive BRAVO - stress test", "[libts][BRAVO]")
+{
+  SECTION("concurrent readers with recursive locks")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    std::atomic<int>                  counter{0};
+    constexpr int                     NUM_THREADS    = 8;
+    constexpr int                     NUM_ITERATIONS = 1000;
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < NUM_THREADS; ++i) {
+      threads.emplace_back([&]() {
+        for (int j = 0; j < NUM_ITERATIONS; ++j) {
+          ts::bravo::Token token1{0};
+          ts::bravo::Token token2{0};
+          mutex.lock_shared(token1);
+          mutex.lock_shared(token2); // Recursive
+          ++counter;
+          mutex.unlock_shared(token2);
+          mutex.unlock_shared(token1);
+        }
+      });
+    }
+
+    for (auto &t : threads) {
+      t.join();
+    }
+
+    CHECK(counter == NUM_THREADS * NUM_ITERATIONS);
+  }
+
+  SECTION("concurrent writers with recursive locks")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    int                               counter        = 0;
+    constexpr int                     NUM_THREADS    = 4;
+    constexpr int                     NUM_ITERATIONS = 500;
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < NUM_THREADS; ++i) {
+      threads.emplace_back([&]() {
+        for (int j = 0; j < NUM_ITERATIONS; ++j) {
+          mutex.lock();
+          mutex.lock(); // Recursive
+          ++counter;
+          mutex.unlock();
+          mutex.unlock();
+        }
+      });
+    }
+
+    for (auto &t : threads) {
+      t.join();
+    }
+
+    CHECK(counter == NUM_THREADS * NUM_ITERATIONS);
+  }
+
+  SECTION("mixed readers and writers")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    std::atomic<int>                  read_counter{0};
+    int                               write_counter  = 0;
+    constexpr int                     NUM_READERS    = 6;
+    constexpr int                     NUM_WRITERS    = 2;
+    constexpr int                     NUM_ITERATIONS = 500;
+
+    std::vector<std::thread> threads;
+
+    // Reader threads
+    for (int i = 0; i < NUM_READERS; ++i) {
+      threads.emplace_back([&]() {
+        for (int j = 0; j < NUM_ITERATIONS; ++j) {
+          ts::bravo::Token token{0};
+          mutex.lock_shared(token);
+          ++read_counter;
+          mutex.unlock_shared(token);
+        }
+      });
+    }
+
+    // Writer threads
+    for (int i = 0; i < NUM_WRITERS; ++i) {
+      threads.emplace_back([&]() {
+        for (int j = 0; j < NUM_ITERATIONS; ++j) {
+          mutex.lock();
+          ++write_counter;
+          mutex.unlock();
+        }
+      });
+    }
+
+    for (auto &t : threads) {
+      t.join();
+    }
+
+    CHECK(read_counter == NUM_READERS * NUM_ITERATIONS);
+    CHECK(write_counter == NUM_WRITERS * NUM_ITERATIONS);
+  }
+
+  SECTION("recursive mixed locks under contention")
+  {
+    ts::bravo::recursive_shared_mutex mutex;
+    std::atomic<int>                  counter{0};
+    constexpr int                     NUM_THREADS    = 4;
+    constexpr int                     NUM_ITERATIONS = 200;
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < NUM_THREADS; ++i) {
+      threads.emplace_back([&, i]() {
+        for (int j = 0; j < NUM_ITERATIONS; ++j) {
+          if (i % 2 == 0) {
+            // Even threads: exclusive with downgrade
+            mutex.lock();
+            mutex.lock(); // Recursive exclusive
+            ts::bravo::Token token{0};
+            mutex.lock_shared(token); // Downgrade
+            ++counter;
+            mutex.unlock_shared(token);
+            mutex.unlock();
+            mutex.unlock();
+          } else {
+            // Odd threads: shared recursive
+            ts::bravo::Token token1{0};
+            ts::bravo::Token token2{0};
+            mutex.lock_shared(token1);
+            mutex.lock_shared(token2);
+            ++counter;
+            mutex.unlock_shared(token2);
+            mutex.unlock_shared(token1);
+          }
+        }
+      });
+    }
+
+    for (auto &t : threads) {
+      t.join();
+    }
+
+    CHECK(counter == NUM_THREADS * NUM_ITERATIONS);
+  }
+}

--- a/src/tsutil/unit_tests/test_Bravo.cc
+++ b/src/tsutil/unit_tests/test_Bravo.cc
@@ -24,10 +24,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include "tsutil/Bravo.h"
 
-#include <chrono>
+#include <atomic>
 #include <mutex>
-#include <shared_mutex>
 #include <thread>
+#include <vector>
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
I found that if `OpenDir` has own reader-writer lock, it doesn't need `StripeSM mutex`. This means we can avoid the StripeSM mutex lock contention issue for reader-while-writer cases.

Benchmarking RWW is a bit tricky but one of benchmark says max rps is improved 9.9% in below conditions.

Conditions:
- 10 urls
- plaintext http
- response body size: 256 bytes 
- origin returns `Cache-Control: public, max-age=0` ///< some requests goes RWW path
- 63 exec_thread
- 40 stripes (8 disks x 5 volumes)

Result:
- vanilla: 58,220.9 req/s
- patch: 63,999.7 req/s

part of #12788