### PR TITLE
Count proxy.process.http.incoming_requests at transaction start

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -451,6 +451,11 @@ HttpSM::attach_client_session(ProxyTransaction *txn)
   t_state.client_info.is_transparent = netvc->get_is_transparent();
   t_state.client_info.port_attribute = static_cast<HttpProxyPort::TransportType>(netvc->attributes);
 
+  Metrics::Counter::increment(http_rsb.incoming_requests);
+  if (t_state.client_info.port_attribute == HttpProxyPort::TRANSPORT_SSL) {
+    Metrics::Counter::increment(http_rsb.https_incoming_requests);
+  }
+
   // Record api hook set state
   hooks_set = txn->has_hooks();
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -1508,12 +1508,6 @@ HttpTransact::HandleRequest(State *s)
   if (!s->state_machine->is_waiting_for_full_body && !s->state_machine->is_buffering_request_body) {
     ink_assert(!s->hdr_info.server_request.valid());
 
-    Metrics::Counter::increment(http_rsb.incoming_requests);
-
-    if (s->client_info.port_attribute == HttpProxyPort::TRANSPORT_SSL) {
-      Metrics::Counter::increment(http_rsb.https_incoming_requests);
-    }
-
     ///////////////////////////////////////////////
     // if request is bad, return error response  //
     ///////////////////////////////////////////////


### PR DESCRIPTION
The proxy.process.http.incoming_requests metric was only incremented in HttpTransact::HandleRequest(), which is called late in the request processing pipeline. Requests that received error or redirect responses before reaching HandleRequest were never counted, causing significant underreporting during high-error-rate scenarios.

This fix moves the increment to HttpSM::attach_client_session(), which is called at the start of every transaction. This ensures all requests are counted, including those that fail header parsing, receive remap redirects, or hit early error conditions. This aligns with the documented behavior that incoming_requests should include errors and redirects (see doc/appendices/command-line/traffic_top.en.rst):

    "Total number of client requests serviced by Traffic Server. This
    includes both successful content-bearing responses as well as
    errors, redirects, and not-modified IMS responses."