### PR TITLE
hrw4u: Fix uv dependencies

### DIFF
--- a/tools/hrw4u/pyproject.toml
+++ b/tools/hrw4u/pyproject.toml
@@ -77,3 +77,10 @@ markers = [
     "reverse: marks tests for reverse conversion (header_rewrite -> hrw4u)",
     "ast: marks tests for AST validation",
 ]
+
+[dependency-groups]
+dev = [
+    "build>=1.4.0",
+    "pyinstaller>=6.18.0",
+    "pytest>=7.4.4",
+]


### PR DESCRIPTION
With the migration to UV, the hrw4u builds failed.