### PR TITLE
Doc: remove references to set-debug TXN_DEBUG in header_rewrite/hrw4u

### DIFF
--- a/doc/admin-guide/configuration/hrw4u.en.rst
+++ b/doc/admin-guide/configuration/hrw4u.en.rst
@@ -353,7 +353,6 @@ Header Rewrite    HRW4U Syntax                 Description
 ================= ============================ ================================
 no-op             no-op();                     Explicit no-op statement
 no-op [L]         break;                       Exit current section early (last rule)
-set-debug         set-debug()                  Enables ATS txn debug
 skip-remap        skip-remap()                 Skip remap processing (open proxy)
 ================= ============================ ================================
 
@@ -548,18 +547,6 @@ origin server::
    SEND_REQUEST {
       outbound.req.Cache-Control = "";
       outbound.req.Pragma = "";
-   }
-
-Enable Debugging Per-Request
-----------------------------
-
-Turns on |TS| debugging statements for a transaction, but only when a special
-header is present in the client request::
-
-   READ_REQUEST {
-      if inbound.req.X-Debug == "supersekret" {
-          set-debug();
-      }
    }
 
 Remove Internal Headers

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1172,22 +1172,6 @@ When invoked, sets the client side MARK value for the current
 transaction.  The ``<value>`` should be specified as a decimal integer.
 Requires at least Linux 2.6.25.
 
-set-debug
-~~~~~~~~~
-::
-
-  set-debug
-
-When invoked, this operator enables the internal transaction debugging flag
-(via :func:`TSHttpTxnDebugSet`), which causes debug messages to be printed to
-the appropriate logs even when the debug tag has not been enabled. For
-additional information on |TS| debugging statements, refer to
-:ref:`developer-debug-tags` in the developer's documentation.
-
-.. note::
-    This operator is deprecated, use the `set-http-cntl`_ operator instead,
-    with the ``TXN_DEBUG`` control.
-
 set-destination
 ~~~~~~~~~~~~~~~
 ::
@@ -1346,7 +1330,6 @@ INTERCEPT_RETRY  Allow intercepts to be retried (default: ``off``)
 RESP_CACHEABLE   Force the response to be cacheable (default: ``off``)
 REQ_CACHEABLE    Force the request to be cacheable (default: ``off``)
 SERVER_NO_STORE  Don't allow the response to be written to cache (default: ``off``)
-TXN_DEBUG        Enable transaction debugging (default: ``off``)
 SKIP_REMAP       Don't require a remap match for the transaction (default: ``off``)
 ================ ====================================================================
 
@@ -1789,16 +1772,6 @@ origin server::
    cond %{SEND_REQUEST_HDR_HOOK}
      rm-header Cache-Control
      rm-header Pragma
-
-Enable Debugging Per-Request
-----------------------------
-
-Turns on |TS| debugging statements for a transaction, but only when a special
-header is present in the client request::
-
-   cond %{READ_REQUEST_HDR_HOOK}
-   cond %{CLIENT-HEADER:X-Debug} =supersekret
-      set-http-cntl TXN_DEBUG on
 
 Remove Internal Headers
 -----------------------


### PR DESCRIPTION
The set-http-cntl TXN_DEBUG and (deprecated) set-debug need a non-overridable config (proxy.config.diags.debug.enabled) to be on. But, if its on, then you don't need header_rewrite to conditionally turn it on. (I suppose turning it off could be a use case, but, that would also require rewriting the docs).