### PR TITLE
Fix cache directory corruption in parallel dir sync

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -1003,7 +1003,6 @@ Lrestart:
     return EVENT_CONT;
   }
   stripe_index = stripe_indices[current_index];
-  current_index++;
 
   StripeSM *stripe = gstripes[stripe_index]; // must be named "vol" to make STAT macros work.
 
@@ -1120,6 +1119,7 @@ Lrestart:
   }
 Ldone:
   writepos = 0;
+  current_index++;
   goto Lrestart;
 }
 


### PR DESCRIPTION
CacheSync::mainEvent is a multi-step state machine: syncing a single stripe's directory requires multiple AIO writes (header, body chunks, footer), each returning EVENT_CONT and re-entering mainEvent on completion. The refactor in #12639 moved current_index++ to the Lrestart label, which is reached on every entry to mainEvent. This caused the stripe index to advance on each AIO callback, even while in the middle of writing a stripe's directory. The result was writing one stripe's directory data to another stripe's disk location, corrupting the on-disk directory. After running with this bug, ATS could not initialize the cache on restart because the recovery code would find heavily corrupted directory state.

Move current_index++ to Ldone where it is only reached after a stripe's full sync completes, matching the original behavior of ++stripe_index in the pre-#12639 code.