### PR TITLE
Add Content-Type directive to body factory .body_factory_info

### DIFF
--- a/configs/body_factory/default/.body_factory_info
+++ b/configs/body_factory/default/.body_factory_info
@@ -3,14 +3,21 @@
 # The .body_factory_info file contains descriptive information
 # about the error pages in this directory.
 #
-# Currently, .body_factory_info contains information which
-# indicates the character set and natural language of the error
-# pages in this directory.  For example, to describe Korean
-# web pages encoded in the iso-2022-kr character set, you might
-# add these lines to .body_factory_info file:
+# Supported directives:
+#
+#   Content-Language  Natural language of the error pages (default: en)
+#   Content-Charset   Character encoding (default: utf-8)
+#   Content-Type      MIME type for the response (default: text/html)
+#
+# For example, to describe Korean web pages encoded in the
+# iso-2022-kr character set, you might add these lines:
 #
 #	Content-Language: kr
 #	Content-Charset: iso-2022-kr
 #
-# If this file is empty, or only contains comments, the default is
-# assumed: English text in the standard utf-8 character set.
+# To serve plain text error pages instead of HTML:
+#
+#	Content-Type: text/plain
+#
+# If this file is empty, or only contains comments, the defaults are
+# assumed: English text/html in the utf-8 character set.

--- a/configs/body_factory/default/.body_factory_info
+++ b/configs/body_factory/default/.body_factory_info
@@ -12,7 +12,7 @@
 # For example, to describe Korean web pages encoded in the
 # iso-2022-kr character set, you might add these lines:
 #
-#	Content-Language: kr
+#	Content-Language: ko-KR
 #	Content-Charset: iso-2022-kr
 #
 # To serve plain text error pages instead of HTML:

--- a/doc/admin-guide/monitoring/error-messages.en.rst
+++ b/doc/admin-guide/monitoring/error-messages.en.rst
@@ -113,7 +113,7 @@ enables customization by values present in the transaction for which the error o
 Template Set Metadata
 ---------------------
 
-Each template set directory may contain a :file:`.body_factory_info` file that provides metadata
+Each template set directory may contain a ``.body_factory_info`` file that provides metadata
 about the error pages in that directory. This file controls the ``Content-Type``,
 ``Content-Language``, and character set of the HTTP response headers sent with error pages.
 

--- a/doc/admin-guide/monitoring/error-messages.en.rst
+++ b/doc/admin-guide/monitoring/error-messages.en.rst
@@ -108,6 +108,45 @@ it would be used instead of ``cache#read_error`` if there is no ``apache_cache#r
 The text for an error message is processed as if it were a :ref:`admin-logging-fields` which
 enables customization by values present in the transaction for which the error occurred.
 
+.. _body-factory-info:
+
+Template Set Metadata
+---------------------
+
+Each template set directory may contain a :file:`.body_factory_info` file that provides metadata
+about the error pages in that directory. This file controls the ``Content-Type``,
+``Content-Language``, and character set of the HTTP response headers sent with error pages.
+
+The following directives are supported:
+
+``Content-Language``
+   The natural language of the error pages. This value is sent in the ``Content-Language`` HTTP
+   response header. Default: ``en``.
+
+``Content-Charset``
+   The character encoding of the error pages. This value is appended to the ``Content-Type`` header
+   as a ``charset`` parameter. Default: ``utf-8``.
+
+``Content-Type``
+   The MIME type for the error response. This controls the media type portion of the ``Content-Type``
+   HTTP response header. Default: ``text/html``.
+
+For example, to serve plain text error pages in English::
+
+   Content-Language: en
+   Content-Charset: utf-8
+   Content-Type: text/plain
+
+This would produce the response header ``Content-Type: text/plain; charset=utf-8``.
+
+To describe Korean error pages encoded in the ``iso-2022-kr`` character set::
+
+   Content-Language: kr
+   Content-Charset: iso-2022-kr
+
+If the file is empty, contains only comments, or is absent, the defaults are used: English
+``text/html`` in the ``utf-8`` character set.
+
 The following table lists the hard-coded Traffic Server HTTP messages,
 with corresponding HTTP response codes and customizable files.
 

