### PR TITLE
Fix the log field type for cqpv and sqpv

### DIFF
--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -480,12 +480,12 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("pqup", field);
 
-  field = new LogField("client_req_protocol_version", "cqpv", LogField::dINT, &LogAccess::marshal_client_req_protocol_version,
+  field = new LogField("client_req_protocol_version", "cqpv", LogField::STRING, &LogAccess::marshal_client_req_protocol_version,
                        &LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqpv", field);
 
-  field = new LogField("server_req_protocol_version", "sqpv", LogField::dINT, &LogAccess::marshal_server_req_protocol_version,
+  field = new LogField("server_req_protocol_version", "sqpv", LogField::STRING, &LogAccess::marshal_server_req_protocol_version,
                        &LogAccess::unmarshal_str);
   global_field_list.add(field, false);
   field_symbol_hash.emplace("sqpv", field);


### PR DESCRIPTION
The log field type for `cqpv` and `sqpv` have been`dINT` since the beginning and those luckily work, but I think the type is wrong.

They are obviously strings.
https://github.com/apache/trafficserver/blob/0fb268b07e2b2e080af335023aade14b9c99ebc8/src/proxy/logging/LogAccess.cc#L2059-L2082
https://github.com/apache/trafficserver/blob/0fb268b07e2b2e080af335023aade14b9c99ebc8/src/proxy/logging/LogAccess.cc#L2091-L2114

