### PR TITLE
compress plugin - use configured compression levels for gzip and brotli

### DIFF
--- a/plugins/compress/brotli_compress.h
+++ b/plugins/compress/brotli_compress.h
@@ -35,6 +35,9 @@ void data_alloc(Data *data);
 // Destroy brotli compression context
 void data_destroy(Data *data);
 
+// Configure the context with compression level. Returns true when ready.
+bool transform_init(Data *data);
+
 // Compress one chunk of data
 void transform_one(Data *data, const char *upstream_buffer, int64_t upstream_length);
 

--- a/plugins/compress/gzip_compress.h
+++ b/plugins/compress/gzip_compress.h
@@ -39,6 +39,9 @@ void data_alloc(Data *data);
 // Destroy gzip/deflate compression context
 void data_destroy(Data *data);
 
+// Configure the context with compression level. Returns true when ready.
+bool transform_init(Data *data);
+
 // Compress one chunk of data
 void transform_one(Data *data, const char *upstream_buffer, int64_t upstream_length);
 


### PR DESCRIPTION
Previously, gzip and brotli compression used hardcoded levels even when custom levels were configured via `HostConfiguration`

Split initialization into `data_alloc()` and `transform_init()` so
- gzip uses `hc->zlib_compression_level()`
- brotli uses `hc->brotli_compression_level()` and `hc->brotli_lgw_size()`

Also adds proper error handling if encoder initialization fails