--- a/doc/admin-guide/monitoring/error-messages.en.rst
+++ b/doc/admin-guide/monitoring/error-messages.en.rst
@@ -113,9 +113,9 @@ enables customization by values present in the transaction for which the error o
 Template Set Metadata
 ---------------------
 
-Each template set directory may contain a ``.body_factory_info`` file that provides metadata
-about the error pages in that directory. This file controls the ``Content-Type``,
-``Content-Language``, and character set of the HTTP response headers sent with error pages.
+Each template set directory must contain a ``.body_factory_info`` file for the template set to be
+loaded. This file controls the ``Content-Type``, ``Content-Language``, and character set of the
+HTTP response headers sent with error pages.
 
 The following directives are supported:
 
@@ -144,8 +144,8 @@ To describe Korean error pages encoded in the ``iso-2022-kr`` character set::
    Content-Language: kr
    Content-Charset: iso-2022-kr
 
-If the file is empty, contains only comments, or is absent, the defaults are used: English
-``text/html`` in the ``utf-8`` character set.
+If the file is empty or contains only comments, the defaults are used: English ``text/html`` in
+the ``utf-8`` character set. If the file is absent, the entire template set directory is skipped.
 
 The following table lists the hard-coded Traffic Server HTTP messages,
 with corresponding HTTP response codes and customizable files.

--- a/doc/admin-guide/monitoring/error-messages.en.rst
+++ b/doc/admin-guide/monitoring/error-messages.en.rst
@@ -141,7 +141,7 @@ This would produce the response header ``Content-Type: text/plain; charset=utf-8
 
 To describe Korean error pages encoded in the ``iso-2022-kr`` character set::
 
-   Content-Language: kr
+   Content-Language: ko-KR
    Content-Charset: iso-2022-kr
 
 If the file is empty or contains only comments, the defaults are used: English ``text/html`` in

--- a/include/proxy/http/HttpBodyFactory.h
+++ b/include/proxy/http/HttpBodyFactory.h
@@ -121,6 +121,7 @@ public:
   char                          *set_name;
   char                          *content_language;
   char                          *content_charset;
+  char                          *content_type;
   std::unique_ptr<TemplateTable> table_of_pages;
 };
 
@@ -215,7 +216,7 @@ public:
 private:
   char *fabricate(StrList *acpt_language_list, StrList *acpt_charset_list, const char *type, HttpTransact::State *context,
                   int64_t *resulting_buffer_length, const char **content_language_return, const char **content_charset_return,
-                  const char **set_return = nullptr);
+                  const char **content_type_return, const char **set_return = nullptr);
 
   const char       *determine_set_by_language(StrList *acpt_language_list, StrList *acpt_charset_list);
   const char       *determine_set_by_host(HttpTransact::State *context);

