### PR TITLE
Add AuTest for connect_attempts_max_retries_down_server

### DIFF
--- a/tests/gold_tests/autest-site/ats_replay.test.ext
+++ b/tests/gold_tests/autest-site/ats_replay.test.ext
@@ -182,6 +182,8 @@ def ATSReplayTest(obj, replay_file: str):
             dns = tr.MakeDNServer(name, **process_config)
         else:
             dns = tr.MakeDNServer(name, default='127.0.0.1')
+        if 'records' in dns_config:
+            dns.addRecords(dns_config['records'])
 
     # Proxy Verifier Server configuration.
     if not 'server' in autest_config:

--- a/tests/gold_tests/dns/connect_attempts.test.py
+++ b/tests/gold_tests/dns/connect_attempts.test.py
@@ -1,0 +1,25 @@
+'''
+Verify Origin Server Connect Attempts Behavior
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify Origin Server Connect Attempts Behavior
+'''
+
+# max_retries_down_server
+Test.ATSReplayTest(replay_file="replay/connect_attempts_rr_down_server.replay.yaml")

--- a/tests/gold_tests/dns/replay/connect_attempts_rr_down_server.replay.yaml
+++ b/tests/gold_tests/dns/replay/connect_attempts_rr_down_server.replay.yaml
@@ -1,0 +1,165 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# This replay file assumes that caching is enabled.
+#
+
+meta:
+  version: "1.0"
+
+# Configuration section for autest integration
+autest:
+  description: 'Verify connect attempts behavior - retry down server'
+
+  dns:
+    name: 'dns-ds'
+    records: {"backend.example.com": ["0.0.0.1", "0.0.0.2"]}
+
+  server:
+    name: 'server-ds'
+
+  client:
+    name: 'client-ds'
+
+  ats:
+    name: 'ts-ds'
+    process_config:
+      enable_cache: false
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'http|hostdb|dns'
+      proxy.config.http.connect_attempts_rr_retries: 0
+      proxy.config.http.connect_attempts_max_retries: 2
+      proxy.config.http.connect_attempts_max_retries_down_server: 1
+      proxy.config.http.connect_attempts_timeout: 30
+      proxy.config.http.down_server.cache_time: 5
+
+    remap_config:
+      - from: "http://example.com/"
+        to: "http://backend.example.com:{SERVER_HTTP_PORT}/"
+
+sessions:
+- transactions:
+  # try 0.0.0.1
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, 1]
+
+    # should not hit
+    server-response:
+      status: 200
+      reason: OK
+
+    proxy-response:
+      status: 502
+
+  # try 0.0.0.2
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, 2]
+
+    # should not hit
+    server-response:
+      status: 200
+      reason: OK
+
+    proxy-response:
+      status: 502
+
+  # retry on dead 0.0.0.1
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, 3]
+
+    # should not hit
+    server-response:
+      status: 200
+      reason: OK
+
+    proxy-response:
+      status: 502
+
+  # retry on dead 0.0.0.2
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, 4]
+
+    # should not hit
+    server-response:
+      status: 200
+      reason: OK
+
+    proxy-response:
+      status: 502
+
+  # request expected hit down_server cache and immidiately get 500
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, 10]
+
+    # should not hit
+    server-response:
+      status: 200
+      reason: OK
+
+    proxy-response:
+      status: 500
+
+  # when down_server.cache_time is expired, try connect attempts
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, 20]
+      delay: 10s
+
+    # should not hit
+    server-response:
+      status: 200
+      reason: OK
+
+    proxy-response:
+      status: 502


### PR DESCRIPTION
This is an effort to verify `connect_attempts_max_retries_down_server` behavior.

The doc for [`proxy.config.http.connect_attempts_max_retries_down_server`](https://docs.trafficserver.apache.org/admin-guide/files/records.yaml.en.html#proxy-config-http-connect-attempts-max-retries-down-server) says below.

> Maximum number of connection attempts Traffic Server can make while an origin is marked down per request.

Also doc of [`proxy.config.http.connect_attempts_max_retries`](https://docs.trafficserver.apache.org/admin-guide/files/records.yaml.en.html#proxy-config-http-connect-attempts-max-retries) says below

> Once the maximum number of retries is reached, the origin is marked down. After this, the setting `proxy.config.http.connect_attempts_max_retries_down_server` is used to limit the number of retry attempts to the known down origin.

However, I don't see ATS makes connection attempts against down servers. From my understanding, `HostDBRecord::select_best_http` doesn't return `HostDBInfo` which is in down state. How `HttpSM` can try to down servers?