### PR TITLE
autest: add missing newline before worker output in parallel runner

### DIFF
--- a/tests/autest-parallel.py.in
+++ b/tests/autest-parallel.py.in
@@ -925,6 +925,7 @@ Examples:
     try:
         if partitions:
             print_progress()
+            print()  # Newline so worker output starts on a fresh line
             with ProcessPoolExecutor(max_workers=len(partitions)) as executor:
                 for worker_id, worker_tests in enumerate(partitions):
                     future = executor.submit(


### PR DESCRIPTION
Missing newline after progress bar causes worker output to overlap.

before:
```
[Parallel] 0/410 tests (0%) | 0/4 workers done | 0s elapsed | ETA: --:--  2026-02-18 12:58:36 Worker: 1 Starting batch of 102 tests (port offset 1000)
2026-02-18 12:58:36 Worker: 3 Starting batch of 102 tests (port offset 3000)
2026-02-18 12:58:36 Worker: 0 Starting batch of 103 tests (port offset 0)
2026-02-18 12:58:36 Worker: 2 Starting batch of 102 tests (port offset 2000)
```

after:
```
[Parallel] 0/410 tests (0%) | 0/4 workers done | 0s elapsed | ETA: --:--  
2026-02-18 12:58:36 Worker: 1 Starting batch of 102 tests (port offset 1000)
2026-02-18 12:58:36 Worker: 3 Starting batch of 102 tests (port offset 3000)
2026-02-18 12:58:36 Worker: 0 Starting batch of 103 tests (port offset 0)
2026-02-18 12:58:36 Worker: 2 Starting batch of 102 tests (port offset 2000)
```