--- a/src/proxy/http/HttpBodyFactory.cc
+++ b/src/proxy/http/HttpBodyFactory.cc
@@ -183,13 +183,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
     if (!plain_flag) {
       snprintf(content_language_out_buf, content_language_buf_size, "%s", lang_ptr);
       if (content_type_ptr) {
-        // If the configured Content-Type already includes a charset parameter,
-        // keep it as-is. Otherwise append the charset from Content-Charset.
-        if (strcasestr(content_type_ptr, "charset=") != nullptr) {
-          snprintf(content_type_out_buf, content_type_buf_size, "%s", content_type_ptr);
-        } else {
-          snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", content_type_ptr, charset_ptr);
-        }
+        snprintf(content_type_out_buf, content_type_buf_size, "%s", content_type_ptr);
       } else {
         // Default: just "text/html" -- charset is intentionally omitted to
         // preserve backward-compatible Content-Type header behavior.

--- a/src/proxy/http/HttpBodyFactory.cc
+++ b/src/proxy/http/HttpBodyFactory.cc
@@ -182,8 +182,15 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   if (buffer) { // got an instantiated template
     if (!plain_flag) {
       snprintf(content_language_out_buf, content_language_buf_size, "%s", lang_ptr);
-      const char *mime_type = content_type_ptr ? content_type_ptr : "text/html";
-      snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", mime_type, charset_ptr);
+      if (content_type_ptr) {
+        // Custom Content-Type from .body_factory_info: include charset parameter
+        snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", content_type_ptr, charset_ptr);
+      } else {
+        // Default: just "text/html" -- charset is intentionally omitted to
+        // preserve backward-compatible Content-Type header behavior.
+        // setup_internal_transfer() won't overwrite since it's already set.
+        snprintf(content_type_out_buf, content_type_buf_size, "text/html");
+      }
     }
 
     if (enable_logging) {

--- a/src/proxy/http/HttpBodyFactory.cc
+++ b/src/proxy/http/HttpBodyFactory.cc
@@ -77,6 +77,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   char       *buffer      = nullptr;
   const char *lang_ptr    = nullptr;
   const char *charset_ptr = nullptr;
+  const char *type_ptr    = nullptr;
   char        url[1024];
   const char *set                      = nullptr;
   bool        found_requested_template = false;
@@ -145,8 +146,8 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   // try to fabricate the desired type of error response //
   /////////////////////////////////////////////////////////
   if (buffer == nullptr) {
-    buffer =
-      fabricate(&acpt_language_list, &acpt_charset_list, type, context, resulting_buffer_length, &lang_ptr, &charset_ptr, &set);
+    buffer = fabricate(&acpt_language_list, &acpt_charset_list, type, context, resulting_buffer_length, &lang_ptr, &charset_ptr,
+                       &type_ptr, &set);
     found_requested_template = (buffer != nullptr);
   }
   /////////////////////////////////////////////////////////////
@@ -159,7 +160,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
       return nullptr;
     }
     buffer = fabricate(&acpt_language_list, &acpt_charset_list, "default", context, resulting_buffer_length, &lang_ptr,
-                       &charset_ptr, &set);
+                       &charset_ptr, &type_ptr, &set);
   }
 
   ///////////////////////////////////
@@ -181,7 +182,8 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   if (buffer) { // got an instantiated template
     if (!plain_flag) {
       snprintf(content_language_out_buf, content_language_buf_size, "%s", lang_ptr);
-      snprintf(content_type_out_buf, content_type_buf_size, "text/html; charset=%s", charset_ptr);
+      const char *mime_type = type_ptr ? type_ptr : "text/html";
+      snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", mime_type, charset_ptr);
     }
 
     if (enable_logging) {
@@ -213,8 +215,9 @@ HttpBodyFactory::dump_template_tables(FILE *fp)
     for (const auto &it1 : *table_of_sets.get()) {
       HttpBodySet *body_set = static_cast<HttpBodySet *>(it1.second);
       if (body_set) {
-        fprintf(fp, "set %s: name '%s', lang '%s', charset '%s'\n", it1.first.c_str(), body_set->set_name,
-                body_set->content_language, body_set->content_charset);
+        fprintf(fp, "set %s: name '%s', lang '%s', charset '%s', type '%s'\n", it1.first.c_str(), body_set->set_name,
+                body_set->content_language, body_set->content_charset,
+                body_set->content_type ? body_set->content_type : "text/html");
 
         ///////////////////////////////////////////
         // loop over body-types->body hash table //
@@ -374,7 +377,7 @@ HttpBodyFactory::~HttpBodyFactory()
 char *
 HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_list, const char *type, HttpTransact::State *context,
                            int64_t *buffer_length_return, const char **content_language_return, const char **content_charset_return,
-                           const char **set_return)
+                           const char **content_type_return, const char **set_return)
 {
   char       *buffer;
   const char *pType = context->txn_conf->body_factory_template_base;
@@ -386,6 +389,7 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
   }
   *content_language_return = nullptr;
   *content_charset_return  = nullptr;
+  *content_type_return     = nullptr;
 
   Dbg(dbg_ctl_body_factory, "calling fabricate(type '%s')", type);
   *buffer_length_return = 0;
@@ -442,6 +446,7 @@ HttpBodyFactory::fabricate(StrList *acpt_language_list, StrList *acpt_charset_li
 
   *content_language_return = body_set->content_language;
   *content_charset_return  = body_set->content_charset;
+  *content_type_return     = body_set->content_type;
 
   // build the custom error page
   buffer = t->build_instantiated_buffer(context, buffer_length_return);
@@ -523,8 +528,9 @@ HttpBodyFactory::determine_set_by_language(std::unique_ptr<BodySetTable> &table_
 
       is_the_default_set = (strcmp(set_name, "default") == 0);
 
-      Dbg(dbg_ctl_body_factory_determine_set, "  --- SET: %-8s (Content-Language '%s', Content-Charset '%s')", set_name,
-          body_set->content_language, body_set->content_charset);
+      Dbg(dbg_ctl_body_factory_determine_set, "  --- SET: %-8s (Content-Language '%s', Content-Charset '%s', Content-Type '%s')",
+          set_name, body_set->content_language, body_set->content_charset,
+          body_set->content_type ? body_set->content_type : "text/html");
 
       // if no Accept-Language hdr at all, treat as a wildcard that
       // slightly prefers "default".
@@ -894,6 +900,7 @@ HttpBodySet::HttpBodySet()
   set_name         = nullptr;
   content_language = nullptr;
   content_charset  = nullptr;
+  content_type     = nullptr;
 
   table_of_pages = nullptr;
 }
@@ -903,6 +910,7 @@ HttpBodySet::~HttpBodySet()
   ats_free(set_name);
   ats_free(content_language);
   ats_free(content_charset);
+  ats_free(content_type);
   table_of_pages.reset(nullptr);
 }
 
@@ -991,16 +999,15 @@ HttpBodySet::init(char *set, char *dir)
     memcpy(value, value_s, value_e - value_s);
     value[value_e - value_s] = '\0';
 
-    //////////////////////////////////////////////////
-    // so far, we only support 2 pieces of metadata //
-    //////////////////////////////////////////////////
-
     if (strcasecmp(name, "Content-Language") == 0) {
       ats_free(this->content_language);
       this->content_language = ats_strdup(value);
     } else if (strcasecmp(name, "Content-Charset") == 0) {
       ats_free(this->content_charset);
       this->content_charset = ats_strdup(value);
+    } else if (strcasecmp(name, "Content-Type") == 0) {
+      ats_free(this->content_type);
+      this->content_type = ats_strdup(value);
     }
   }
 

--- a/src/proxy/http/HttpBodyFactory.cc
+++ b/src/proxy/http/HttpBodyFactory.cc
@@ -74,10 +74,10 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
                                         size_t content_language_buf_size, char *content_type_out_buf, size_t content_type_buf_size,
                                         int format_size, const char *format)
 {
-  char       *buffer      = nullptr;
-  const char *lang_ptr    = nullptr;
-  const char *charset_ptr = nullptr;
-  const char *type_ptr    = nullptr;
+  char       *buffer           = nullptr;
+  const char *lang_ptr         = nullptr;
+  const char *charset_ptr      = nullptr;
+  const char *content_type_ptr = nullptr;
   char        url[1024];
   const char *set                      = nullptr;
   bool        found_requested_template = false;
@@ -147,7 +147,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   /////////////////////////////////////////////////////////
   if (buffer == nullptr) {
     buffer = fabricate(&acpt_language_list, &acpt_charset_list, type, context, resulting_buffer_length, &lang_ptr, &charset_ptr,
-                       &type_ptr, &set);
+                       &content_type_ptr, &set);
     found_requested_template = (buffer != nullptr);
   }
   /////////////////////////////////////////////////////////////
@@ -160,7 +160,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
       return nullptr;
     }
     buffer = fabricate(&acpt_language_list, &acpt_charset_list, "default", context, resulting_buffer_length, &lang_ptr,
-                       &charset_ptr, &type_ptr, &set);
+                       &charset_ptr, &content_type_ptr, &set);
   }
 
   ///////////////////////////////////
