### PR TITLE
9.2.x: Make chunk size parsing more strict

### DIFF
--- a/proxy/http/HttpTunnel.cc
+++ b/proxy/http/HttpTunnel.cc
@@ -171,9 +171,10 @@ ChunkedHandler::read_size()
           }
         } else {
           // We are done parsing size
-          if ((num_digits == 0 || running_sum < 0) ||       /* Bogus chunk size */
-              (!ParseRules::is_wslfcr(*tmp) && *tmp != ';') /* Unexpected character */
-          ) {
+          const auto is_bogus_chunk_size   = (num_digits == 0 || running_sum < 0);
+          const auto is_rfc_compliant_char = (ParseRules::is_ws(*tmp) || ParseRules::is_cr(*tmp) || *tmp == ';');
+          const auto is_acceptable_lf      = (ParseRules::is_lf(*tmp) && !strict_chunk_parsing);
+          if (is_bogus_chunk_size || (!is_rfc_compliant_char && !is_acceptable_lf)) {
             state = CHUNK_READ_ERROR;
             done  = true;
             break;

--- a/tests/gold_tests/chunked_encoding/replays/malformed_chunked_header.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/malformed_chunked_header.replay.yaml
@@ -237,3 +237,49 @@ sessions:
         encoding: uri
         # Chunk header must end with a sequence of CRLF.
         data: 3;x%0Adef%0D%0A0%0D%0A%0D%0A
+
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /response/malformed/chunk/size2
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 106 ]
+
+    # The connection will be dropped and this response will not go out.
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+      content:
+        transfer: plain
+        encoding: uri
+        # Chunk header must end with a sequence of CRLF.
+        data: 3%0Ddef%0D%0A0%0D%0A%0D%0A
+
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /response/malformed/chunk/size2
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 107 ]
+
+    # The connection will be dropped and this response will not go out.
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+      content:
+        transfer: plain
+        encoding: uri
+        # Chunk header must end with a sequence of CRLF.
+        data: 3%0Adef%0D%0A0%0D%0A%0D%0A


### PR DESCRIPTION
## Summary
- Cherry-pick of #12187 to 9.2.x branch
- Fixes cases where invalid chunked requests were forwarded to origin even with `proxy.config.http.strict_chunk_parsing` set to 1
- Makes ChunkedHandler::read_size() properly detect invalid chunked bodies (e.g., missing CR before LF in chunk size line)

## Test plan
- Build verified successfully
- Original PR was tested and merged to master
- Includes test case for malformed chunked header