### PR TITLE
synserver accept assertion to log event details before aborting

### DIFF
--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -893,6 +893,7 @@ static int
 synserver_vc_refuse(TSCont contp, TSEvent event, void *data)
 {
   if (event != TS_EVENT_NET_ACCEPT && event != TS_EVENT_NET_ACCEPT_FAILED) {
+    // net_accept() passes negated errno as data on EVENT_ERROR; Linux MAX_ERRNO is 4095
     intptr_t data_val = reinterpret_cast<intptr_t>(data);
     if (data_val < 0 && data_val >= -4095) {
       int err = static_cast<int>(-data_val);
@@ -922,6 +923,7 @@ static int
 synserver_vc_accept(TSCont contp, TSEvent event, void *data)
 {
   if (event != TS_EVENT_NET_ACCEPT && event != TS_EVENT_NET_ACCEPT_FAILED) {
+    // net_accept() passes negated errno as data on EVENT_ERROR; Linux MAX_ERRNO is 4095
     intptr_t data_val = reinterpret_cast<intptr_t>(data);
     if (data_val < 0 && data_val >= -4095) {
       int err = static_cast<int>(-data_val);


### PR DESCRIPTION
### Problem

Rocky CI build [#8376](https://ci.trafficserver.apache.org/job/Github_Builds/job/rocky/8376/) crashed with a core dump in `synserver_vc_accept` after `SDK_API_HttpParentProxySet_Success` passed. The bare `TSAssert` logged no information about which event was actually received, making diagnosis impossible.

### Changes

- **Replace bare `TSAssert` with diagnostic `ink_abort`** -- logs the unexpected event number and, if the data looks like a negated errno, the `strerror` string in both `synserver_vc_accept` and `synserver_vc_refuse`
- **Validate data as `intptr_t` before narrowing to errno** -- checks the range (-1 to -4095) in pointer-width space to avoid truncating a pointer that accidentally lands in the errno range

### Testing

- [x] All 15 CI checks pass
- [x] Does not change behavior (still aborts on unexpected events) -- only adds diagnostics before the abort

<!-- merge-description-updated:2026-02-21T20:00:00Z -->