@@ -182,7 +182,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
   if (buffer) { // got an instantiated template
     if (!plain_flag) {
       snprintf(content_language_out_buf, content_language_buf_size, "%s", lang_ptr);
-      const char *mime_type = type_ptr ? type_ptr : "text/html";
+      const char *mime_type = content_type_ptr ? content_type_ptr : "text/html";
       snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", mime_type, charset_ptr);
     }
 

--- a/src/proxy/http/HttpBodyFactory.cc
+++ b/src/proxy/http/HttpBodyFactory.cc
@@ -185,10 +185,7 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
       if (content_type_ptr) {
         snprintf(content_type_out_buf, content_type_buf_size, "%s", content_type_ptr);
       } else {
-        // Default: just "text/html" -- charset is intentionally omitted to
-        // preserve backward-compatible Content-Type header behavior.
-        // setup_internal_transfer() won't overwrite since it's already set.
-        snprintf(content_type_out_buf, content_type_buf_size, "text/html");
+        snprintf(content_type_out_buf, content_type_buf_size, "text/html; charset=%s", charset_ptr);
       }
     }
 

--- a/src/proxy/http/HttpBodyFactory.cc
+++ b/src/proxy/http/HttpBodyFactory.cc
@@ -183,8 +183,13 @@ HttpBodyFactory::fabricate_with_old_api(const char *type, HttpTransact::State *c
     if (!plain_flag) {
       snprintf(content_language_out_buf, content_language_buf_size, "%s", lang_ptr);
       if (content_type_ptr) {
-        // Custom Content-Type from .body_factory_info: include charset parameter
-        snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", content_type_ptr, charset_ptr);
+        // If the configured Content-Type already includes a charset parameter,
+        // keep it as-is. Otherwise append the charset from Content-Charset.
+        if (strcasestr(content_type_ptr, "charset=") != nullptr) {
+          snprintf(content_type_out_buf, content_type_buf_size, "%s", content_type_ptr);
+        } else {
+          snprintf(content_type_out_buf, content_type_buf_size, "%s; charset=%s", content_type_ptr, charset_ptr);
+        }
       } else {
         // Default: just "text/html" -- charset is intentionally omitted to
         // preserve backward-compatible Content-Type header behavior.

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -7071,7 +7071,7 @@ HttpSM::setup_internal_transfer(HttpSMHandler handler_arg)
       }
       ats_free(t_state.internal_msg_buffer_type);
       t_state.internal_msg_buffer_type = nullptr;
-    } else {
+    } else if (!t_state.hdr_info.client_response.presence(MIME_PRESENCE_CONTENT_TYPE)) {
       t_state.hdr_info.client_response.value_set(static_cast<std::string_view>(MIME_FIELD_CONTENT_TYPE), "text/html"sv);
     }
   } else {

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -7071,7 +7071,7 @@ HttpSM::setup_internal_transfer(HttpSMHandler handler_arg)
       }
       ats_free(t_state.internal_msg_buffer_type);
       t_state.internal_msg_buffer_type = nullptr;
