### PR TITLE
NetAcceptAction::cancel() use-after-free fix: part 2

### DIFF
--- a/src/iocore/net/QUICNetProcessor.cc
+++ b/src/iocore/net/QUICNetProcessor.cc
@@ -251,9 +251,7 @@ QUICNetProcessor::main_accept(Continuation *cont, SOCKET fd, AcceptOptions const
   na->server.sock = UnixSocket{fd};
   ats_ip_copy(&na->server.accept_addr, &accept_ip);
 
-  na->action_         = new NetAcceptAction();
-  *na->action_        = cont;
-  na->action_->server = &na->server;
+  na->action_ = new NetAcceptAction(cont, &na->server);
   na->init_accept();
 
   return na->action_.get();

--- a/src/iocore/net/UnixNetProcessor.cc
+++ b/src/iocore/net/UnixNetProcessor.cc
@@ -133,9 +133,7 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   na->proxyPort     = sa ? sa->proxyPort : nullptr;
   na->snpa          = dynamic_cast<SSLNextProtocolAccept *>(cont);
 
-  na->action_         = new NetAcceptAction();
-  *na->action_        = cont;
-  na->action_->server = &na->server;
+  na->action_ = new NetAcceptAction(cont, &na->server);
 
   if (opt.frequent_accept) { // true
     if (accept_threads > 0 && listen_per_thread == 0) {


### PR DESCRIPTION
This is a revised version of PR #12803 which was reverted in PR #12841 because it lacked the idempotent cancel guard, causing its own set of crashes.

There is a race between NetAcceptAction::cancel() and NetAccept::acceptEvent() where the server pointer could be dereferenced after the NetAccept object was deleted. Thread A calls cancel(), which sets cancelled=true via Action::cancel(). Thread B running acceptEvent() sees cancelled==true and deletes the NetAccept (including the embedded Server). Thread A then calls server->close() on freed memory.

This is fixed by making the server pointer in NetAcceptAction atomic and using exchange(nullptr) so only one thread can obtain and close the server. Additionally, cancel() is made idempotent by checking !cancelled before calling Action::cancel(), which prevents ink_assert(!cancelled) assertion failures when cancel is called from both external callers (TSActionCancel) and internal error paths (acceptEvent, acceptFastEvent, acceptLoopEvent).