### PR TITLE
Fix HostDBInfo::is_down condition

### DIFF
--- a/include/iocore/hostdb/HostDBProcessor.h
+++ b/include/iocore/hostdb/HostDBProcessor.h
@@ -230,7 +230,7 @@ HostDBInfo::is_alive()
 }
 
 /**
-  Check if this HostDBInfo is currently marked down (true) or not (false). Returns true while within the `fail_window` period after
+  Check if this HostDBInfo is currently marked DOWN (true) or UP (false). Returns true while within the `fail_window` period after
   `last_failure`. Once `fail_window` expires, the host is treated as UP and this function returns false.
 
                     |<-- fail_window -->|
@@ -240,7 +240,7 @@ HostDBInfo::is_alive()
                     |                   |
                     ^                   ^
                      \                   \
-                    last_failure        last_failure + fail_window
+                      last_failure        last_failure + fail_window
  */
 inline bool
 HostDBInfo::is_down(ts_time now, ts_seconds fail_window)


### PR DESCRIPTION
The condition of `HostDBInfo::is_down` seems opposite.

This function is only used by `HostDBRecord::select_best_srv()` , so only SRV record case is affected.

https://github.com/apache/trafficserver/blob/2a30bccc413c7a4abfcc2a410386a3469273ae55/src/iocore/hostdb/HostDB.cc#L1609-L1611