### PR TITLE
Fix ppa log field

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -5747,11 +5747,7 @@ HttpTransact::initialize_state_variables_from_request(State *s, HTTPHdr *obsolet
   memset(&s->request_data.dest_ip, 0, sizeof(s->request_data.dest_ip));
   if (vc) {
     s->request_data.incoming_port = vc->get_local_port();
-    s->pp_info.version            = vc->get_proxy_protocol_version();
-    if (s->pp_info.version != ProxyProtocolVersion::UNDEFINED) {
-      ats_ip_copy(s->pp_info.src_addr, vc->get_proxy_protocol_src_addr());
-      ats_ip_copy(s->pp_info.dst_addr, vc->get_proxy_protocol_dst_addr());
-    }
+    s->pp_info                    = vc->get_proxy_protocol_info();
   }
   s->request_data.xact_start                      = s->client_request_time;
   s->request_data.api_info                        = &s->api_info;

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -1650,14 +1650,18 @@ LogAccess::marshal_proxy_protocol_dst_ip(char *buf)
 int
 LogAccess::marshal_proxy_protocol_authority(char *buf)
 {
-  if (buf && m_http_sm) {
+  int len = INK_MIN_ALIGN;
+
+  if (m_http_sm) {
     if (auto authority = m_http_sm->t_state.pp_info.get_tlv(PP2_TYPE_AUTHORITY)) {
-      int len = static_cast<int>(authority->size());
-      marshal_str(buf, authority->data(), len);
-      return len;
+      len = padded_length(authority->size() + 1);
+      if (buf) {
+        marshal_str(buf, authority->data(), len);
+        buf[authority->size()] = '\0';
+      }
     }
   }
-  return 0;
+  return len;
 }
 
 /*-------------------------------------------------------------------------


### PR DESCRIPTION
`ppa` is a field for PP2_TYPE_AUTHORITY.

- Copy a whole pp_info for logging
- Calculate the length with alignment in consideration
- Put null terminator at the end of the log field value