### PR TITLE
[compress] Fix compressible-status-code config (#12116)

### DIFF
--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -248,6 +248,8 @@ HostConfiguration::add_compression_algorithms(string &line)
 void
 HostConfiguration::add_compressible_status_codes(string &line)
 {
+  compressible_status_codes_.clear();
+
   for (;;) {
     string token = extractFirstToken(line, isCommaOrSpace);
     if (token.empty()) {


### PR DESCRIPTION
Backport https://github.com/apache/trafficserver/pull/12116 to the 9.2.x branch.