### PR TITLE
Add cache stripe lock contention metric

### DIFF
--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -1151,6 +1151,7 @@ register_cache_stats(CacheStatsBlock *rsb, const std::string &prefix)
   rsb->span_offline           = ts::Metrics::Gauge::createPtr(prefix + ".span.offline");
   rsb->span_online            = ts::Metrics::Gauge::createPtr(prefix + ".span.online");
   rsb->stripe_lock_contention = ts::Metrics::Counter::createPtr(prefix + ".stripe.lock_contention");
+  rsb->writer_lock_contention = ts::Metrics::Counter::createPtr(prefix + ".writer.lock_contention");
 }
 
 void

--- a/src/iocore/cache/CacheRead.cc
+++ b/src/iocore/cache/CacheRead.cc
@@ -275,7 +275,7 @@ CacheVC::openReadFromWriter(int event, Event *e)
   CACHE_TRY_LOCK(writer_lock, write_vc->mutex, mutex->thread_holding);
   if (!writer_lock.is_locked()) {
     DDbg(dbg_ctl_cache_read_agg, "%p: key: %X lock miss", this, first_key.slice32(1));
-    VC_SCHED_LOCK_RETRY_NO_METRIC(); // Not stripe->mutex, don't count as stripe contention
+    VC_SCHED_WRITER_LOCK_RETRY();
   }
   MUTEX_RELEASE(lock);
 

--- a/src/iocore/cache/P_CacheInternal.h
+++ b/src/iocore/cache/P_CacheInternal.h
@@ -79,9 +79,10 @@ struct EvacuationBlock;
     return EVENT_CONT;                                                                                         \
   } while (0)
 
-// Variant without metric increment for non-stripe lock retries (e.g., write_vc->mutex)
-#define VC_SCHED_LOCK_RETRY_NO_METRIC()                                                                        \
+// Variant for writer lock contention (write_vc->mutex during read aggregation)
+#define VC_SCHED_WRITER_LOCK_RETRY()                                                                           \
   do {                                                                                                         \
+    ts::Metrics::Counter::increment(cache_rsb.writer_lock_contention);                                         \
     trigger = mutex->thread_holding->schedule_in_local(this, HRTIME_MSECONDS(cache_config_mutex_retry_delay)); \
     return EVENT_CONT;                                                                                         \
   } while (0)

--- a/src/iocore/cache/P_CacheStats.h
+++ b/src/iocore/cache/P_CacheStats.h
@@ -73,4 +73,5 @@ struct CacheStatsBlock {
   ts::Metrics::Gauge::AtomicType   *span_online            = nullptr;
   ts::Metrics::Gauge::AtomicType   *span_failing           = nullptr;
   ts::Metrics::Counter::AtomicType *stripe_lock_contention = nullptr;
+  ts::Metrics::Counter::AtomicType *writer_lock_contention = nullptr;
 };


### PR DESCRIPTION
## Summary

Adds two new metrics to track cache lock contention:

1. **`proxy.process.cache.stripe.lock_contention`** - counts stripe mutex contention
2. **`proxy.process.cache.writer.lock_contention`** - counts writer VC mutex contention during read aggregation

Also available per-volume as `proxy.process.cache.volume_N.stripe.lock_contention`.

## Background

When ATS is configured with more threads than cache volumes, threads contend heavily for the stripe mutex, causing throughput degradation. These metrics make contention visible so operators can tune their configuration.

## Benchmark Results

Testing on a 16-core system with 100 cached URLs:

| Threads | Volumes | Throughput | Contentions/s |
|---------|---------|------------|---------------|
| 16 | 1 | 476k req/s | 12,095k |
| 16 | 16 | 1,160k req/s | 177k |
| 24 | 32 | 1,260k req/s | 161k |

With only 1 volume, 16 threads is **slower** than 4 threads due to contention. Adding volumes eliminates the bottleneck.

## Usage

```bash
# Stripe lock contention (global)
traffic_ctl metric get proxy.process.cache.stripe.lock_contention

# Stripe lock contention (per-volume)
traffic_ctl metric match volume.*stripe.lock_contention

# Writer lock contention
traffic_ctl metric get proxy.process.cache.writer.lock_contention
```

## Implementation

### Stripe Lock Contention Call Sites (`VC_SCHED_LOCK_RETRY` / `VC_LOCK_RETRY_EVENT`)

All for `stripe->mutex`:

**CacheRead.cc:**
- [L210](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L210) - openReadClose
- [L428](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L428) - openReadReadDone
- [L456](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L456) - openReadReadDone
- [L653](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L653) - openReadMain
- [L705](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L705) - openReadMain
- [L766](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L766) - openReadStartEarliest
- [L932](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L932) - openReadVecWrite
- [L988](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L988) - openReadStartHead
- [L1210](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L1210) - openReadDirDelete

**CacheVC.cc:**
- [L355](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheVC.cc#L355) - openReadClose
- [L553](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheVC.cc#L553) - die
- [L938](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheVC.cc#L938) - scanOpenWrite

**CacheWrite.cc:**
- [L78](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L78) - handleWriteLock
- [L84](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L84) - handleWriteLock
- [L278](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L278) - openWriteCloseDir
- [L331](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L331) - openWriteCloseHeadDone
- [L410](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L410) - openWriteCloseDataDone
- [L504](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L504) - openWriteWriteDone
- [L648](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L648) - openWriteOverwrite
- [L681](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L681) - openWriteOverwrite
- [L794](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheWrite.cc#L794) - openWriteMain

### Writer Lock Contention Call Site (`VC_SCHED_WRITER_LOCK_RETRY`)

For `write_vc->mutex` (not stripe):

**CacheRead.cc:**
- [L278](https://github.com/bryancall/trafficserver/blob/f488fe83b8b0109f41da5778628703b5d4b87924/src/iocore/cache/CacheRead.cc#L278) - openReadFromWriter (read aggregation)

## Files Changed

- `P_CacheStats.h`: Add `stripe_lock_contention` and `writer_lock_contention` counters
- `CacheProcessor.cc`: Register both metrics
- `P_CacheInternal.h`: Add metric increments to retry macros, add `VC_SCHED_WRITER_LOCK_RETRY()`
- `CacheRead.cc`: Use `VC_SCHED_WRITER_LOCK_RETRY()` for writer mutex case