### PR TITLE
Coverity Fixes

### DIFF
--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -293,7 +293,7 @@ ConditionUrl::set_qualifier(const std::string &q)
 
     if (_url_qual == URL_QUAL_QUERY) {
       if (!sub_qual.empty()) {
-        _query_param = sub_qual;
+        _query_param = std::move(sub_qual);
         Dbg(pi_dbg_ctl, "\tQuery parameter sub-key: %s", _query_param.c_str());
       }
     } else {

--- a/src/iocore/aio/test_AIO.cc
+++ b/src/iocore/aio/test_AIO.cc
@@ -456,10 +456,10 @@ public:
 
 #endif
 
+// coverity[exn_spec_violation] - called functions may throw but this is a test program
 int
 main(int argc, char *argv[])
 {
-  // coverity[fun_call_w_exception] - called functions may throw but this is a test program
   int i;
 
   // Read the configuration file

--- a/src/iocore/cache/Stripe.cc
+++ b/src/iocore/cache/Stripe.cc
@@ -170,10 +170,10 @@ Stripe::_init_directory(std::size_t directory_size, int header_size, int footer_
   this->directory.footer = reinterpret_cast<StripeHeaderFooter *>(this->directory.raw_dir + footer_offset);
 }
 
+// coverity[exn_spec_violation] - ink_assert aborts (doesn't throw), Dbg is exception-safe
 Stripe::~Stripe()
 {
   if (this->directory.raw_dir != nullptr) {
-    // coverity[fun_call_w_exception] - ink_assert aborts (doesn't throw), Dbg is exception-safe
     // Debug logging to track cleanup - helps correlate with crash location
     Dbg(dbg_ctl_cache_free, "Stripe %s: freeing raw_dir=%p size=%zu huge=%s", hash_text.get() ? hash_text.get() : "(null)",
         this->directory.raw_dir, this->directory.raw_dir_size, this->directory.raw_dir_huge ? "true" : "false");

--- a/src/proxy/hdrs/unit_tests/test_HeaderValidator.cc
+++ b/src/proxy/hdrs/unit_tests/test_HeaderValidator.cc
@@ -56,8 +56,6 @@ TEST_CASE("testIsHeaderValid", "[proxy][hdrtest]")
 {
   HTTPHdr hdr;
   // extra to prevent proxy allocation.
-  // coverity[resource_leak] - heap is freed via hdr.destroy() which calls
-  // HdrHeapSDKHandle::destroy() -> m_heap->destroy()
   HdrHeap *heap = new_HdrHeap(HdrHeap::DEFAULT_SIZE + 64);
 
   SECTION("Test (valid) request with 4 required pseudo headers")
@@ -249,4 +247,6 @@ TEST_CASE("testIsHeaderValid", "[proxy][hdrtest]")
   }
   // teardown
   hdr.destroy();
+  // coverity[leaked_storage] - heap is freed via hdr.destroy() which calls
+  // HdrHeapSDKHandle::destroy() -> m_heap->destroy()
 }


### PR DESCRIPTION
Fix one new Coverity issue and attempt to fix 3 of the previous suppressions that were not recognized by the last Coverity run.