### PR TITLE
Fix uninitialized LogConfig member variable

### DIFF
--- a/include/proxy/logging/LogConfig.h
+++ b/include/proxy/logging/LogConfig.h
@@ -163,8 +163,8 @@ public:
   bool    reconfiguration_needed  = false;
   bool    logging_space_exhausted = false;
   int64_t m_space_used            = 0;
-  int64_t m_partition_space_left;
-  bool    roll_log_files_now; // signal that files must be rolled
+  int64_t m_partition_space_left  = static_cast<int64_t>(UINT_MAX);
+  bool    roll_log_files_now      = false; // signal that files must be rolled
 
   LogObjectManager log_object_manager;
 

--- a/src/proxy/logging/LogConfig.cc
+++ b/src/proxy/logging/LogConfig.cc
@@ -252,7 +252,7 @@ LogConfig::read_configuration_variables()
   -------------------------------------------------------------------------*/
 
 // TODO: Is UINT_MAX here really correct?
-LogConfig::LogConfig() : m_partition_space_left(static_cast<int64_t>(UINT_MAX))
+LogConfig::LogConfig()
 {
   // Setup the default values for all LogConfig public variables so that
   // a LogConfig object is valid upon return from the constructor even


### PR DESCRIPTION
Valgrind reported a conditional jump depending on an uninitialized value in Log::periodic_tasks(). The root cause was that roll_log_files_now was not initialized in LogConfig. While we're at it, I'm initializing m_partition_space_left in the member declaration as well.

Fixed by adding default member initializers in the class definition, consistent with the other members.

Valgrind report that reported this:

```
  Thread 30 [LOG_FLUSH]:
  Conditional jump or move depends on uninitialised value(s)
     at 0x68F310: Log::periodic_tasks(long)
     by 0x6901FF: Log::flush_thread_main(void*)
     by 0x695FEC: LoggingFlushContinuation::mainEvent(int, void*)
     by 0x883EA2: EThread::execute()
     by 0x87FD61: spawn_thread_internal(void*)
   Uninitialised value was created by a heap allocation
     at 0x4C2A593: operator new(unsigned long)
     by 0x695440: Log::init(int)
```