### PR TITLE
Docs: Fix misleading compress plugin cache option description

### DIFF
--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -109,9 +109,12 @@ compression is performed on-the-fly for subsequent cache hits.
 .. note::
 
    The plugin always adds ``Vary: Accept-Encoding`` to compressible responses.
-   This causes |TS| to store compressed and uncompressed responses as separate
-   :term:`alternates <alternate>`, so both variants will be cached after clients
-   of each type have made a request — regardless of this setting.
+   This causes |TS| to use separate cache :term:`alternates <alternate>` (keys)
+   for requests with different ``Accept-Encoding`` values. Which body
+   representation is actually stored in cache still depends on the ``cache``
+   option: with ``cache true`` the compressed response is cached, while with
+   ``cache false`` only the uncompressed response is cached and compression is
+   performed on-the-fly for clients that send ``Accept-Encoding``.
 
 Enabled by default.
 

--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -99,13 +99,21 @@ Per site configuration for remap plugin should be ignored.
 cache
 -----
 
-When set to ``true``, |TS| caches the compressed (transformed) response when
-the client sends ``Accept-Encoding``. When set to ``false``, |TS| caches only
-the uncompressed (untransformed) response and compresses on-the-fly from cache
-for subsequent requests. In both cases, the plugin adds
-``Vary: Accept-Encoding`` to compressible responses, which causes |TS| to
-maintain separate :term:`alternates <alternate>` for compressed and uncompressed
-variants as different clients make requests. Enabled by default.
+Controls which version of the response is stored in cache when the compress
+transform runs (i.e., when the client sends ``Accept-Encoding``).
+
+When set to ``true``, the compressed (transformed) response is cached. When set
+to ``false``, the uncompressed (untransformed) response is cached and
+compression is performed on-the-fly for subsequent cache hits.
+
+.. note::
+
+   The plugin always adds ``Vary: Accept-Encoding`` to compressible responses.
+   This causes |TS| to store compressed and uncompressed responses as separate
+   :term:`alternates <alternate>`, so both variants will be cached after clients
+   of each type have made a request — regardless of this setting.
+
+Enabled by default.
 
 range-request
 -------------

--- a/doc/admin-guide/plugins/compress.en.rst
+++ b/doc/admin-guide/plugins/compress.en.rst
@@ -64,8 +64,9 @@ It can be enabled globally for |TS| by adding the following to your
 
 With no further options, this will enable the following default behavior:
 
-*  Enable caching of both compressed and uncompressed versions of origin
-   responses as :term:`alternates <alternate>`.
+*  Enable caching of compressed responses. Uncompressed and compressed versions
+   are maintained as separate :term:`alternates <alternate>` via
+   ``Vary: Accept-Encoding``.
 
 *  Compress objects with `text/*` content types for every origin.
 
@@ -98,10 +99,13 @@ Per site configuration for remap plugin should be ignored.
 cache
 -----
 
-When set to ``true``, causes |TS| to cache both the compressed and uncompressed
-versions of the content as :term:`alternates <alternate>`. When set to
-``false``, |TS| will cache only the compressed or decompressed variant returned
-by the origin. Enabled by default.
+When set to ``true``, |TS| caches the compressed (transformed) response when
+the client sends ``Accept-Encoding``. When set to ``false``, |TS| caches only
+the uncompressed (untransformed) response and compresses on-the-fly from cache
+for subsequent requests. In both cases, the plugin adds
+``Vary: Accept-Encoding`` to compressible responses, which causes |TS| to
+maintain separate :term:`alternates <alternate>` for compressed and uncompressed
+variants as different clients make requests. Enabled by default.
 
 range-request
 -------------

--- a/plugins/compress/sample.compress.config
+++ b/plugins/compress/sample.compress.config
@@ -25,7 +25,8 @@
 # - for when the proxy parses responses, and the resulting compression/decompression
 #   is wasteful
 #
-# cache: when set, the plugin stores the uncompressed and compressed response as alternates
+# cache: when true, caches the compressed response; when false, caches only the uncompressed
+#   response and compresses on-the-fly from cache. Vary: Accept-Encoding handles alternates.
 #
 # compressible-content-type: wildcard pattern for matching compressible content types
 #


### PR DESCRIPTION
### Problem
The compress plugin documentation described `cache true`/`cache false` behavior incorrectly, which could lead operators to expect the wrong cache representation.

### Changes
- **Correct cache semantics** -- clarifies that `cache true` stores the compressed transformed response, while `cache false` stores only the uncompressed response and compresses on cache hits.
- **Clarify alternate keying** -- explains that `Vary: Accept-Encoding` creates separate cache alternates/keys by request header value, while stored body representation still depends on `cache`.
- **Align sample config comment** -- updates `sample.compress.config` comments to match actual plugin behavior.

### Testing
- [x] Reviewed plugin cache-path logic in `plugins/compress/compress.cc` (`compress_transform_add`).
- [x] Verified behavior with gzip and non-gzip clients on ATS 11.0.0 ASAN build.

Fixes: #8989

<!-- merge-description-updated:2026-03-09T23:34:02Z -->