### PR TITLE
Check state of HostDBInfo

### DIFF
--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -1324,7 +1324,9 @@ HostDBRecord::select_best_http(ts_time now, ts_seconds fail_window, sockaddr con
       }
     }
   } else {
-    best_alive = &info[0];
+    if (!info[0].is_down(now, fail_window)) {
+      best_alive = &info[0];
+    }
   }
 
   return best_alive;

--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -1324,7 +1324,7 @@ HostDBRecord::select_best_http(ts_time now, ts_seconds fail_window, sockaddr con
       }
     }
   } else {
-    if (!info[0].is_down(now, fail_window)) {
+    if (info[0].select(now, fail_window)) {
       best_alive = &info[0];
     }
   }

--- a/tests/gold_tests/dns/dns_host_down.test.py
+++ b/tests/gold_tests/dns/dns_host_down.test.py
@@ -55,24 +55,13 @@ class DownCachedOriginServerTest:
                 'proxy.config.hostdb.host_file.path': os.path.join(Test.TestDirectory, "hosts_file"),
             })
 
-    # Even when the origin server is down, SM will return a hit-fresh domain from HostDB.
-    # After request has failed, SM should mark the IP as down
     def _test_host_mark_down(self):
         tr = Test.AddTestRun()
 
         tr.Processes.Default.StartBefore(self._server)
         tr.Processes.Default.StartBefore(self._ts)
 
-        tr.AddVerifierClientProcess(
-            "client-1", DownCachedOriginServerTest.replay_file, http_ports=[self._ts.Variables.port], other_args='--keys 1')
-
-    # After host has been marked down from previous test, HostDB should not return
-    # the host as available and DNS lookup should fail.
-    def _test_host_unreachable(self):
-        tr = Test.AddTestRun()
-
-        tr.AddVerifierClientProcess(
-            "client-2", DownCachedOriginServerTest.replay_file, http_ports=[self._ts.Variables.port], other_args='--keys 2')
+        tr.AddVerifierClientProcess("client-1", DownCachedOriginServerTest.replay_file, http_ports=[self._ts.Variables.port])
 
     # Verify error log marking host down exists
     def _test_error_log(self):
@@ -86,7 +75,6 @@ class DownCachedOriginServerTest:
 
     def run(self):
         self._test_host_mark_down()
-        self._test_host_unreachable()
         self._test_error_log()
 
 

--- a/tests/gold_tests/dns/replay/server_down.replay.yaml
+++ b/tests/gold_tests/dns/replay/server_down.replay.yaml
@@ -36,6 +36,7 @@ sessions:
       status: 200
 
     # Returns 502 since server connection is unreachable
+    # This transaction should mark the IP as down
     proxy-response:
       status: 502
 
@@ -55,5 +56,7 @@ sessions:
     server-response:
       status: 200
 
+    # After host has been marked down from previous test, HostDB should not return
+    # the host as available and HostDB lookup should fail.
     proxy-response:
-      status: 502
+      status: 500


### PR DESCRIPTION
`HostDBRecord::select_best_http()` function is expected return `nullptr` is all `HostDBInfo` are down state. However, a `HostDBRecord` has only one `HostDBInfo` (`info.count() == 1`), state of the info is not checked.