### PR TITLE
Fix log_retention test: use correct test run variable

### DIFF
--- a/tests/gold_tests/logging/log_retention.test.py
+++ b/tests/gold_tests/logging/log_retention.test.py
@@ -488,7 +488,7 @@ tr.StillRunningAfter = test.ts
 tr.StillRunningAfter = test.server
 
 tr = Test.AddTestRun("Get the log to rotate.")
-test.tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
+tr.MakeCurlCommandMulti(test.get_command_to_rotate_once(), ts=test.ts)
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = test.ts
 tr.StillRunningAfter = test.server


### PR DESCRIPTION
This was failing on my box. 


Test 7 ('Get the log to rotate.') was calling MakeCurlCommandMulti on test.tr (the test run from the TestLogRetention constructor) instead of the newly created tr. This left the new test run with no process defined, causing the test to fail with 'List came back empty.'