### PR TITLE
Fix autest compatibility with Fedora 43 / Python 3.14

### DIFF
--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -16,6 +16,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
 import subprocess
 import json
 import re
@@ -49,6 +50,28 @@ def IsOpenSSL(self):
         # OpenSSL 1.1.1k  25 Mar 2021
         lambda: "OpenSSL" in openssl_str and "compatible; BoringSSL" not in openssl_str,
         "SSL library is not OpenSSL")
+
+
+def HasLegacyTLSSupport(self):
+    """Check if the system supports legacy TLS protocols (TLSv1.0 and TLSv1.1).
+
+    Modern OpenSSL 3.x installations often disable these protocols entirely.
+    This condition checks if curl can use the --tlsv1 flag, which indicates
+    TLSv1.0 support is available.
+    """
+    def check_tls1_support():
+        try:
+            # Check if openssl supports TLSv1
+            result = subprocess.run(
+                ['openssl', 'ciphers', '-v', '-tls1'],
+                capture_output=True, text=True
+            )
+            # If the command succeeds and returns ciphers, TLSv1 is supported
+            return result.returncode == 0 and len(result.stdout.strip()) > 0
+        except Exception:
+            return False
+
+    return self.Condition(check_tls1_support, "System does not support legacy TLS protocols (TLSv1.0/TLSv1.1)")
 
 
 def HasCurlVersion(self, version):
@@ -118,6 +141,7 @@ ExtendCondition(HasOpenSSLVersion)
 ExtendCondition(HasProxyVerifierVersion)
 ExtendCondition(IsBoringSSL)
 ExtendCondition(IsOpenSSL)
+ExtendCondition(HasLegacyTLSSupport)
 ExtendCondition(HasATSFeature)
 ExtendCondition(HasCurlVersion)
 ExtendCondition(HasCurlFeature)

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -66,6 +66,7 @@ def HasLegacyTLSSupport(self):
     This check attempts to create an actual TLSv1 connection to a known HTTPS
     server to detect if the protocol is truly available at runtime.
     """
+
     def check_tls1_support():
         try:
             # Try to actually use TLSv1 against a real HTTPS server
@@ -73,7 +74,9 @@ def HasLegacyTLSSupport(self):
             # We use a well-known server that's likely to be reachable
             result = subprocess.run(
                 ['openssl', 's_client', '-tls1', '-connect', 'www.google.com:443'],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
                 input=''  # Don't wait for input
             )
             # Combine stdout and stderr for checking

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -63,33 +63,39 @@ def HasLegacyTLSSupport(self):
     causes 'openssl ciphers -v -tls1' to still list TLSv1 ciphers, but actual
     TLS 1.0 connections will fail with "no protocols available".
 
-    This check attempts to create an actual TLSv1 connection to a known HTTPS
-    server to detect if the protocol is truly available at runtime.
+    We only probe TLSv1.0 (not TLSv1.1 separately) because crypto-policies
+    always disable both legacy versions together. If TLSv1.0 is unavailable,
+    TLSv1.1 will be too.
+
+    The check connects to localhost on a closed port to avoid any external
+    network dependency. A "connection refused" error means the TLS protocol
+    was available but nothing was listening; "no protocols available" means
+    the crypto-policy blocked TLSv1.0 entirely.
     """
 
     def check_tls1_support():
         try:
-            # Try to actually use TLSv1 against a real HTTPS server
-            # This catches crypto-policy restrictions that aren't visible in cipher listings
-            # We use a well-known server that's likely to be reachable
+            # Connect to localhost on a port nothing is listening on.
+            # This avoids external network dependency while still detecting
+            # whether the crypto-policy allows TLSv1.0.
             result = subprocess.run(
-                ['openssl', 's_client', '-tls1', '-connect', 'www.google.com:443'],
+                ['openssl', 's_client', '-tls1', '-connect', '127.0.0.1:1'],
                 capture_output=True,
                 text=True,
-                timeout=10,
-                input=''  # Don't wait for input
+                timeout=5,
+                input=''  # Don't wait for interactive input
             )
-            # Combine stdout and stderr for checking
             output = result.stdout + result.stderr
-            # If we get "no protocols available", TLSv1 is disabled by policy
+            # "no protocols available" means TLSv1 is disabled by crypto-policy
             if 'no protocols available' in output:
                 return False
-            # If we get a successful connection or a server-side TLS version mismatch,
-            # it means TLSv1 is enabled on this client
+            # Connection refused or other errors mean TLSv1 was attempted
+            # (the protocol is available, just no server listening)
             return True
         except subprocess.TimeoutExpired:
-            # If network is slow but TLSv1 was attempted, assume it's available
-            return True
+            # Timeout on localhost shouldn't happen, but if it does,
+            # assume TLSv1 is not available (safer than false positive)
+            return False
         except Exception:
             # If we can't determine, assume TLSv1 is not available (safer)
             return False

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -56,35 +56,31 @@ def HasLegacyTLSSupport(self):
     """Check if the system supports legacy TLS protocols (TLSv1.0 and TLSv1.1).
 
     Modern OpenSSL 3.x installations often disable these protocols entirely,
-    even if the openssl binary still accepts the -tls1 flag. This condition
-    checks if actual TLSv1.0 ciphers are available (not just TLSv1.2/TLSv1.3
-    ciphers returned when using the -tls1 flag).
+    even if the openssl binary still accepts the -tls1 flag and lists TLSv1 ciphers.
 
     On Fedora/RHEL systems, the crypto-policies framework may disable legacy
-    TLS even when OpenSSL is compiled with support for it.
+    TLS at runtime even when OpenSSL is compiled with support for it. This
+    causes 'openssl ciphers -v -tls1' to still list TLSv1 ciphers, but actual
+    TLS 1.0 connections will fail with "no protocols available".
+
+    This check attempts to create an actual TLSv1 connection to detect if
+    the protocol is truly available, not just listed.
     """
     def check_tls1_support():
         try:
-            # Check if openssl has actual TLSv1.0 ciphers available
-            # When TLSv1.0 is disabled by crypto-policy, 'openssl ciphers -v -tls1'
-            # will still return ciphers, but they'll be TLSv1.2/TLSv1.3 ciphers
+            # Try to actually use TLSv1 - this catches crypto-policy restrictions
+            # that aren't visible in cipher listings
             result = subprocess.run(
-                ['openssl', 'ciphers', '-v', '-tls1'],
-                capture_output=True, text=True
+                ['openssl', 's_client', '-tls1', '-connect', 'localhost:1'],
+                capture_output=True, text=True, timeout=5
             )
-            if result.returncode != 0:
+            # If we get "no protocols available", TLSv1 is disabled by policy
+            if 'no protocols available' in result.stderr:
                 return False
-
-            # Check if any cipher is specifically TLSv1 (not TLSv1.2 or TLSv1.3)
-            # TLSv1.0 ciphers show as "SSLv3" or "TLSv1" in the version column
-            for line in result.stdout.strip().split('\n'):
-                parts = line.split()
-                if len(parts) >= 2:
-                    # The second column is the protocol version
-                    version = parts[1]
-                    if version in ('SSLv3', 'TLSv1'):
-                        return True
-            return False
+            # Connection refused is fine - we're just testing if TLSv1 is allowed
+            return True
+        except subprocess.TimeoutExpired:
+            return True  # Timeout means TLSv1 was at least attempted
         except Exception:
             return False
 

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -55,19 +55,36 @@ def IsOpenSSL(self):
 def HasLegacyTLSSupport(self):
     """Check if the system supports legacy TLS protocols (TLSv1.0 and TLSv1.1).
 
-    Modern OpenSSL 3.x installations often disable these protocols entirely.
-    This condition checks if curl can use the --tlsv1 flag, which indicates
-    TLSv1.0 support is available.
+    Modern OpenSSL 3.x installations often disable these protocols entirely,
+    even if the openssl binary still accepts the -tls1 flag. This condition
+    checks if actual TLSv1.0 ciphers are available (not just TLSv1.2/TLSv1.3
+    ciphers returned when using the -tls1 flag).
+
+    On Fedora/RHEL systems, the crypto-policies framework may disable legacy
+    TLS even when OpenSSL is compiled with support for it.
     """
     def check_tls1_support():
         try:
-            # Check if openssl supports TLSv1
+            # Check if openssl has actual TLSv1.0 ciphers available
+            # When TLSv1.0 is disabled by crypto-policy, 'openssl ciphers -v -tls1'
+            # will still return ciphers, but they'll be TLSv1.2/TLSv1.3 ciphers
             result = subprocess.run(
                 ['openssl', 'ciphers', '-v', '-tls1'],
                 capture_output=True, text=True
             )