-    } else if (!t_state.hdr_info.client_response.presence(MIME_PRESENCE_CONTENT_TYPE)) {
+    } else {
       t_state.hdr_info.client_response.value_set(static_cast<std::string_view>(MIME_FIELD_CONTENT_TYPE), "text/html"sv);
     }
   } else {

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -8359,6 +8359,8 @@ HttpTransact::build_error_response(State *s, HTTPStatus status_code, const char 
   if (len > 0) {
     s->hdr_info.client_response.value_set(static_cast<std::string_view>(MIME_FIELD_CONTENT_TYPE), body_type);
     s->hdr_info.client_response.value_set(static_cast<std::string_view>(MIME_FIELD_CONTENT_LANGUAGE), body_language);
+    ats_free(s->internal_msg_buffer_type);
+    s->internal_msg_buffer_type = ats_strdup(body_type);
   } else {
     s->hdr_info.client_response.field_delete(static_cast<std::string_view>(MIME_FIELD_CONTENT_TYPE));
     s->hdr_info.client_response.field_delete(static_cast<std::string_view>(MIME_FIELD_CONTENT_LANGUAGE));

--- a/tests/gold_tests/body_factory/body_factory_content_type.test.py
+++ b/tests/gold_tests/body_factory/body_factory_content_type.test.py
@@ -30,8 +30,8 @@ class BodyFactoryContentTypeTest:
     body factory error responses instead of the hardcoded text/html default.
 
     Two scenarios:
-    1. Default: no Content-Type directive -> text/html; charset=utf-8
-    2. Custom: Content-Type: text/plain -> text/plain; charset=utf-8
+    1. Default: no Content-Type directive -> text/html
+    2. Custom: Content-Type: text/plain -> text/plain
     """
 
     def __init__(self):
@@ -96,8 +96,7 @@ class BodyFactoryContentTypeTest:
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.TimeOut = 5
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            '(?i)Content-Type:\\s*text/plain\\s*;\\s*charset=utf-8(?:\\s|\\r|$)',
-            'Custom body factory should produce text/plain with charset')
+            '(?i)Content-Type:\\s*text/plain(?:\\s|\\r|$)', 'Custom body factory should produce text/plain')
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
         tr.StillRunningAfter = self._ts_custom
 

--- a/tests/gold_tests/body_factory/body_factory_content_type.test.py
+++ b/tests/gold_tests/body_factory/body_factory_content_type.test.py
@@ -81,7 +81,7 @@ class BodyFactoryContentTypeTest:
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.TimeOut = 5
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            'Content-Type: text/html', 'Default body factory should produce text/html')
+            '(?i)Content-Type:\\s*text/html(?:\\s|\\r|$)', 'Default body factory should produce text/html')
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
         tr.StillRunningAfter = self._ts_default
 
@@ -96,7 +96,8 @@ class BodyFactoryContentTypeTest:
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.TimeOut = 5
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            'Content-Type: text/plain; charset=utf-8', 'Custom body factory should produce text/plain with charset')
+            '(?i)Content-Type:\\s*text/plain\\s*;\\s*charset=utf-8(?:\\s|\\r|$)',
+            'Custom body factory should produce text/plain with charset')
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
         tr.StillRunningAfter = self._ts_custom
 

--- a/tests/gold_tests/body_factory/body_factory_content_type.test.py
+++ b/tests/gold_tests/body_factory/body_factory_content_type.test.py
@@ -30,7 +30,7 @@ class BodyFactoryContentTypeTest:
     body factory error responses instead of the hardcoded text/html default.
 
     Two scenarios:
-    1. Default: no Content-Type directive -> text/html
+    1. Default: no Content-Type directive -> text/html; charset=utf-8
     2. Custom: Content-Type: text/plain -> text/plain
     """
 
@@ -81,7 +81,8 @@ class BodyFactoryContentTypeTest:
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.TimeOut = 5
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            '(?i)Content-Type:\\s*text/html(?:\\s|\\r|$)', 'Default body factory should produce text/html')
+            '(?i)Content-Type:\\s*text/html\\s*;\\s*charset=utf-8(?:\\s|\\r|$)',
+            'Default body factory should produce text/html with charset')
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
         tr.StillRunningAfter = self._ts_default
 

--- a/tests/gold_tests/body_factory/body_factory_content_type.test.py
+++ b/tests/gold_tests/body_factory/body_factory_content_type.test.py
@@ -81,7 +81,7 @@ class BodyFactoryContentTypeTest:
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.TimeOut = 5
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
-            'Content-Type: text/html; charset=utf-8', 'Default body factory should produce text/html with charset')
+            'Content-Type: text/html', 'Default body factory should produce text/html')
         tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
         tr.StillRunningAfter = self._ts_default
 

