### PR TITLE
Fix: Handle EBADF in synserver accept instead of aborting

### DIFF
--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -896,9 +896,10 @@ synserver_vc_refuse(TSCont contp, TSEvent event, void *data)
     intptr_t data_val = reinterpret_cast<intptr_t>(data);
     // Listening socket closed by synserver_stop while accept was pending.
     if (event == TS_EVENT_ERROR && data_val == -EBADF) {
-      Warning("synserver_vc_refuse: accept got EBADF, listener likely shut down");
+      Dbg(dbg_ctl_SockServer, "synserver_vc_refuse: accept got EBADF, listener likely shut down");
       return TS_EVENT_IMMEDIATE;
     }
+    // net_accept() passes negated errno as data on EVENT_ERROR; Linux MAX_ERRNO is 4095
     if (data_val < 0 && data_val >= -4095) {
       int err = static_cast<int>(-data_val);
       ink_abort("synserver_vc_refuse: unexpected event %d, accept errno: %s (%d)", event, strerror(err), err);
@@ -930,9 +931,10 @@ synserver_vc_accept(TSCont contp, TSEvent event, void *data)
     intptr_t data_val = reinterpret_cast<intptr_t>(data);
     // Listening socket closed by synserver_stop while accept was pending.
     if (event == TS_EVENT_ERROR && data_val == -EBADF) {
-      Warning("synserver_vc_accept: accept got EBADF, listener likely shut down");
+      Dbg(dbg_ctl_SockServer, "synserver_vc_accept: accept got EBADF, listener likely shut down");
       return TS_EVENT_IMMEDIATE;
     }
+    // net_accept() passes negated errno as data on EVENT_ERROR; Linux MAX_ERRNO is 4095
     if (data_val < 0 && data_val >= -4095) {
       int err = static_cast<int>(-data_val);
       ink_abort("synserver_vc_accept: unexpected event %d, accept errno: %s (%d)", event, strerror(err), err);


### PR DESCRIPTION
### Problem

The regression suite intermittently crashes in `synserver_vc_accept` with:

```
Fatal: synserver_vc_accept: unexpected event 3, accept errno: Bad file descriptor (9)
```

This happens because multiple `EXCLUSIVE_REGRESSION_TEST` tests (`SDK_API_HttpTxnTransform`, `SDK_API_HttpAltInfo`, etc.) share port 3300 and their teardown can overlap with a pending accept.  When `synserver_stop`/`synserver_delete` closes the listening socket, `net_accept()` gets `EBADF` from `accept()` and sends `EVENT_ERROR` with `-EBADF` as data to the continuation.

### Related PRs

- #12903 -- added diagnostic logging to the synserver accept handlers, replacing a bare `TSAssert` with `ink_abort` that prints the event type and errno.  The output from that change confirmed the root cause: `EVENT_ERROR` (3) with `EBADF` (9) during test teardown.

### Changes

* **Handle `EVENT_ERROR` + `EBADF` gracefully** -- in both `synserver_vc_accept` and `synserver_vc_refuse`, check specifically for `EVENT_ERROR` with `data == -EBADF` and return instead of aborting.  This is the expected error when the listening socket was closed during teardown.
* **Preserve abort for other errors** -- any unexpected event or errno still triggers `ink_abort` with full diagnostics, so new failure modes won't be silently swallowed.

### Testing

- [x] Addresses crash seen in [centos #6334](https://ci.trafficserver.apache.org/job/Github_Builds/job/centos/6334/console) and [rocky #8376](https://ci.trafficserver.apache.org/job/Github_Builds/job/rocky/8376/)
- [x] CI
