### PR TITLE
Revert "cmake: detect FreeBSD's native cap with capsicum (#12859)"

### DIFF
--- a/cmake/Findcap.cmake
+++ b/cmake/Findcap.cmake
@@ -28,22 +28,20 @@
 #     cap::cap
 #
 
-# Check for Linux libcap
 find_library(cap_LIBRARY NAMES cap)
 find_path(cap_INCLUDE_DIR NAMES sys/capability.h)
 
-# Check for FreeBSD Capsicum (Base system)
-find_path(capsicum_INCLUDE_DIR NAMES sys/capsicum.h)
+mark_as_advanced(cap_FOUND cap_LIBRARY cap_INCLUDE_DIR)
 
-if(capsicum_INCLUDE_DIR)
-  # FreeBSD native path
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cap REQUIRED_VARS cap_LIBRARY cap_INCLUDE_DIR)
+
+if(cap_FOUND)
+  set(cap_INCLUDE_DIRS ${cap_INCLUDE_DIR})
+endif()
+
+if(cap_FOUND AND NOT TARGET cap::cap)
   add_library(cap::cap INTERFACE IMPORTED)
-  target_compile_definitions(cap::cap INTERFACE HAVE_SYS_CAPSICUM_H)
-  # No target_link_libraries needed as it's in libc
-elseif(cap_LIBRARY AND cap_INCLUDE_DIR)
-  # Linux/Other path
-  add_library(cap::cap INTERFACE IMPORTED)
-  target_include_directories(cap::cap INTERFACE ${cap_INCLUDE_DIR})
+  target_include_directories(cap::cap INTERFACE ${cap_INCLUDE_DIRS})
   target_link_libraries(cap::cap INTERFACE ${cap_LIBRARY})
-  target_compile_definitions(cap::cap INTERFACE HAVE_SYS_CAPABILITY_H)
 endif()


### PR DESCRIPTION
This reverts commit cc9fa72965e61e6e81294f727237941087e79f0a.

Reverts PR #12859 