### PR TITLE
Add HOSTNAME option to traffic_ctl hostdb status

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -683,11 +683,13 @@ traffic_ctl hostdb
 ------------------
 .. program:: traffic_ctl hostdb
 
-.. option:: status
+.. option:: status [HOSTNAME]
 
    :ref:`admin_lookup_records`
 
    Get the current status of HostDB.
+
+   If ``HOSTNAME`` is specified, the output is filtered to show only records whose names contain the given string.
 
 traffic_ctl rpc
 ---------------

--- a/src/mgmt/rpc/handlers/hostdb/HostDB.cc
+++ b/src/mgmt/rpc/handlers/hostdb/HostDB.cc
@@ -24,15 +24,21 @@
 #include "iocore/hostdb/HostDBProcessor.h"
 #include "../src/iocore/hostdb/P_HostDBProcessor.h"
 #include "swoc/MemSpan.h"
+#include "swoc/TextView.h"
 #include "tsutil/TsSharedMutex.h"
 #include "yaml-cpp/node/node.h"
 #include <shared_mutex>
 #include <string>
+#include <string_view>
 
 namespace
 {
 DbgCtl dbg_ctl_rpc_server{"rpc.server"};
 DbgCtl dbg_ctl_rpc_handler_server{"rpc.handler.hostdb"};
+
+struct HostDBGetStatusCmdInfo {
+  std::string hostname;
+};
 
 constexpr std::string_view
 str(HostDBType type)
@@ -74,7 +80,7 @@ namespace YAML
 {
 template <> struct convert<HostDBCache> {
   static Node
-  encode(const HostDBCache *const hostDB)
+  encode(const HostDBCache *const hostDB, std::string_view hostname)
   {
     Node partitions;
     for (size_t i = 0; i < hostDB->refcountcache->partition_count(); i++) {
@@ -96,6 +102,9 @@ template <> struct convert<HostDBCache> {
 
       for (RefCountCacheHashEntry *entry : partition_entries) {
         HostDBRecord *record = static_cast<HostDBRecord *>(entry->item.get());
+        if (!hostname.empty() && record->name_view().find(hostname) == std::string_view::npos) {
+          continue;
+        }
         partition_node["records"].push_back(*record);
       }
 
@@ -157,6 +166,20 @@ template <> struct convert<HostDBRecord> {
     return node;
   }
 };
+
+template <> struct convert<HostDBGetStatusCmdInfo> {
+  static bool
+  decode(const Node &node, HostDBGetStatusCmdInfo &rhs)
+  {
+    if (auto n = node["hostname"]) {
+      rhs.hostname = n.as<std::string>();
+    } else {
+      return false;
+    }
+
+    return true;
+  }
+};
 } // namespace YAML
 
 namespace rpc::handlers::hostdb
@@ -164,11 +187,13 @@ namespace rpc::handlers::hostdb
 namespace err = rpc::handlers::errors;
 
 swoc::Rv<YAML::Node>
-get_hostdb_status(std::string_view const & /* params ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
+get_hostdb_status(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
   try {
-    YAML::Node data = YAML::convert<HostDBCache>::encode(hostDBProcessor.cache());
+    HostDBGetStatusCmdInfo cmd = params.as<HostDBGetStatusCmdInfo>();
+
+    YAML::Node data = YAML::convert<HostDBCache>::encode(hostDBProcessor.cache(), cmd.hostname);
 
     resp.result()["data"] = data;
   } catch (std::exception const &ex) {

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -506,10 +506,16 @@ HostDBCommand::HostDBCommand(ts::Arguments *args) : CtrlCommand(args)
 void
 HostDBCommand::status_get()
 {
-  auto const            &data = get_parsed_arguments()->get(STATUS_STR);
-  HostDBGetStatusRequest request{
-    {std::begin(data), std::end(data)}
-  };
+  HostDBGetStatusRequest::Params params;
+
+  auto const &data = get_parsed_arguments()->get(STATUS_STR);
+  if (data.size() >= 1) {
+    params = {
+      data[0],
+    };
+  }
+
+  HostDBGetStatusRequest request{params};
 
   auto response = invoke_rpc(request);
 

--- a/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
@@ -126,8 +126,10 @@ struct HostGetStatusRequest : shared::rpc::ClientRequest {
 };
 //------------------------------------------------------------------------------------------------------------------------------------
 struct HostDBGetStatusRequest : shared::rpc::ClientRequest {
-  using super  = shared::rpc::ClientRequest;
-  using Params = std::vector<std::string>;
+  using super = shared::rpc::ClientRequest;
+  struct Params {
+    std::string hostname;
+  };
   HostDBGetStatusRequest(Params p) { super::params = std::move(p); }
 
   std::string

--- a/src/traffic_ctl/jsonrpc/ctrl_yaml_codecs.h
+++ b/src/traffic_ctl/jsonrpc/ctrl_yaml_codecs.h
@@ -71,6 +71,16 @@ template <> struct convert<HostSetStatusRequest::Params> {
   }
 };
 //------------------------------------------------------------------------------------------------------------------------------------
+template <> struct convert<HostDBGetStatusRequest::Params> {
+  static Node
+  encode(HostDBGetStatusRequest::Params const &params)
+  {
+    Node node;
+    node["hostname"] = params.hostname;
+    return node;
+  }
+};
+//------------------------------------------------------------------------------------------------------------------------------------
 template <> struct convert<BasicPluginMessageRequest::Params> {
   static Node
   encode(BasicPluginMessageRequest::Params const &params)


### PR DESCRIPTION
The `hostdb status` output can be large, it's convenient to filter the list with HOSTNAME option. 