### PR TITLE
header_rewrite fix storage lifetime for LAST-CAPTURE

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1741,12 +1741,11 @@ ConditionLastCapture::append_value(std::string &s, const Resources &res)
 bool
 ConditionLastCapture::eval(const Resources &res)
 {
-  std::string s;
-
-  append_value(s, res);
+  _storage.clear();
+  append_value(_storage, res);
   Dbg(pi_dbg_ctl, "Evaluating LAST-CAPTURE()");
 
-  return static_cast<const MatcherType *>(_matcher.get())->test(s, res);
+  return static_cast<const MatcherType *>(_matcher.get())->test(_storage, res);
 }
 
 static const struct sockaddr *

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1732,8 +1732,8 @@ ConditionLastCapture::set_qualifier(const std::string &q)
 void
 ConditionLastCapture::append_value(std::string &s, const Resources &res)
 {
-  if (res.matches.size() > _ix) {
-    s.append(res.matches[_ix]);
+  if (res.matches().size() > _ix) {
+    s.append(res.matches()[_ix]);
     Dbg(pi_dbg_ctl, "Evaluating LAST-CAPTURE(%d)", _ix);
   }
 }
@@ -1741,11 +1741,12 @@ ConditionLastCapture::append_value(std::string &s, const Resources &res)
 bool
 ConditionLastCapture::eval(const Resources &res)
 {
-  _storage.clear();
-  append_value(_storage, res);
+  std::string s;
+
+  append_value(s, res);
   Dbg(pi_dbg_ctl, "Evaluating LAST-CAPTURE()");
 
-  return static_cast<const MatcherType *>(_matcher.get())->test(_storage, res);
+  return static_cast<const MatcherType *>(_matcher.get())->test(s, res);
 }
 
 static const struct sockaddr *

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -940,5 +940,6 @@ protected:
   bool eval(const Resources &res) override;
 
 private:
-  int _ix = -1;
+  int      _ix = -1;
+  DataType _storage;
 };

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -940,6 +940,5 @@ protected:
   bool eval(const Resources &res) override;
 
 private:
-  int      _ix = -1;
-  DataType _storage;
+  int _ix = -1;
 };

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -364,7 +364,7 @@ private:
     Dbg(pi_dbg_ctl, "Test regular expression against: %s (NOCASE = %s)", t.c_str(),
         has_modifier(_mods, CondModifiers::MOD_NOCASE) ? "true" : "false");
     const auto &re    = std::get<regexHelper>(_data);
-    int         count = re.regexMatch(t, const_cast<Resources &>(res).matches);
+    int         count = res.match(re, t);
 
     if (count > 0) {
       Dbg(pi_dbg_ctl, "Successfully found regular expression match");

--- a/plugins/header_rewrite/resources.h
+++ b/plugins/header_rewrite/resources.h
@@ -86,14 +86,14 @@ public:
     // For last capture to work safely, this has to make a copy of the subject string
     // so the matches results will point into that and avoid any lifetime issues with
     // the passed in `s`
-    _extended_match_info.subject_storage = s;
-    return re.regexMatch(_extended_match_info.subject_storage, _extended_match_info.matches);
+    _extended_info.subject_storage = s;
+    return re.regexMatch(_extended_info.subject_storage, _extended_info.matches);
   }
 
   const RegexMatches &
   matches() const
   {
-    return _extended_match_info.matches;
+    return _extended_info.matches;
   }
 
   TSCont              contp          = nullptr;
@@ -113,12 +113,12 @@ public:
 #endif
   TSHttpStatus resp_status = TS_HTTP_STATUS_NONE;
 
-  struct LastMatchLifetimeExtension {
+  struct LifetimeExtension {
     std::string  subject_storage;
     RegexMatches matches;
   };
-  bool                               changed_url = false;
-  mutable LastMatchLifetimeExtension _extended_match_info;
+  bool                      changed_url = false;
+  mutable LifetimeExtension _extended_info;
 
 private:
   void


### PR DESCRIPTION
There is a bug in LAST-CAPTURE where the stored matches would point into a temporary and cause issues with using the last captured value.

This PR move the storage for the regex subject to be in the Resources object so it can live through the entire hook.