### PR TITLE
Fix Valgrind uninitialized memory warnings

### DIFF
--- a/src/iocore/cache/CacheTest.cc
+++ b/src/iocore/cache/CacheTest.cc
@@ -566,6 +566,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
       CryptoHash    hash;
 
       d->alloc(BUFFER_SIZE_INDEX_16K);
+      memset(d->data(), 0, BUFFER_SIZE_FOR_INDEX(BUFFER_SIZE_INDEX_16K));
       data.push_back(make_ptr(d));
       hash.u64[0] = (static_cast<uint64_t>(i) << 32) + i;
       hash.u64[1] = (static_cast<uint64_t>(i) << 32) + i;
@@ -610,6 +611,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
     if (!cache->get(&hash, &get_data)) {
       IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
       d->alloc(BUFFER_SIZE_INDEX_16K);
+      memset(d->data(), 0, d->block_size());
       data.push_back(make_ptr(d));
       cache->put(&hash, data.back().get(), 1 << 15);
       if (i >= sample_size / 2) {
@@ -630,6 +632,7 @@ test_RamCache(RegressionTest *t, RamCache *cache, const char *name, int64_t cach
     if (!cache->get(&hash, &get_data)) {
       IOBufferData *d = THREAD_ALLOC(ioDataAllocator, this_thread());
       d->alloc(BUFFER_SIZE_INDEX_8K + (r[i] % 3));
+      memset(d->data(), 0, d->block_size());
       data.push_back(make_ptr(d));
       cache->put(&hash, data.back().get(), d->block_size());
       if (i >= sample_size / 2) {

--- a/src/proxy/logging/LogBuffer.cc
+++ b/src/proxy/logging/LogBuffer.cc
@@ -126,6 +126,8 @@ LogBuffer::LogBuffer(const LogConfig *cfg, LogObject *owner, size_t size, size_t
   }
   m_buffer = static_cast<char *>(align_pointer_forward(m_unaligned_buffer, buf_align));
 
+  memset(m_buffer, 0, size);
+
   // add the header
   hdr_size = _add_buffer_header(cfg);
 


### PR DESCRIPTION
Valgrind reported some uses of uninitialized memory when running the
regression tests under it. This patch addresses the following valgrind
reported issues:

1. LogBuffer flush:
   Syscall param write(buf) points to uninitialised byte(s)
      at Log::flush_thread_main(void*)
      by LogBuffer::LogBuffer(LogConfig const*, LogObject*, ...)

2. Cache test pwrite:
   Syscall param pwrite64(buf) points to uninitialised byte(s)
      at AIOThreadInfo::aio_thread_main(AIOThreadInfo*)
      by Stripe::Stripe(CacheDisk*, long, long, int, int)