### PR TITLE
Disallow '@' in HTTP/1 header field-names per RFC 9110

### DIFF
--- a/include/tscore/ParseRules.h
+++ b/include/tscore/ParseRules.h
@@ -712,7 +712,7 @@ ParseRules::is_http_field_name(char c)
 #ifndef COMPILE_PARSE_RULES
   return (parseRulesCType[static_cast<unsigned char>(c)] & is_http_field_name_BIT);
 #else
-  if (!is_char(c) || is_control(c) || (is_mime_sep(c) && c != '@') || c == '=' || c == ':') {
+  if (!is_char(c) || is_control(c) || (is_mime_sep(c)) || c == '=' || c == ':') {
     return false;
   }
   return true;


### PR DESCRIPTION


# Disallow `@` in HTTP/1 header field-names per RFC 9110

## Summary

Disallow the `@` character in HTTP/1 header field-names to ensure compliance with RFC 9110.

## Background

RFC 9110 defines:

```
field-name = token
```

Where `token` consists only of `tchar` characters:

```
tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
      / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
      / DIGIT / ALPHA
```

The `@` character is **not** included in the `tchar` set and therefore is not valid in HTTP header field-names.

The current implementation of `ParseRules::is_http_field_name()` explicitly allows `@` as an exception:

```cpp
(is_mime_sep(c) && c != '@')
```

This results in HTTP/1 requests such as:

```
To@st: value
```

being accepted instead of rejected.

## Change

Remove the special-case allowance for `@` in `ParseRules::is_http_field_name()`.

Before:

```cpp
(is_mime_sep(c) && c != '@')
```

After:

```cpp
is_mime_sep(c)
```

This ensures that `@` is rejected as part of HTTP/1 header field-names.

## Result

Requests containing header names with `@` now correctly return:

```
400 Invalid HTTP Request
```

instead of being processed normally.

## Scope

* Minimal change
* No structural modifications
* No parser architecture changes
* Strict RFC 9110 compliance enforcement

## Impact

Improves HTTP/1 standards compliance by rejecting syntactically invalid header field-names.
