### PR TITLE
Fix: set UA_BEGIN_WRITE milestone unconditionally

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -1691,6 +1691,7 @@ HttpSM::handle_api_return()
     break;
   }
   case HttpTransact::StateMachineAction_t::SERVER_READ: {
+    milestones.mark(TS_MILESTONE_UA_BEGIN_WRITE);
     if (unlikely(t_state.did_upgrade_succeed)) {
       // We've successfully handled the upgrade, let's now setup
       // a blind tunnel.
@@ -1727,6 +1728,7 @@ HttpSM::handle_api_return()
     break;
   }
   case HttpTransact::StateMachineAction_t::SERVE_FROM_CACHE: {
+    milestones.mark(TS_MILESTONE_UA_BEGIN_WRITE);
     HttpTunnelProducer *p = setup_cache_read_transfer();
     tunnel.tunnel_run(p);
     break;


### PR DESCRIPTION
**Mark `UA_BEGIN_WRITE` in `SERVER_READ` and `SERVE_FROM_CACHE`** -- this milestone was only set inside the `API_SEND_RESPONSE_HDR` hook path, which requires a plugin to hook `TS_HTTP_SEND_RESPONSE_HDR_HOOK`. Without that hook, `UA_BEGIN_WRITE` stayed at zero, causing all `msdms` log fields that reference it (`c_ttfb`, `o_proc`, `o_body`, `hit_proc`, `hit_xfer`) to report `-1`.

In production environments with plugins this was masked, but bare ATS installations and autests saw missing values for these fields.

**Testing:** Existing autests pass. A dedicated milestone logging autest will be added in a follow-up PR.

<!-- merge-description-updated:2026-02-21T00:00:00Z -->