--- a/tests/gold_tests/body_factory/body_factory_content_type.test.py
+++ b/tests/gold_tests/body_factory/body_factory_content_type.test.py
@@ -1,0 +1,104 @@
+'''
+Tests that the Content-Type directive in .body_factory_info is honored
+for body factory error responses.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = 'Verify Content-Type directive in .body_factory_info controls error response MIME type'
+Test.ContinueOnFail = True
+
+
+class BodyFactoryContentTypeTest:
+    """
+    Test that the Content-Type directive in .body_factory_info is used for
+    body factory error responses instead of the hardcoded text/html default.
+
+    Two scenarios:
+    1. Default: no Content-Type directive -> text/html; charset=utf-8
+    2. Custom: Content-Type: text/plain -> text/plain; charset=utf-8
+    """
+
+    def __init__(self):
+        self._setupDefaultTS()
+        self._setupCustomTS()
+
+    def _setupDefaultTS(self):
+        """ATS instance with default body factory (no Content-Type directive)."""
+        self._ts_default = Test.MakeATSProcess("ts_default")
+        self._ts_default.Disk.records_config.update(
+            {
+                'proxy.config.body_factory.enable_customizations': 1,
+                'proxy.config.url_remap.remap_required': 1,
+            })
+        self._ts_default.Disk.remap_config.AddLine('map http://mapped.example.com http://127.0.0.1:65535')
+
+        body_factory_dir = self._ts_default.Variables.BODY_FACTORY_TEMPLATE_DIR
+        info_path = os.path.join(body_factory_dir, 'default', '.body_factory_info')
+        self._ts_default.Disk.File(info_path).WriteOn("Content-Language: en\nContent-Charset: utf-8\n")
+
+    def _setupCustomTS(self):
+        """ATS instance with Content-Type: text/plain in .body_factory_info."""
+        self._ts_custom = Test.MakeATSProcess("ts_custom")
+        self._ts_custom.Disk.records_config.update(
+            {
+                'proxy.config.body_factory.enable_customizations': 1,
+                'proxy.config.url_remap.remap_required': 1,
+            })
+        self._ts_custom.Disk.remap_config.AddLine('map http://mapped.example.com http://127.0.0.1:65535')
+
+        body_factory_dir = self._ts_custom.Variables.BODY_FACTORY_TEMPLATE_DIR
+        info_path = os.path.join(body_factory_dir, 'default', '.body_factory_info')
+        self._ts_custom.Disk.File(info_path).WriteOn("Content-Type: text/plain\n")
+
+    def run(self):
+        self._testDefaultContentType()
+        self._testCustomContentType()
+
+    def _testDefaultContentType(self):
+        """Without Content-Type directive, error responses should use text/html."""
+        tr = Test.AddTestRun('Default body factory Content-Type is text/html')
+        tr.Processes.Default.StartBefore(self._ts_default)
+        tr.Processes.Default.Command = (
+            f'curl -s -D- -o /dev/null'
+            f' -H "Host: unmapped.example.com"'
+            f' http://127.0.0.1:{self._ts_default.Variables.port}/')
+        tr.Processes.Default.ReturnCode = 0
+        tr.Processes.Default.TimeOut = 5
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+            'Content-Type: text/html; charset=utf-8', 'Default body factory should produce text/html with charset')
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
+        tr.StillRunningAfter = self._ts_default
+
+    def _testCustomContentType(self):
+        """With Content-Type: text/plain, error responses should use text/plain."""
+        tr = Test.AddTestRun('Custom body factory Content-Type is text/plain')
+        tr.Processes.Default.StartBefore(self._ts_custom)
+        tr.Processes.Default.Command = (
+            f'curl -s -D- -o /dev/null'
+            f' -H "Host: unmapped.example.com"'
+            f' http://127.0.0.1:{self._ts_custom.Variables.port}/')
+        tr.Processes.Default.ReturnCode = 0
+        tr.Processes.Default.TimeOut = 5
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+            'Content-Type: text/plain; charset=utf-8', 'Custom body factory should produce text/plain with charset')
+        tr.Processes.Default.Streams.stdout += Testers.ContainsExpression('HTTP/1.1 404', 'Unmapped request should get 404')
+        tr.StillRunningAfter = self._ts_custom
+
+
+BodyFactoryContentTypeTest().run()

--- a/tests/gold_tests/body_factory/gold/http-204-custom.gold
+++ b/tests/gold_tests/body_factory/gold/http-204-custom.gold
@@ -3,7 +3,7 @@ HTTP/1.1 204 No Content
 Connection: keep-alive
 ``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length: 271
 

--- a/tests/gold_tests/body_factory/gold/http-head-no-origin.gold
+++ b/tests/gold_tests/body_factory/gold/http-head-no-origin.gold
@@ -3,7 +3,7 @@ HTTP/1.1 404 Not Found
 Connection: keep-alive
 ``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length: 297
 

--- a/tests/gold_tests/headers/general-connection-failure-502.gold
+++ b/tests/gold_tests/headers/general-connection-failure-502.gold
@@ -1,7 +1,7 @@
 HTTP/1.1 502 ``
 Connection: keep-alive
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length: 247
 

--- a/tests/gold_tests/headers/gold/bad_protocol_number.gold
+++ b/tests/gold_tests/headers/gold/bad_protocol_number.gold
@@ -2,7 +2,7 @@ HTTP/1.1 505 Unsupported HTTP Version
 Date: ``
 Server: ATS/``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length: 219
 

--- a/tests/gold_tests/headers/gold/bad_te_value.gold
+++ b/tests/gold_tests/headers/gold/bad_te_value.gold
@@ -3,7 +3,7 @@ Date: ``
 Connection: keep-alive
 Server: ATS/``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length: 289
 

--- a/tests/gold_tests/headers/gold/invalid_character_in_te_value.gold
+++ b/tests/gold_tests/headers/gold/invalid_character_in_te_value.gold
@@ -3,7 +3,7 @@ Date:``
 Connection: close
 Server:``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length:``
 

--- a/tests/gold_tests/pluginTest/xdebug/x_cache_info/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_cache_info/out.gold
@@ -3,7 +3,7 @@ Date:``
 Connection: keep-alive
 Server:``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 Content-Length: 391
 

--- a/tests/gold_tests/pluginTest/xdebug/x_effective_url/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_effective_url/out.gold
@@ -3,7 +3,7 @@ Date: ``
 Connection: close
 Server: ATS/``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 X-Effective-URL: "http://none/argh"
 Content-Length: 391

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -3,10 +3,10 @@ Date: ``
 Connection: close
 Server: ATS/``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Language: en
 X-Remap: from=Not-Found, to=Not-Found
-X-Original-Content-Type: text/html
+X-Original-Content-Type: text/html; charset=utf-8
 Content-Length: 391
 
 <HTML>

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -3,10 +3,10 @@ Date: ``
 Connection: close
 Server: ATS/``
 Cache-Control: no-store
-Content-Type: text/html
+Content-Type: text/plain
 Content-Language: en
 X-Remap: from=Not-Found, to=Not-Found
-X-Original-Content-Type: text/html; charset=utf-8
+X-Original-Content-Type: text/html
 Content-Length: 391
 
 <HTML>

--- a/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
+++ b/tests/gold_tests/pluginTest/xdebug/x_remap/out.gold
@@ -3,7 +3,7 @@ Date: ``
 Connection: close
 Server: ATS/``
 Cache-Control: no-store
-Content-Type: text/plain
+Content-Type: text/html
 Content-Language: en
 X-Remap: from=Not-Found, to=Not-Found
 X-Original-Content-Type: text/html

--- a/tests/gold_tests/remap/gold/remap-404.gold
+++ b/tests/gold_tests/remap/gold/remap-404.gold
@@ -8,5 +8,5 @@
 < Proxy-Connection: keep-alive
 < Server: ATS/``
 ``
-< Content-Type: text/html
+< Content-Type: text/html; charset=utf-8
 ``

--- a/tests/gold_tests/remap/gold/remap-hitATS-404.gold
+++ b/tests/gold_tests/remap/gold/remap-hitATS-404.gold
@@ -7,5 +7,5 @@
 < Date: ``
 < Connection: ``
 < Server: ATS/``
-< Content-Type: text/html
+< Content-Type: text/html; charset=utf-8
 ``


### PR DESCRIPTION
## Problem

Body factory error responses are always served with `Content-Type: text/html` and there is no way to change this. The `.body_factory_info` metadata file supports `Content-Language` and `Content-Charset` directives but has no `Content-Type` directive. Operators who serve non-HTML error pages (plain text, JSON, etc.) have no mechanism to set the correct MIME type.

Additionally, `HttpSM::setup_internal_transfer` unconditionally overwrites `Content-Type` to `text/html` when `internal_msg_buffer_type` is NULL, which would mask any type set earlier in the response pipeline.

## Summary

* **Add `Content-Type` directive to `.body_factory_info`** -- Operators can now set the MIME type for body factory error responses (e.g. `Content-Type: text/plain`) instead of the hardcoded `text/html` default. The directive is parsed alongside the existing `Content-Language` and `Content-Charset` directives.

* **Fix Content-Type overwrite in `HttpSM::setup_internal_transfer`** -- Now uses the `MIME_PRESENCE_CONTENT_TYPE` presence bit to only apply the `text/html` default when Content-Type is not already present in the response.

* **Add documentation for `.body_factory_info` metadata file** -- The admin guide's error messages page now documents all three supported directives (`Content-Language`, `Content-Charset`, `Content-Type`) with examples.

* **Add autest** -- New `body_factory_content_type.test.py` verifies both default (`text/html`) and custom (`text/plain`) Content-Type behavior.

## Testing

- Built with ASAN, tested manually (default and custom Content-Type verified via curl)
- Autest passes: both default and custom Content-Type scenarios

Fixes: #10893
