### PR TITLE
Restore DbgCtl::_rm_reference() for ABI compatibility

### DIFF
--- a/include/tsutil/DbgCtl.h
+++ b/include/tsutil/DbgCtl.h
@@ -151,6 +151,11 @@ private:
 
   static const _TagData *_new_reference(char const *tag);
 
+  // Deprecated: backward compatibility stub, no-op since we now use leaky singleton.
+  // TODO: This can be removed in 11.x because we don't have to worry about
+  // compatibility there.
+  static void _rm_reference();
+
   class _RegistryAccessor;
 
   static std::atomic<int> _config_mode;

--- a/src/tsutil/DbgCtl.cc
+++ b/src/tsutil/DbgCtl.cc
@@ -170,6 +170,14 @@ DbgCtl::_new_reference(char const *tag)
   return new_tag_data;
 }
 
+// Deprecated: backward compatibility stub for ABI compatibility with plugins
+// compiled against pre-leaky-singleton versions. Does nothing since the
+// registry is now never destroyed.
+void
+DbgCtl::_rm_reference()
+{
+}
+
 void
 DbgCtl::update(const std::function<bool(const char *)> &f)
 {


### PR DESCRIPTION
PR #12777 introduced a leaky singleton pattern for DbgCtl to fix use-after-free crashes during shutdown. However, removing the _rm_reference() method broke ABI compatibility with existing plugins that were compiled against the old header, where the destructor called this method. This commit restores _rm_reference() as a no-op stub, allowing old plugins to load successfully while maintaining the leaky singleton behavior.