### PR TITLE
Docs: Add cache inspector removal to upgrading guide

### DIFF
--- a/doc/release-notes/upgrading.en.rst
+++ b/doc/release-notes/upgrading.en.rst
@@ -36,6 +36,7 @@ removed in the next major release of ATS.
 * Removed Features
   * HostDB no longer supports persistent storage for DNS resolution
   * Removed support for the MMH crypto hash function
+  * Removed the built-in stats and cache inspector pages that were previously accessible via the |TS| HTTP interface
 
   * Traffic Manager is no longer part of |TS|. Administrative tools now interact with |TS| directly by using the :ref:`jsonrpc-node`.
 


### PR DESCRIPTION
The stats and cache inspector pages were removed in ATS 10 (PR #10710) but this was not documented in the upgrading guide. Users upgrading from 9.x would not know these features are gone.

This adds a bullet to the "Removed Features" section of the v10.x upgrading doc noting the removal.