### PR TITLE
Fix header_rewrite run-plugin relative path resolution

### DIFF
--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -704,14 +704,17 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     }
   }
 
-  if (!geoDBpath.empty()) {
-    if (!geoDBpath.starts_with('/')) {
-      geoDBpath = std::string(TSConfigDirGet()) + '/' + geoDBpath;
-    }
-
-    Dbg(pi_dbg_ctl, "Remap geo db %s", geoDBpath.c_str());
-    std::call_once(initHRWLibs, [&geoDBpath]() { initHRWLibraries(geoDBpath); });
+  if (!geoDBpath.empty() && !geoDBpath.starts_with('/')) {
+    geoDBpath = std::string(TSConfigDirGet()) + '/' + geoDBpath;
   }
+
+  if (!geoDBpath.empty()) {
+    Dbg(pi_dbg_ctl, "Remap geo db %s", geoDBpath.c_str());
+  }
+
+  // Always initialize the plugin factory, even if no geo DB is specified. This
+  // is needed for run-plugin to work with relative paths.
+  std::call_once(initHRWLibs, [&geoDBpath]() { initHRWLibraries(geoDBpath); });
 
   auto *conf = new RulesConfig(timezone, inboundIpSource);
 

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
@@ -145,7 +145,23 @@ autest:
             args:
               - "rules/query_sub_key.conf"
 
+      # Test run-plugin with a relative plugin path. This verifies that the
+      # plugin factory is properly initialized when header_rewrite is used as a
+      # remap plugin without a geo database.
+      - from: "http://www.example.com/from_14/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/to_14/"
+        plugins:
+          - name: "header_rewrite.so"
+            args:
+              - "rules/run_plugin.conf"
 
+    log_validation:
+      traffic_out:
+        excludes:
+          - expression: "failed to find plugin"
+            description: "Should not fail to find plugin with relative path"
+          - expression: "Unable to load plugin"
+            description: "Should not fail to load plugin"
 
 # Proxy verifier sessions
 sessions:
@@ -1074,3 +1090,27 @@ sessions:
       headers:
         fields:
         - [ X-Query-Sub, { as: absent } ]
+
+# Test 30: run-plugin with relative path
+# This test verifies that the plugin factory is properly initialized when
+# header_rewrite is used as a remap plugin without a geo database. If the fix
+# is not applied, run-plugin with a relative path would fail to find the plugin.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /from_14/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, 36 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/run_plugin.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/run_plugin.conf
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test run-plugin operator with a relative plugin path.
+# This verifies that the plugin factory is properly initialized when
+# header_rewrite is used as a remap plugin without a geo database.
+# We use multiplexer.so because with no arguments it creates an empty
+# instance and just returns TSREMAP_NO_REMAP, allowing the request to
+# proceed normally to the backend.
+cond %{REMAP_PSEUDO_HOOK}
+  run-plugin multiplexer.so


### PR DESCRIPTION
This will need the #12854 PluginFactory fix before this test passes.

---

The plugin factory was not initialized when header_rewrite was used only as a remap plugin without a geo database. This caused run-plugin with relative paths to fail because there were no search directories configured. Now initHRWLibraries() is always called in TSRemapNewInstance().

Added a test to the header_rewrite bundle to verify run-plugin works with relative paths in remap mode.