### PR TITLE
Update gitignore for codex files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,11 @@ src/iocore/cache/unit_tests/var/trafficserver/cache.db
 .cursor/
 .claude/
 !.claude/CLAUDE.md
+.agents/
+.codex/
+!.codex/
+.codex/*
+!.codex/AGENTS.md
 
 # Extensions
 ext/


### PR DESCRIPTION
Add Codex-specific local workspace directories to the repository ignore list so personal agent and Codex metadata files are not accidentally committed, matching the existing handling for other AI tooling folders like .cursor and .claude while preserving the tracked CLAUDE.md exception.