### PR TITLE
header_rewrite fix storage lifetime for LAST-CAPTURE (#12809)

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1718,8 +1718,8 @@ ConditionLastCapture::set_qualifier(const std::string &q)
 void
 ConditionLastCapture::append_value(std::string &s, const Resources &res)
 {
-  if (res.matches.size() > _ix) {
-    s.append(res.matches[_ix]);
+  if (res.matches().size() > _ix) {
+    s.append(res.matches()[_ix]);
     Dbg(pi_dbg_ctl, "Evaluating LAST-CAPTURE(%d)", _ix);
   }
 }

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -193,7 +193,7 @@ private:
   test_reg(const std::string &t, const Resources &res) const
   {
     Dbg(pi_dbg_ctl, "Test regular expression %s : %s (NOCASE = %d)", _data.c_str(), t.c_str(), static_cast<int>(_nocase));
-    int count = _reHelper.regexMatch(t, const_cast<Resources &>(res).matches);
+    int count = res.match(_reHelper, t);
 
     if (count > 0) {
       Dbg(pi_dbg_ctl, "Successfully found regular expression match");

--- a/plugins/header_rewrite/resources.h
+++ b/plugins/header_rewrite/resources.h
@@ -23,6 +23,7 @@
 
 #include <string>
 
+#include "regex_helper.h"
 #include "ts/ts.h"
 #include "ts/remap.h"
 
@@ -79,6 +80,22 @@ public:
     return _ready;
   }
 
+  int
+  match(const regexHelper &re, const std::string &s) const
+  {
+    // For last capture to work safely, this has to make a copy of the subject string
+    // so the matches results will point into that and avoid any lifetime issues with
+    // the passed in `s`
+    _extended_info.subject_storage = s;
+    return re.regexMatch(_extended_info.subject_storage, _extended_info.matches);
+  }
+
+  const RegexMatches &
+  matches() const
+  {
+    return _extended_info.matches;
+  }
+
   TSCont              contp          = nullptr;
   TSRemapRequestInfo *_rri           = nullptr;
   TSMBuffer           bufp           = nullptr;
@@ -95,8 +112,13 @@ public:
   TransactionState state; // Without cripts, txnp / ssnp goes here
 #endif
   TSHttpStatus resp_status = TS_HTTP_STATUS_NONE;
-  RegexMatches matches;
-  bool         changed_url = false;
+
+  struct LifetimeExtension {
+    std::string  subject_storage;
+    RegexMatches matches;
+  };
+  bool                      changed_url = false;
+  mutable LifetimeExtension _extended_info;
 
 private:
   void


### PR DESCRIPTION
* Use a class member variable to hold regex match

* Use regex subject storage in Resources

* rename extended struct

(cherry picked from commit 9efc018724def2c1a0e1fe5129bb04c79f53bcf0)