### PR TITLE
Fix flaky filter_body test: ReturnCode

### DIFF
--- a/tests/gold_tests/autest-site/ats_replay.test.ext
+++ b/tests/gold_tests/autest-site/ats_replay.test.ext
@@ -172,9 +172,11 @@ def ATSReplayTest(obj, replay_file: str):
     process_config = server_config.get('process_config', {})
     server = tr.AddVerifierServerProcess(name, replay_file, **process_config)
 
-    # Set expected return code for server if specified.
+    # Set expected return code for server if specified. A list of codes is
+    # wrapped in Any() so that any of the listed values is accepted.
     if 'return_code' in server_config:
-        server.ReturnCode = server_config['return_code']
+        rc = server_config['return_code']
+        server.ReturnCode = Any(*rc) if isinstance(rc, list) else rc
 
     # ATS configuration.
     if not 'ats' in autest_config:
@@ -193,9 +195,11 @@ def ATSReplayTest(obj, replay_file: str):
     client = tr.AddVerifierClientProcess(
         name, replay_file, http_ports=[ts.Variables.port], https_ports=https_ports, **process_config)
 
-    # Set expected return code if specified.
+    # Set expected return code if specified. A list of codes is wrapped in
+    # Any() so that any of the listed values is accepted.
     if 'return_code' in client_config:
-        client.ReturnCode = client_config['return_code']
+        rc = client_config['return_code']
+        client.ReturnCode = Any(*rc) if isinstance(rc, list) else rc
 
     if dns:
         ts.StartBefore(dns)

--- a/tests/gold_tests/pluginTest/filter_body/filter_body.replay.yaml
+++ b/tests/gold_tests/pluginTest/filter_body/filter_body.replay.yaml
@@ -29,7 +29,9 @@ autest:
 
   client:
     name: 'client'
-    return_code: 1
+    # There's a race condition for when the connection is droped by ATS - this
+    # can result in either a 0 or 1 return code.
+    return_code: [0, 1]
 
   ats:
     name: 'ts'


### PR DESCRIPTION
The filter_body test's Proxy Verifier client can exit with either 0 or 1 depending on timing of connection closure during request body blocking. The ATSReplayTest extension only supported a single scalar return_code value, so the test would intermittently fail when the client happened to exit with 0 instead of the expected 1.

Support a list of return codes in the replay YAML by wrapping them in Any() when a list is provided, and update the filter_body test to accept either exit code.