### PR TITLE
Keep a copy of the effective client ip for logging

### DIFF
--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -713,6 +713,9 @@ public:
     ConnectionAttributes        client_info;
     ConnectionAttributes        parent_info;
     ConnectionAttributes        server_info;
+    // This is a copy of the effective client IP address (see pp-clnt) to
+    // ensure this is available for logging
+    IpEndpoint effective_client_addr;
 
     Source_t            source               = Source_t::NONE;
     Source_t            pre_transform_source = Source_t::NONE;

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -448,6 +448,7 @@ HttpSM::attach_client_session(ProxyTransaction *txn)
 
   ats_ip_copy(&t_state.client_info.src_addr, netvc->get_remote_addr());
   ats_ip_copy(&t_state.client_info.dst_addr, netvc->get_local_addr());
+  ats_ip_copy(&t_state.effective_client_addr, netvc->get_effective_remote_addr());
   t_state.client_info.is_transparent = netvc->get_is_transparent();
   t_state.client_info.port_attribute = static_cast<HttpProxyPort::TransportType>(netvc->attributes);
 

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -1442,16 +1442,7 @@ LogAccess::marshal_plugin_identity_tag(char *buf)
 int
 LogAccess::marshal_client_host_ip(char *buf)
 {
-  if (m_http_sm) {
-    auto txn = m_http_sm->get_ua_txn();
-    if (txn) {
-      sockaddr const *addr = txn->get_client_addr();
-      if (addr && ats_is_ip(addr)) {
-        return marshal_ip(buf, addr);
-      }
-    }
-  }
-  return INK_MIN_ALIGN;
+  return marshal_ip(buf, &m_http_sm->t_state.effective_client_addr.sa);
 }
 
 int


### PR DESCRIPTION
Fixes a bug introduced in #12761:

If the transaction client vc went away before logging, then the update marshal client ip function didn't actually marshal anything and it messed up parsing the log entry later.

This fix is to just keep a copy of the effective IP for logging purposes, per tradition.