### PR TITLE
log-filenames.test.py: fix diags check flakyness

### DIFF
--- a/tests/gold_tests/logging/log-filenames.test.py
+++ b/tests/gold_tests/logging/log-filenames.test.py
@@ -160,7 +160,7 @@ class LogFilenamesTest:
 
         diags_path = self.ts.Disk.diags_log.AbsPath
         self.ts.Disk.diags_log.Content += Testers.ContainsExpression(
-            "Traffic Server is fully initialized", f"{diags_path} should contain traffic_server diag messages")
+            "logging.yaml finished loading", f"{diags_path} should contain traffic_server diag messages")
 
         error_log_path = self.ts.Disk.error_log.AbsPath
         self.ts.Disk.error_log.Content += Testers.ContainsExpression(


### PR DESCRIPTION
The log-filenames AuTest can be flaky in CI when logs are directed to
stdout or stderr. The startup message used by the assertion can be
interleaved with other log output, so an exact match is brittle.

Use an earlier and more stable startup marker from diagnostic logging:
"logging.yaml finished loading". This still validates that diags
content is emitted while avoiding the split-line failure mode.