-            # If the command succeeds and returns ciphers, TLSv1 is supported
-            return result.returncode == 0 and len(result.stdout.strip()) > 0
+            if result.returncode != 0:
+                return False
+
+            # Check if any cipher is specifically TLSv1 (not TLSv1.2 or TLSv1.3)
+            # TLSv1.0 ciphers show as "SSLv3" or "TLSv1" in the version column
+            for line in result.stdout.strip().split('\n'):
+                parts = line.split()
+                if len(parts) >= 2:
+                    # The second column is the protocol version
+                    version = parts[1]
+                    if version in ('SSLv3', 'TLSv1'):
+                        return True
+            return False
         except Exception:
             return False
 

--- a/tests/gold_tests/autest-site/conditions.test.ext
+++ b/tests/gold_tests/autest-site/conditions.test.ext
@@ -63,25 +63,32 @@ def HasLegacyTLSSupport(self):
     causes 'openssl ciphers -v -tls1' to still list TLSv1 ciphers, but actual
     TLS 1.0 connections will fail with "no protocols available".
 
-    This check attempts to create an actual TLSv1 connection to detect if
-    the protocol is truly available, not just listed.
+    This check attempts to create an actual TLSv1 connection to a known HTTPS
+    server to detect if the protocol is truly available at runtime.
     """
     def check_tls1_support():
         try:
-            # Try to actually use TLSv1 - this catches crypto-policy restrictions
-            # that aren't visible in cipher listings
+            # Try to actually use TLSv1 against a real HTTPS server
+            # This catches crypto-policy restrictions that aren't visible in cipher listings
+            # We use a well-known server that's likely to be reachable
             result = subprocess.run(
-                ['openssl', 's_client', '-tls1', '-connect', 'localhost:1'],
-                capture_output=True, text=True, timeout=5
+                ['openssl', 's_client', '-tls1', '-connect', 'www.google.com:443'],
+                capture_output=True, text=True, timeout=10,
+                input=''  # Don't wait for input
             )
+            # Combine stdout and stderr for checking
+            output = result.stdout + result.stderr
             # If we get "no protocols available", TLSv1 is disabled by policy
-            if 'no protocols available' in result.stderr:
+            if 'no protocols available' in output:
                 return False
-            # Connection refused is fine - we're just testing if TLSv1 is allowed
+            # If we get a successful connection or a server-side TLS version mismatch,
+            # it means TLSv1 is enabled on this client
             return True
         except subprocess.TimeoutExpired:
-            return True  # Timeout means TLSv1 was at least attempted
+            # If network is slow but TLSv1 was attempted, assume it's available
+            return True
         except Exception:
+            # If we can't determine, assume TLSv1 is not available (safer)
             return False
 
     return self.Condition(check_tls1_support, "System does not support legacy TLS protocols (TLSv1.0/TLSv1.1)")

--- a/tests/gold_tests/autest-site/microserver.test.ext
+++ b/tests/gold_tests/autest-site/microserver.test.ext
@@ -17,6 +17,7 @@
 #  limitations under the License.
 
 import json
+import os
 import socket
 import ssl
 
@@ -109,7 +110,7 @@ def addSessionFromFiles(self, session_dir):
 # make headers with the key and values provided
 def makeHeader(self, requestString, **kwargs):
     headerStr = requestString + '\r\n'
-    for k, v in kwargs.iteritems():
+    for k, v in kwargs.items():
         headerStr += k + ': ' + v + '\r\n'
     headerStr = headerStr + '\r\n'
     return headerStr
@@ -142,14 +143,20 @@ def uServerUpAndRunning(serverHost, port, isSsl, isIPv6, request, clientcert='',
 
     sock.sendall(request.encode())
     decoded_output = ''
-    while True:
-        host.WriteDebug("??")
-        output = sock.recv(4096)  # suggested bufsize from docs.python.org
-        host.WriteDebug("!!")
-        if len(output) <= 0:
-            break
-        else:
-            decoded_output += output.decode()
+    sock.settimeout(10.0)  # 10 second timeout for recv
+    try:
+        while True:
+            host.WriteDebug("??")
+            output = sock.recv(4096)  # suggested bufsize from docs.python.org
+            host.WriteDebug("!!")
+            if len(output) <= 0:
+                break
+            else:
+                decoded_output += output.decode('utf-8', errors='replace')
+    except socket.timeout:
+        host.WriteDebug(['uServerUpAndRunning', 'when'], "Socket timeout waiting for response")
+        sock.close()
+        return False
     sock.close()
     sock = None
 

--- a/tests/gold_tests/autest-site/ports.py
+++ b/tests/gold_tests/autest-site/ports.py
@@ -74,7 +74,7 @@ def PortOpen(port: int, address: str = None, listening_ports: Set[int] = None) -
         host.WriteDebug(
             'PortOpen', f"Connection to port {port} succeeded, the port is open, "
             "and a future connection cannot use it")
-    except socket.error:
+    except OSError:
         host.WriteDebug(
             'PortOpen', f"socket error for port {port}, port is closed, "
             "and therefore a future connection can use it")

--- a/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.cc
+++ b/tests/gold_tests/pluginTest/polite_hook_wait/polite_hook_wait.cc
@@ -202,8 +202,9 @@ Blocking_action::_thread_func(void *vba)
   ba->_cont_mutex_locked.store(true, std::memory_order_release);
 
   // This is a stand-in for some blocking call to validate the HTTP request in some way.
+  // Use a longer delay to account for slower systems and variable scheduling latency.
   //
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   // Pass "validation" for first transaction, fail it for second.
   //

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -24,7 +24,7 @@ Test TLS protocol offering  based on SNI
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
 Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
-Test.SkipUnless(Condition.HasLegacyTLSSupport(), "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems")
+Test.SkipUnless(Condition.HasLegacyTLSSupport())
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -24,10 +24,7 @@ Test TLS protocol offering  based on SNI
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
 Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
-Test.SkipUnless(
-    Condition.HasLegacyTLSSupport(),
-    "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems"
-)
+Test.SkipUnless(Condition.HasLegacyTLSSupport(), "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems")
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/tls/tls_client_versions.test.py
+++ b/tests/gold_tests/tls/tls_client_versions.test.py
@@ -24,6 +24,10 @@ Test TLS protocol offering  based on SNI
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
 Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
+Test.SkipUnless(
+    Condition.HasLegacyTLSSupport(),
+    "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems"
+)
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/tls/tls_client_versions_minmax.test.py
+++ b/tests/gold_tests/tls/tls_client_versions_minmax.test.py
@@ -24,7 +24,7 @@ Test TLS protocol offering  based on SNI
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
 Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
-Test.SkipUnless(Condition.HasLegacyTLSSupport(), "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems")
+Test.SkipUnless(Condition.HasLegacyTLSSupport())
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/tls/tls_client_versions_minmax.test.py
+++ b/tests/gold_tests/tls/tls_client_versions_minmax.test.py
@@ -24,10 +24,7 @@ Test TLS protocol offering  based on SNI
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
 Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
-Test.SkipUnless(
-    Condition.HasLegacyTLSSupport(),
-    "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems"
-)
+Test.SkipUnless(Condition.HasLegacyTLSSupport(), "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems")
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/tls/tls_client_versions_minmax.test.py
+++ b/tests/gold_tests/tls/tls_client_versions_minmax.test.py
@@ -24,6 +24,10 @@ Test TLS protocol offering  based on SNI
 # for special domain foo.com only offer TLSv1 and TLSv1_1
 
 Test.SkipUnless(Condition.HasOpenSSLVersion("1.1.1"))
+Test.SkipUnless(
+    Condition.HasLegacyTLSSupport(),
+    "This test requires TLSv1.0/TLSv1.1 support which is disabled on modern systems"
+)
 
 # Define default ATS
 ts = Test.MakeATSProcess("ts", enable_tls=True)


### PR DESCRIPTION
## Summary

This PR fixes multiple autest compatibility issues that cause test failures on modern systems like Fedora 43 with Python 3.14 and OpenSSL 3.x.

### Python 3.14 Compatibility Fixes
- Fix `kwargs.iteritems()` → `kwargs.items()` in `microserver.test.ext`
- Add missing `os` import in `microserver.test.ext` and `conditions.test.ext`
- Add explicit UTF-8 encoding to socket `decode()` calls
- Replace deprecated `socket.error` with `OSError` in `ports.py`
- Add socket timeout to prevent `recv()` from hanging indefinitely

### TLS Protocol Deprecation Fixes
- Add `HasLegacyTLSSupport()` condition to detect TLSv1.0/TLSv1.1 support
- Skip `tls_client_versions` tests on systems without legacy TLS support
- Modern OpenSSL 3.x + Fedora crypto-policies disable TLSv1.0/TLSv1.1 by default
- Detection uses actual TLS connection test to handle crypto-policy restrictions

### Timing Improvements
- Increase sleep duration in `polite_hook_wait.cc` from 200ms to 500ms to account for variable scheduling latency

## Test Plan

Tested on:
- Fedora 43 (Server Edition)
- Python 3.14.2
- GCC 15.2.1
- OpenSSL 3.x with DEFAULT crypto-policy

Results:
- TLS client_versions tests now properly skip instead of failing
- Core autest functionality works correctly
- No regressions observed