### PR TITLE
Add CAP_CHOWN to permitted capability set

### DIFF
--- a/include/tscore/ink_cap.h
+++ b/include/tscore/ink_cap.h
@@ -81,8 +81,9 @@ public:
     FILE_PRIVILEGE     = 0x1u, ///< Access filesystem objects with privilege
     TRACE_PRIVILEGE    = 0x2u, ///< Trace other processes with privilege
     LOW_PORT_PRIVILEGE = 0x4u, ///< Bind to privilege ports.
-    OWNER_PRIVILEGE    = 0x8u  ///< Bypass permission checks on operations that normally require
+    OWNER_PRIVILEGE    = 0x8u, ///< Bypass permission checks on operations that normally require
                                ///  filesystem UID & process UID to match
+    CHOWN_PRIVILEGE = 0x10u    ///< Change file ownership
   };
 
   ElevateAccess(unsigned level = FILE_PRIVILEGE);

--- a/include/tscore/ink_cap.h
+++ b/include/tscore/ink_cap.h
@@ -81,8 +81,7 @@ public:
     FILE_PRIVILEGE     = 0x1u, ///< Access filesystem objects with privilege
     TRACE_PRIVILEGE    = 0x2u, ///< Trace other processes with privilege
     LOW_PORT_PRIVILEGE = 0x4u, ///< Bind to privilege ports.
-    OWNER_PRIVILEGE    = 0x8u, ///< Bypass permission checks on operations that normally require
-                               ///  filesystem UID & process UID to match
+    OWNER_PRIVILEGE    = 0x8u, ///< Owner-only operations on unowned files (CAP_FOWNER)
     CHOWN_PRIVILEGE    = 0x10u ///< Change file ownership
   };
 

--- a/include/tscore/ink_cap.h
+++ b/include/tscore/ink_cap.h
@@ -83,7 +83,7 @@ public:
     LOW_PORT_PRIVILEGE = 0x4u, ///< Bind to privilege ports.
     OWNER_PRIVILEGE    = 0x8u, ///< Bypass permission checks on operations that normally require
                                ///  filesystem UID & process UID to match
-    CHOWN_PRIVILEGE = 0x10u    ///< Change file ownership
+    CHOWN_PRIVILEGE    = 0x10u ///< Change file ownership
   };
 
   ElevateAccess(unsigned level = FILE_PRIVILEGE);

--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -273,7 +273,7 @@ RestrictCapabilities()
   cap_t caps_orig = cap_get_proc();
 
   // Capabilities we need.
-  cap_value_t      perm_list[]    = {CAP_NET_ADMIN, CAP_NET_BIND_SERVICE, CAP_IPC_LOCK, CAP_DAC_OVERRIDE, CAP_FOWNER};
+  cap_value_t      perm_list[]    = {CAP_NET_ADMIN, CAP_NET_BIND_SERVICE, CAP_IPC_LOCK, CAP_DAC_OVERRIDE, CAP_FOWNER, CAP_CHOWN};
   static int const PERM_CAP_COUNT = sizeof(perm_list) / sizeof(*perm_list);
   cap_value_t      eff_list[]     = {CAP_NET_ADMIN, CAP_NET_BIND_SERVICE, CAP_IPC_LOCK};
   static int const EFF_CAP_COUNT  = sizeof(eff_list) / sizeof(*eff_list);

--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -436,7 +436,7 @@ void
 ElevateAccess::acquirePrivilege(unsigned priv_mask)
 {
   unsigned    cap_count = 0;
-  cap_value_t cap_list[3];
+  cap_value_t cap_list[4];
   cap_t       new_cap_state;
 
   Dbg(dbg_ctl_privileges, "[acquirePrivilege] level= %x", level);
@@ -460,6 +460,11 @@ ElevateAccess::acquirePrivilege(unsigned priv_mask)
 
   if (priv_mask & ElevateAccess::OWNER_PRIVILEGE) {
     cap_list[cap_count] = CAP_FOWNER;
+    ++cap_count;
+  }
+
+  if (priv_mask & ElevateAccess::CHOWN_PRIVILEGE) {
+    cap_list[cap_count] = CAP_CHOWN;
     ++cap_count;
   }
 

--- a/src/tscore/ink_cap.cc
+++ b/src/tscore/ink_cap.cc
@@ -468,7 +468,7 @@ ElevateAccess::acquirePrivilege(unsigned priv_mask)
     ++cap_count;
   }
 
-  ink_release_assert(cap_count <= sizeof(cap_list));
+  ink_release_assert(cap_count <= sizeof(cap_list) / sizeof(cap_list[0]));
 
   if (cap_count > 0) {
     this->cap_state = cap_get_proc(); // save current capabilities


### PR DESCRIPTION
## Summary

Add `CAP_CHOWN` to the permitted capability set retained by `RestrictCapabilities()` after the privilege drop from root to the unprivileged user.

This enables plugins that manage TLS certificate files to set `root:root` ownership on backup copies they write to disk, supporting deployments where cert files are restricted to `root:root 600` inside `root:root 700` directories.

## Changes

* **`src/tscore/ink_cap.cc`** -- Added `CAP_CHOWN` to `perm_list` in `RestrictCapabilities()`. Like `CAP_DAC_OVERRIDE` and `CAP_FOWNER`, it is retained in the permitted set only (not effective). A plugin must explicitly promote it to the effective set before use.

## Security Considerations

`CAP_CHOWN` allows changing file ownership. It follows the same security model as `CAP_DAC_OVERRIDE` (already retained): held in the permitted set but **not** in the effective set during normal operation. A plugin must use RAII-style elevation to briefly promote it, then drop it immediately after the `fchown()` call.

## Testing

Verified on Fedora 43 with libcap 2.76:
- `CAP_CHOWN` appears in `CapPrm` but not `CapEff` after startup
- `fchown()` succeeds when the capability is elevated
- No change to steady-state behavior