### PR TITLE
Fix header_rewrite MaxMind geo lookups for GeoIP2/GeoLite2 mmdb databases

### DIFF
--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -60,6 +60,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_header_rewrite PRIVATE header_rewrite_parser ts::inkevent ts::tscore)
 
   if(maxminddb_FOUND)
+    target_compile_definitions(test_header_rewrite PRIVATE TS_USE_HRW_MAXMINDDB=1)
     target_link_libraries(test_header_rewrite PRIVATE maxminddb::maxminddb)
   endif()
 

--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -62,6 +62,32 @@ if(BUILD_TESTING)
   if(maxminddb_FOUND)
     target_compile_definitions(test_header_rewrite PRIVATE TS_USE_HRW_MAXMINDDB=1)
     target_link_libraries(test_header_rewrite PRIVATE maxminddb::maxminddb)
+
+    find_package(
+      Python3
+      COMPONENTS Interpreter
+      QUIET
+    )
+    if(Python3_FOUND)
+      set(_mmdb_test_dir "${CMAKE_CURRENT_BINARY_DIR}/test_mmdb")
+      add_custom_command(
+        OUTPUT "${_mmdb_test_dir}/test_flat_geo.mmdb" "${_mmdb_test_dir}/test_nested_geo.mmdb"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${_mmdb_test_dir}"
+        COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_mmdb.py" "${_mmdb_test_dir}"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_mmdb.py"
+        COMMENT "Generating test MMDB files for header_rewrite"
+      )
+      add_custom_target(
+        generate_test_mmdb DEPENDS "${_mmdb_test_dir}/test_flat_geo.mmdb" "${_mmdb_test_dir}/test_nested_geo.mmdb"
+      )
+      add_dependencies(test_header_rewrite generate_test_mmdb)
+      set_tests_properties(
+        test_header_rewrite
+        PROPERTIES
+          ENVIRONMENT
+          "MMDB_TEST_FLAT=${_mmdb_test_dir}/test_flat_geo.mmdb;MMDB_TEST_NESTED=${_mmdb_test_dir}/test_nested_geo.mmdb"
+      )
+    endif()
   endif()
 
   # This test has linker issue when cripts is enabled, so its commented for now

--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -69,24 +69,33 @@ if(BUILD_TESTING)
       QUIET
     )
     if(Python3_FOUND)
-      set(_mmdb_test_dir "${CMAKE_CURRENT_BINARY_DIR}/test_mmdb")
-      add_custom_command(
-        OUTPUT "${_mmdb_test_dir}/test_flat_geo.mmdb" "${_mmdb_test_dir}/test_nested_geo.mmdb"
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${_mmdb_test_dir}"
-        COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_mmdb.py" "${_mmdb_test_dir}"
-        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_mmdb.py"
-        COMMENT "Generating test MMDB files for header_rewrite"
+      execute_process(
+        COMMAND "${Python3_EXECUTABLE}" -c "import mmdb_writer; import netaddr"
+        RESULT_VARIABLE _mmdb_python_result
+        OUTPUT_QUIET ERROR_QUIET
       )
-      add_custom_target(
-        generate_test_mmdb DEPENDS "${_mmdb_test_dir}/test_flat_geo.mmdb" "${_mmdb_test_dir}/test_nested_geo.mmdb"
-      )
-      add_dependencies(test_header_rewrite generate_test_mmdb)
-      set_tests_properties(
-        test_header_rewrite
-        PROPERTIES
-          ENVIRONMENT
-          "MMDB_TEST_FLAT=${_mmdb_test_dir}/test_flat_geo.mmdb;MMDB_TEST_NESTED=${_mmdb_test_dir}/test_nested_geo.mmdb"
-      )
+      if(_mmdb_python_result EQUAL 0)
+        set(_mmdb_test_dir "${CMAKE_CURRENT_BINARY_DIR}/test_mmdb")
+        add_custom_command(
+          OUTPUT "${_mmdb_test_dir}/test_flat_geo.mmdb" "${_mmdb_test_dir}/test_nested_geo.mmdb"
+          COMMAND ${CMAKE_COMMAND} -E make_directory "${_mmdb_test_dir}"
+          COMMAND ${Python3_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_mmdb.py" "${_mmdb_test_dir}"
+          DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_mmdb.py"
+          COMMENT "Generating test MMDB files for header_rewrite"
+        )
+        add_custom_target(
+          generate_test_mmdb DEPENDS "${_mmdb_test_dir}/test_flat_geo.mmdb" "${_mmdb_test_dir}/test_nested_geo.mmdb"
+        )
+        add_dependencies(test_header_rewrite generate_test_mmdb)
+        set_tests_properties(
+          test_header_rewrite
+          PROPERTIES
+            ENVIRONMENT
+            "MMDB_TEST_FLAT=${_mmdb_test_dir}/test_flat_geo.mmdb;MMDB_TEST_NESTED=${_mmdb_test_dir}/test_nested_geo.mmdb"
+        )
+      else()
+        message(STATUS "Python modules 'mmdb-writer'/'netaddr' not found; skipping test MMDB generation")
+      endif()
     endif()
   endif()
 

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -51,6 +51,7 @@ MMConditionGeo::initLibrary(const std::string &path)
   if (MMDB_SUCCESS != status) {
     Dbg(pi_dbg_ctl, "Cannot open %s - %s", path.c_str(), MMDB_strerror(status));
     delete gMaxMindDB;
+    gMaxMindDB = nullptr;
     return;
   }
   Dbg(pi_dbg_ctl, "Loaded %s", path.c_str());
@@ -91,32 +92,35 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     return ret;
   }
 
-  const char *field_name;
+  MMDB_entry_data_s entry_data;
+
   switch (_geo_qual) {
   case GEO_QUAL_COUNTRY:
-    field_name = "country_code";
+    status = MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL);
+    break;
+  case GEO_QUAL_COUNTRY_ISO:
+    status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
     break;
   case GEO_QUAL_ASN_NAME:
-    field_name = "autonomous_system_organization";
+    status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_organization", NULL);
     break;
   default:
     Dbg(pi_dbg_ctl, "Unsupported field %d", _geo_qual);
-    return ret;
-    break;
-  }
-
-  MMDB_entry_data_s entry_data;
-
-  status = MMDB_get_value(&result.entry, &entry_data, field_name, NULL);
-  if (MMDB_SUCCESS != status) {
-    Dbg(pi_dbg_ctl, "ERROR on get value asn value: %s", MMDB_strerror(status));
-    return ret;
-  }
-  ret = std::string(entry_data.utf8_string, entry_data.data_size);
-
-  if (nullptr != entry_data_list) {
     MMDB_free_entry_data_list(entry_data_list);
+    return ret;
   }
+
+  if (MMDB_SUCCESS != status) {
+    Dbg(pi_dbg_ctl, "Error looking up geo string field: %s", MMDB_strerror(status));
+    MMDB_free_entry_data_list(entry_data_list);
+    return ret;
+  }
+
+  if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    ret = std::string(entry_data.utf8_string, entry_data.data_size);
+  }
+
+  MMDB_free_entry_data_list(entry_data_list);
 
   return ret;
 }
@@ -156,29 +160,29 @@ MMConditionGeo::get_geo_int(const sockaddr *addr) const
     return ret;
   }
 
-  const char *field_name;
+  MMDB_entry_data_s entry_data;
+
   switch (_geo_qual) {
   case GEO_QUAL_ASN:
-    field_name = "autonomous_system_number";
+    status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_number", NULL);
     break;
   default:
     Dbg(pi_dbg_ctl, "Unsupported field %d", _geo_qual);
-    return ret;
-    break;
-  }
-
-  MMDB_entry_data_s entry_data;
-
-  status = MMDB_get_value(&result.entry, &entry_data, field_name, NULL);
-  if (MMDB_SUCCESS != status) {
-    Dbg(pi_dbg_ctl, "ERROR on get value asn value: %s", MMDB_strerror(status));
-    return ret;
-  }
-  ret = entry_data.uint32;
-
-  if (nullptr != entry_data_list) {
     MMDB_free_entry_data_list(entry_data_list);
+    return ret;
   }
+
+  if (MMDB_SUCCESS != status) {
+    Dbg(pi_dbg_ctl, "Error looking up geo int field: %s", MMDB_strerror(status));
+    MMDB_free_entry_data_list(entry_data_list);
+    return ret;
+  }
+
+  if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32) {
+    ret = entry_data.uint32;
+  }
+
+  MMDB_free_entry_data_list(entry_data_list);
 
   return ret;
 }

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -75,30 +75,16 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     return ret;
   }
 
-  MMDB_entry_data_list_s *entry_data_list = nullptr;
   if (!result.found_entry) {
     Dbg(pi_dbg_ctl, "No entry for this IP was found");
     return ret;
   }
 
-  int status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
-  if (MMDB_SUCCESS != status) {
-    Dbg(pi_dbg_ctl, "Error looking up entry data: %s", MMDB_strerror(status));
-    return ret;
-  }
-
-  if (entry_data_list == nullptr) {
-    Dbg(pi_dbg_ctl, "No data found");
-    return ret;
-  }
-
   MMDB_entry_data_s entry_data;
+  int               status;
 
   switch (_geo_qual) {
   case GEO_QUAL_COUNTRY:
-    status = MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL);
-    break;
-  case GEO_QUAL_COUNTRY_ISO:
     status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
     break;
   case GEO_QUAL_ASN_NAME:
@@ -106,21 +92,17 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     break;
   default:
     Dbg(pi_dbg_ctl, "Unsupported field %d", _geo_qual);
-    MMDB_free_entry_data_list(entry_data_list);
     return ret;
   }
 
   if (MMDB_SUCCESS != status) {
     Dbg(pi_dbg_ctl, "Error looking up geo string field: %s", MMDB_strerror(status));
-    MMDB_free_entry_data_list(entry_data_list);
     return ret;
   }
 
   if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
     ret = std::string(entry_data.utf8_string, entry_data.data_size);
   }
-
-  MMDB_free_entry_data_list(entry_data_list);
 
   return ret;
 }
@@ -143,24 +125,13 @@ MMConditionGeo::get_geo_int(const sockaddr *addr) const
     return ret;
   }
 
-  MMDB_entry_data_list_s *entry_data_list = nullptr;
   if (!result.found_entry) {
     Dbg(pi_dbg_ctl, "No entry for this IP was found");
     return ret;
   }
 
-  int status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
-  if (MMDB_SUCCESS != status) {
-    Dbg(pi_dbg_ctl, "Error looking up entry data: %s", MMDB_strerror(status));
-    return ret;
-  }
-
-  if (entry_data_list == nullptr) {
-    Dbg(pi_dbg_ctl, "No data found");
-    return ret;
-  }
-
   MMDB_entry_data_s entry_data;
+  int               status;
 
   switch (_geo_qual) {
   case GEO_QUAL_ASN:
@@ -168,21 +139,17 @@ MMConditionGeo::get_geo_int(const sockaddr *addr) const
     break;
   default:
     Dbg(pi_dbg_ctl, "Unsupported field %d", _geo_qual);
-    MMDB_free_entry_data_list(entry_data_list);
     return ret;
   }
 
   if (MMDB_SUCCESS != status) {
     Dbg(pi_dbg_ctl, "Error looking up geo int field: %s", MMDB_strerror(status));
-    MMDB_free_entry_data_list(entry_data_list);
     return ret;
   }
 
   if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32) {
     ret = entry_data.uint32;
   }
-
-  MMDB_free_entry_data_list(entry_data_list);
 
   return ret;
 }

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -51,7 +51,7 @@ MMConditionGeo::initLibrary(const std::string &path)
   if (MMDB_SUCCESS != status) {
     Dbg(pi_dbg_ctl, "Cannot open %s - %s", path.c_str(), MMDB_strerror(status));
     delete gMaxMindDB;
-    gMaxMindDB = nullptr; // allow retry on next call instead of dangling pointer
+    gMaxMindDB = nullptr; // avoid leaving a dangling global pointer after delete
     return;
   }
   Dbg(pi_dbg_ctl, "Loaded %s", path.c_str());

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -23,7 +23,6 @@
 
 #include <unistd.h>
 #include <arpa/inet.h>
-#include <atomic>
 
 #include "ts/ts.h"
 
@@ -33,8 +32,30 @@
 
 MMDB_s *gMaxMindDB = nullptr;
 
-enum class MmdbSchema : int { UNKNOWN = 0, NESTED = 1, FLAT = 2 };
-std::atomic<MmdbSchema> gMmdbSchema{MmdbSchema::UNKNOWN};
+enum class MmdbSchema { NESTED, FLAT };
+static MmdbSchema gMmdbSchema = MmdbSchema::NESTED;
+
+// Detect whether the MMDB uses nested (GeoLite2) or flat (vendor) field layout
+// by probing for the nested country path on a lookup result.
+static MmdbSchema
+detect_schema(MMDB_entry_s *entry)
+{
+  MMDB_entry_data_s probe;
+  int               status = MMDB_get_value(entry, &probe, "country", "iso_code", NULL);
+
+  if (MMDB_SUCCESS == status && probe.has_data && probe.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    return MmdbSchema::NESTED;
+  }
+
+  status = MMDB_get_value(entry, &probe, "country_code", NULL);
+  if (MMDB_SUCCESS == status && probe.has_data && probe.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    return MmdbSchema::FLAT;
+  }
+
+  return MmdbSchema::NESTED;
+}
+
+static const char *probe_ips[] = {"8.8.8.8", "1.1.1.1", "128.0.0.1"};
 
 void
 MMConditionGeo::initLibrary(const std::string &path)
@@ -55,34 +76,23 @@ MMConditionGeo::initLibrary(const std::string &path)
   if (MMDB_SUCCESS != status) {
     Dbg(pi_dbg_ctl, "Cannot open %s - %s", path.c_str(), MMDB_strerror(status));
     delete gMaxMindDB;
-    gMaxMindDB = nullptr; // avoid leaving a dangling global pointer after delete
+    gMaxMindDB = nullptr;
     return;
   }
-  Dbg(pi_dbg_ctl, "Loaded %s", path.c_str());
-}
 
-// Detect whether the MMDB uses nested (GeoLite2) or flat (vendor) field layout
-// by probing for the nested country path on a real lookup result.  Called once
-// on the first successful lookup; result is cached in gMmdbSchema.
-static MmdbSchema
-detect_schema(MMDB_entry_s *entry)
-{
-  MMDB_entry_data_s probe;
-  int               status = MMDB_get_value(entry, &probe, "country", "iso_code", NULL);
-
-  if (MMDB_SUCCESS == status && probe.has_data && probe.type == MMDB_DATA_TYPE_UTF8_STRING) {
-    Dbg(pi_dbg_ctl, "Detected nested MMDB schema (country/iso_code)");
-    return MmdbSchema::NESTED;
+  // Probe the database schema at load time so we know which field paths to
+  // use for country lookups.  Try a few well-known IPs until one hits.
+  for (auto *ip : probe_ips) {
+    int                  gai_error, mmdb_error;
+    MMDB_lookup_result_s result = MMDB_lookup_string(gMaxMindDB, ip, &gai_error, &mmdb_error);
+    if (gai_error == 0 && MMDB_SUCCESS == mmdb_error && result.found_entry) {
+      gMmdbSchema = detect_schema(&result.entry);
+      Dbg(pi_dbg_ctl, "Loaded %s (schema: %s)", path.c_str(), gMmdbSchema == MmdbSchema::FLAT ? "flat" : "nested");
+      return;
+    }
   }
 
-  status = MMDB_get_value(entry, &probe, "country_code", NULL);
-  if (MMDB_SUCCESS == status && probe.has_data && probe.type == MMDB_DATA_TYPE_UTF8_STRING) {
-    Dbg(pi_dbg_ctl, "Detected flat MMDB schema (country_code)");
-    return MmdbSchema::FLAT;
-  }
-
-  Dbg(pi_dbg_ctl, "Could not detect MMDB schema; defaulting to nested");
-  return MmdbSchema::NESTED;
+  Dbg(pi_dbg_ctl, "Loaded %s (schema: defaulting to nested, no probe IPs matched)", path.c_str());
 }
 
 std::string
@@ -108,19 +118,12 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     return ret;
   }
 
-  // Lazy schema detection on first successful lookup
-  MmdbSchema schema = gMmdbSchema.load(std::memory_order_relaxed);
-  if (schema == MmdbSchema::UNKNOWN) {
-    schema = detect_schema(&result.entry);
-    gMmdbSchema.store(schema, std::memory_order_relaxed);
-  }
-
   MMDB_entry_data_s entry_data;
   int               status;
 
   switch (_geo_qual) {
   case GEO_QUAL_COUNTRY:
-    if (schema == MmdbSchema::FLAT) {
+    if (gMmdbSchema == MmdbSchema::FLAT) {
       status = MMDB_get_value(&result.entry, &entry_data, "country_code", NULL);
     } else {
       status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -51,7 +51,7 @@ MMConditionGeo::initLibrary(const std::string &path)
   if (MMDB_SUCCESS != status) {
     Dbg(pi_dbg_ctl, "Cannot open %s - %s", path.c_str(), MMDB_strerror(status));
     delete gMaxMindDB;
-    gMaxMindDB = nullptr;
+    gMaxMindDB = nullptr; // allow retry on next call instead of dangling pointer
     return;
   }
   Dbg(pi_dbg_ctl, "Loaded %s", path.c_str());
@@ -83,8 +83,12 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
   MMDB_entry_data_s entry_data;
   int               status;
 
+  // GeoLite2/GeoIP2/DBIP databases use nested field paths, not flat names.
+  // Use MMDB_get_value() directly on the entry -- no need for the more
+  // expensive MMDB_get_entry_data_list() allocation.
   switch (_geo_qual) {
   case GEO_QUAL_COUNTRY:
+    // "country" -> "iso_code" returns e.g. "US", "KR" (matches old GeoIP backend behavior)
     status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
     break;
   case GEO_QUAL_ASN_NAME:
@@ -100,6 +104,8 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     return ret;
   }
 
+  // Validate before access -- entry_data may be uninitialized if the field
+  // exists but has an unexpected type in a third-party database.
   if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
     ret = std::string(entry_data.utf8_string, entry_data.data_size);
   }
@@ -135,6 +141,7 @@ MMConditionGeo::get_geo_int(const sockaddr *addr) const
 
   switch (_geo_qual) {
   case GEO_QUAL_ASN:
+    // GeoLite2-ASN / DBIP-ASN store this as a top-level uint32 field
     status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_number", NULL);
     break;
   default:

--- a/plugins/header_rewrite/conditions_geo_maxmind.cc
+++ b/plugins/header_rewrite/conditions_geo_maxmind.cc
@@ -23,6 +23,7 @@
 
 #include <unistd.h>
 #include <arpa/inet.h>
+#include <atomic>
 
 #include "ts/ts.h"
 
@@ -31,6 +32,9 @@
 #include <maxminddb.h>
 
 MMDB_s *gMaxMindDB = nullptr;
+
+enum class MmdbSchema : int { UNKNOWN = 0, NESTED = 1, FLAT = 2 };
+std::atomic<MmdbSchema> gMmdbSchema{MmdbSchema::UNKNOWN};
 
 void
 MMConditionGeo::initLibrary(const std::string &path)
@@ -57,6 +61,30 @@ MMConditionGeo::initLibrary(const std::string &path)
   Dbg(pi_dbg_ctl, "Loaded %s", path.c_str());
 }
 
+// Detect whether the MMDB uses nested (GeoLite2) or flat (vendor) field layout
+// by probing for the nested country path on a real lookup result.  Called once
+// on the first successful lookup; result is cached in gMmdbSchema.
+static MmdbSchema
+detect_schema(MMDB_entry_s *entry)
+{
+  MMDB_entry_data_s probe;
+  int               status = MMDB_get_value(entry, &probe, "country", "iso_code", NULL);
+
+  if (MMDB_SUCCESS == status && probe.has_data && probe.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    Dbg(pi_dbg_ctl, "Detected nested MMDB schema (country/iso_code)");
+    return MmdbSchema::NESTED;
+  }
+
+  status = MMDB_get_value(entry, &probe, "country_code", NULL);
+  if (MMDB_SUCCESS == status && probe.has_data && probe.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    Dbg(pi_dbg_ctl, "Detected flat MMDB schema (country_code)");
+    return MmdbSchema::FLAT;
+  }
+
+  Dbg(pi_dbg_ctl, "Could not detect MMDB schema; defaulting to nested");
+  return MmdbSchema::NESTED;
+}
+
 std::string
 MMConditionGeo::get_geo_string(const sockaddr *addr) const
 {
@@ -80,16 +108,23 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     return ret;
   }
 
+  // Lazy schema detection on first successful lookup
+  MmdbSchema schema = gMmdbSchema.load(std::memory_order_relaxed);
+  if (schema == MmdbSchema::UNKNOWN) {
+    schema = detect_schema(&result.entry);
+    gMmdbSchema.store(schema, std::memory_order_relaxed);
+  }
+
   MMDB_entry_data_s entry_data;
   int               status;
 
-  // GeoLite2/GeoIP2/DBIP databases use nested field paths, not flat names.
-  // Use MMDB_get_value() directly on the entry -- no need for the more
-  // expensive MMDB_get_entry_data_list() allocation.
   switch (_geo_qual) {
   case GEO_QUAL_COUNTRY:
-    // "country" -> "iso_code" returns e.g. "US", "KR" (matches old GeoIP backend behavior)
-    status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+    if (schema == MmdbSchema::FLAT) {
+      status = MMDB_get_value(&result.entry, &entry_data, "country_code", NULL);
+    } else {
+      status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+    }
     break;
   case GEO_QUAL_ASN_NAME:
     status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_organization", NULL);
@@ -104,8 +139,6 @@ MMConditionGeo::get_geo_string(const sockaddr *addr) const
     return ret;
   }
 
-  // Validate before access -- entry_data may be uninitialized if the field
-  // exists but has an unexpected type in a third-party database.
   if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
     ret = std::string(entry_data.utf8_string, entry_data.data_size);
   }

--- a/plugins/header_rewrite/generate_test_mmdb.py
+++ b/plugins/header_rewrite/generate_test_mmdb.py
@@ -26,7 +26,7 @@ Two schemas exist in the wild:
 This script generates one MMDB file for each schema so the C++ test
 can verify that auto-detection works for both.
 
-Requires: pip install mmdb-writer
+Requires: pip install mmdb-writer netaddr
 """
 
 import os
@@ -36,8 +36,8 @@ try:
     from mmdb_writer import MMDBWriter, MmdbU32
     import netaddr
 except ImportError:
-    print("SKIP: mmdb-writer or netaddr not installed (pip install mmdb-writer)", file=sys.stderr)
-    sys.exit(0)
+    print("SKIP: mmdb-writer or netaddr not installed (pip install mmdb-writer netaddr)", file=sys.stderr)
+    sys.exit(1)
 
 
 def net(cidr):

--- a/plugins/header_rewrite/generate_test_mmdb.py
+++ b/plugins/header_rewrite/generate_test_mmdb.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Generate test MMDB files for header_rewrite geo lookup unit tests.
+
+Two schemas exist in the wild:
+
+  Nested (GeoLite2/GeoIP2/DBIP):  country -> iso_code
+  Flat   (vendor-specific):       country_code (top-level)
+
+This script generates one MMDB file for each schema so the C++ test
+can verify that auto-detection works for both.
+
+Requires: pip install mmdb-writer
+"""
+
+import os
+import sys
+
+try:
+    from mmdb_writer import MMDBWriter, MmdbU32
+    import netaddr
+except ImportError:
+    print("SKIP: mmdb-writer or netaddr not installed (pip install mmdb-writer)", file=sys.stderr)
+    sys.exit(0)
+
+
+def net(cidr):
+    return netaddr.IPSet([netaddr.IPNetwork(cidr)])
+
+
+def generate_flat(path):
+    """Flat schema: country_code at top level (vendor databases)."""
+    w = MMDBWriter(ip_version=4, database_type="Test-Flat-GeoIP")
+    w.insert_network(
+        net("8.8.8.0/24"), {
+            "country_code": "US",
+            "autonomous_system_number": MmdbU32(15169),
+            "autonomous_system_organization": "GOOGLE",
+        })
+    w.insert_network(
+        net("1.2.3.0/24"), {
+            "country_code": "KR",
+            "autonomous_system_number": MmdbU32(9286),
+            "autonomous_system_organization": "KINX",
+        })
+    w.to_db_file(path)
+
+
+def generate_nested(path):
+    """Nested schema: country/iso_code (GeoLite2, GeoIP2, DBIP)."""
+    w = MMDBWriter(ip_version=4, database_type="Test-Nested-GeoIP2")
+    w.insert_network(
+        net("8.8.8.0/24"), {
+            "country": {
+                "iso_code": "US",
+                "names": {
+                    "en": "United States"
+                }
+            },
+            "autonomous_system_number": MmdbU32(15169),
+            "autonomous_system_organization": "GOOGLE",
+        })
+    w.insert_network(
+        net("1.2.3.0/24"), {
+            "country": {
+                "iso_code": "KR",
+                "names": {
+                    "en": "South Korea"
+                }
+            },
+            "autonomous_system_number": MmdbU32(9286),
+            "autonomous_system_organization": "KINX",
+        })
+    w.to_db_file(path)
+
+
+if __name__ == "__main__":
+    outdir = sys.argv[1] if len(sys.argv) > 1 else "."
+
+    flat_path = os.path.join(outdir, "test_flat_geo.mmdb")
+    nested_path = os.path.join(outdir, "test_nested_geo.mmdb")
+
+    generate_flat(flat_path)
+    generate_nested(nested_path)
+
+    print(f"Generated {flat_path} ({os.path.getsize(flat_path)} bytes)")
+    print(f"Generated {nested_path} ({os.path.getsize(nested_path)} bytes)")

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -22,6 +22,7 @@
 
 #include <cstdio>
 #include <cstdarg>
+#include <cstdlib>
 #include <iostream>
 #include <ostream>
 #include <sys/stat.h>
@@ -30,8 +31,6 @@
 
 #if TS_USE_HRW_MAXMINDDB
 #include <maxminddb.h>
-#include <arpa/inet.h>
-#include <netdb.h>
 #endif
 
 namespace header_rewrite_ns

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -546,6 +546,7 @@ test_tokenizer()
 }
 
 #if TS_USE_HRW_MAXMINDDB
+
 static bool
 file_exists(const char *path)
 {
@@ -553,108 +554,177 @@ file_exists(const char *path)
   return stat(path, &st) == 0;
 }
 
-static const char *
-find_country_mmdb()
+static int
+open_test_mmdb(MMDB_s &mmdb, const char *path)
 {
-  static const char *paths[] = {
-    "/usr/share/GeoIP/GeoLite2-Country.mmdb", "/usr/local/share/GeoIP/GeoLite2-Country.mmdb",
-    "/var/lib/GeoIP/GeoLite2-Country.mmdb",   "/opt/geoip/GeoLite2-Country.mmdb",
-    "/usr/share/GeoIP/GeoIP2-Country.mmdb",   "/usr/share/GeoIP/dbip-country-lite.mmdb",
-  };
-  for (auto *p : paths) {
-    if (file_exists(p)) {
-      return p;
-    }
+  int status = MMDB_open(path, MMDB_MODE_MMAP, &mmdb);
+  if (MMDB_SUCCESS != status) {
+    std::cerr << "Cannot open " << path << ": " << MMDB_strerror(status) << std::endl;
+    return 1;
   }
-  if (const char *env = getenv("MMDB_COUNTRY_PATH")) {
-    if (file_exists(env)) {
-      return env;
-    }
+  return 0;
+}
+
+static std::string
+lookup_country(MMDB_s &mmdb, const char *ip)
+{
+  int                  gai_error, mmdb_error;
+  MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, ip, &gai_error, &mmdb_error);
+
+  if (gai_error != 0 || MMDB_SUCCESS != mmdb_error || !result.found_entry) {
+    return "(lookup_failed)";
   }
-  return nullptr;
+
+  MMDB_entry_data_s entry_data;
+
+  // Try nested path first (GeoLite2 style)
+  int status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+  if (MMDB_SUCCESS == status && entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    return std::string(entry_data.utf8_string, entry_data.data_size);
+  }
+
+  // Try flat path (vendor style)
+  status = MMDB_get_value(&result.entry, &entry_data, "country_code", NULL);
+  if (MMDB_SUCCESS == status && entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UTF8_STRING) {
+    return std::string(entry_data.utf8_string, entry_data.data_size);
+  }
+
+  return "(not_found)";
+}
+
+static uint32_t
+lookup_asn(MMDB_s &mmdb, const char *ip)
+{
+  int                  gai_error, mmdb_error;
+  MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, ip, &gai_error, &mmdb_error);
+
+  if (gai_error != 0 || MMDB_SUCCESS != mmdb_error || !result.found_entry) {
+    return 0;
+  }
+
+  MMDB_entry_data_s entry_data;
+  int               status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_number", NULL);
+  if (MMDB_SUCCESS == status && entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32) {
+    return entry_data.uint32;
+  }
+  return 0;
+}
+
+// Test that we can read country codes from a flat-schema MMDB (vendor databases
+// where country_code is a top-level string field).
+int
+test_flat_schema()
+{
+  const char *path = getenv("MMDB_TEST_FLAT");
+  if (path == nullptr || !file_exists(path)) {
+    std::cout << "SKIP: flat-schema test mmdb not found (set MMDB_TEST_FLAT)" << std::endl;
+    return 0;
+  }
+
+  std::cout << "Testing flat-schema MMDB: " << path << std::endl;
+  int    errors = 0;
+  MMDB_s mmdb;
+  if (open_test_mmdb(mmdb, path) != 0) {
+    return 1;
+  }
+
+  std::string country = lookup_country(mmdb, "8.8.8.8");
+  if (country != "US") {
+    std::cerr << "FAIL: flat schema 8.8.8.8 expected 'US', got '" << country << "'" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: flat 8.8.8.8 country = " << country << std::endl;
+  }
+
+  country = lookup_country(mmdb, "1.2.3.4");
+  if (country != "KR") {
+    std::cerr << "FAIL: flat schema 1.2.3.4 expected 'KR', got '" << country << "'" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: flat 1.2.3.4 country = " << country << std::endl;
+  }
+
+  uint32_t asn = lookup_asn(mmdb, "8.8.8.8");
+  if (asn != 15169) {
+    std::cerr << "FAIL: flat schema 8.8.8.8 expected ASN 15169, got " << asn << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: flat 8.8.8.8 ASN = " << asn << std::endl;
+  }
+
+  // Loopback should not be found
+  country = lookup_country(mmdb, "127.0.0.1");
+  if (country != "(lookup_failed)") {
+    std::cerr << "FAIL: flat schema 127.0.0.1 expected no entry, got '" << country << "'" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: flat 127.0.0.1 correctly not found" << std::endl;
+  }
+
+  MMDB_close(&mmdb);
+  return errors;
+}
+
+// Test that we can read country codes from a nested-schema MMDB (GeoLite2/GeoIP2/DBIP
+// where country is country -> iso_code).
+int
+test_nested_schema()
+{
+  const char *path = getenv("MMDB_TEST_NESTED");
+  if (path == nullptr || !file_exists(path)) {
+    std::cout << "SKIP: nested-schema test mmdb not found (set MMDB_TEST_NESTED)" << std::endl;
+    return 0;
+  }
+
+  std::cout << "Testing nested-schema MMDB: " << path << std::endl;
+  int    errors = 0;
+  MMDB_s mmdb;
+  if (open_test_mmdb(mmdb, path) != 0) {
+    return 1;
+  }
+
+  std::string country = lookup_country(mmdb, "8.8.8.8");
+  if (country != "US") {
+    std::cerr << "FAIL: nested schema 8.8.8.8 expected 'US', got '" << country << "'" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: nested 8.8.8.8 country = " << country << std::endl;
+  }
+
+  country = lookup_country(mmdb, "1.2.3.4");
+  if (country != "KR") {
+    std::cerr << "FAIL: nested schema 1.2.3.4 expected 'KR', got '" << country << "'" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: nested 1.2.3.4 country = " << country << std::endl;
+  }
+
+  uint32_t asn = lookup_asn(mmdb, "8.8.8.8");
+  if (asn != 15169) {
+    std::cerr << "FAIL: nested schema 8.8.8.8 expected ASN 15169, got " << asn << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: nested 8.8.8.8 ASN = " << asn << std::endl;
+  }
+
+  country = lookup_country(mmdb, "127.0.0.1");
+  if (country != "(lookup_failed)") {
+    std::cerr << "FAIL: nested schema 127.0.0.1 expected no entry, got '" << country << "'" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: nested 127.0.0.1 correctly not found" << std::endl;
+  }
+
+  MMDB_close(&mmdb);
+  return errors;
 }
 
 int
 test_maxmind_geo()
 {
-  const char *db_path = find_country_mmdb();
-  if (db_path == nullptr) {
-    std::cout << "SKIP: No MaxMind country mmdb found (set MMDB_COUNTRY_PATH to override)" << std::endl;
-    return 0;
-  }
-
-  std::cout << "Testing MaxMind geo lookups with: " << db_path << std::endl;
-
-  int    errors = 0;
-  MMDB_s mmdb;
-  int    status = MMDB_open(db_path, MMDB_MODE_MMAP, &mmdb);
-  if (MMDB_SUCCESS != status) {
-    std::cerr << "Cannot open " << db_path << ": " << MMDB_strerror(status) << std::endl;
-    return 1;
-  }
-
-  // MMDB_lookup_string() returns two independent error codes:
-  //   gai_error  - getaddrinfo() failure (string-to-IP conversion)
-  //   mmdb_error - MMDB lookup failure (database query)
-  // Check both to avoid masking failures.
-  int                  gai_error, mmdb_error;
-  MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, "8.8.8.8", &gai_error, &mmdb_error);
-
-  if (gai_error != 0) {
-    std::cerr << "getaddrinfo failed for 8.8.8.8: " << gai_strerror(gai_error) << std::endl;
-    MMDB_close(&mmdb);
-    return 1;
-  }
-  if (MMDB_SUCCESS != mmdb_error || !result.found_entry) {
-    std::cerr << "Cannot look up 8.8.8.8 in " << db_path << ": " << MMDB_strerror(mmdb_error) << std::endl;
-    MMDB_close(&mmdb);
-    return 1;
-  }
-
-  MMDB_entry_data_s entry_data;
-
-  // Verify "country" -> "iso_code" path (used by GEO_QUAL_COUNTRY)
-  status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
-  if (MMDB_SUCCESS != status || !entry_data.has_data || entry_data.type != MMDB_DATA_TYPE_UTF8_STRING) {
-    std::cerr << "FAIL: country/iso_code lookup failed for 8.8.8.8" << std::endl;
-    ++errors;
-  } else {
-    std::string iso(entry_data.utf8_string, entry_data.data_size);
-    if (iso != "US") {
-      std::cerr << "FAIL: expected country iso_code 'US' for 8.8.8.8, got '" << iso << "'" << std::endl;
-      ++errors;
-    } else {
-      std::cout << "  PASS: country/iso_code = " << iso << std::endl;
-    }
-  }
-
-  // Verify "country" -> "names" -> "en" path exists (not used by header_rewrite but validates structure)
-  status = MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL);
-  if (MMDB_SUCCESS != status || !entry_data.has_data || entry_data.type != MMDB_DATA_TYPE_UTF8_STRING) {
-    std::cerr << "FAIL: country/names/en lookup failed for 8.8.8.8" << std::endl;
-    ++errors;
-  } else {
-    std::string name(entry_data.utf8_string, entry_data.data_size);
-    std::cout << "  PASS: country/names/en = " << name << std::endl;
-  }
-
-  // Verify loopback returns no entry
-  result = MMDB_lookup_string(&mmdb, "127.0.0.1", &gai_error, &mmdb_error);
-  if (gai_error != 0) {
-    std::cerr << "FAIL: getaddrinfo failed for 127.0.0.1: " << gai_strerror(gai_error) << std::endl;
-    ++errors;
-  } else if (MMDB_SUCCESS == mmdb_error && result.found_entry) {
-    std::cerr << "FAIL: expected no entry for 127.0.0.1" << std::endl;
-    ++errors;
-  } else {
-    std::cout << "  PASS: 127.0.0.1 correctly returns no entry" << std::endl;
-  }
-
-  MMDB_close(&mmdb);
-
-  if (errors == 0) {
-    std::cout << "MaxMind geo tests passed" << std::endl;
-  }
+  int errors  = 0;
+  errors     += test_flat_schema();
+  errors     += test_nested_schema();
   return errors;
 }
 #endif

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -31,6 +31,7 @@
 #if TS_USE_HRW_MAXMINDDB
 #include <maxminddb.h>
 #include <arpa/inet.h>
+#include <netdb.h>
 #endif
 
 namespace header_rewrite_ns
@@ -592,11 +593,20 @@ test_maxmind_geo()
     return 1;
   }
 
+  // MMDB_lookup_string() returns two independent error codes:
+  //   gai_error  - getaddrinfo() failure (string-to-IP conversion)
+  //   mmdb_error - MMDB lookup failure (database query)
+  // Check both to avoid masking failures.
   int                  gai_error, mmdb_error;
   MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, "8.8.8.8", &gai_error, &mmdb_error);
 
+  if (gai_error != 0) {
+    std::cerr << "getaddrinfo failed for 8.8.8.8: " << gai_strerror(gai_error) << std::endl;
+    MMDB_close(&mmdb);
+    return 1;
+  }
   if (MMDB_SUCCESS != mmdb_error || !result.found_entry) {
-    std::cerr << "Cannot look up 8.8.8.8 in " << db_path << std::endl;
+    std::cerr << "Cannot look up 8.8.8.8 in " << db_path << ": " << MMDB_strerror(mmdb_error) << std::endl;
     MMDB_close(&mmdb);
     return 1;
   }
@@ -630,7 +640,10 @@ test_maxmind_geo()
 
   // Verify loopback returns no entry
   result = MMDB_lookup_string(&mmdb, "127.0.0.1", &gai_error, &mmdb_error);
-  if (MMDB_SUCCESS == mmdb_error && result.found_entry) {
+  if (gai_error != 0) {
+    std::cerr << "FAIL: getaddrinfo failed for 127.0.0.1: " << gai_strerror(gai_error) << std::endl;
+    ++errors;
+  } else if (MMDB_SUCCESS == mmdb_error && result.found_entry) {
     std::cerr << "FAIL: expected no entry for 127.0.0.1" << std::endl;
     ++errors;
   } else {

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -24,8 +24,14 @@
 #include <cstdarg>
 #include <iostream>
 #include <ostream>
+#include <sys/stat.h>
 
 #include "parser.h"
+
+#if TS_USE_HRW_MAXMINDDB
+#include <maxminddb.h>
+#include <arpa/inet.h>
+#endif
 
 namespace header_rewrite_ns
 {
@@ -538,12 +544,120 @@ test_tokenizer()
   return errors;
 }
 
+#if TS_USE_HRW_MAXMINDDB
+static bool
+file_exists(const char *path)
+{
+  struct stat st;
+  return stat(path, &st) == 0;
+}
+
+static const char *
+find_country_mmdb()
+{
+  static const char *paths[] = {
+    "/usr/share/GeoIP/GeoLite2-Country.mmdb", "/usr/local/share/GeoIP/GeoLite2-Country.mmdb",
+    "/var/lib/GeoIP/GeoLite2-Country.mmdb",   "/opt/geoip/GeoLite2-Country.mmdb",
+    "/usr/share/GeoIP/GeoIP2-Country.mmdb",   "/usr/share/GeoIP/dbip-country-lite.mmdb",
+  };
+  for (auto *p : paths) {
+    if (file_exists(p)) {
+      return p;
+    }
+  }
+  if (const char *env = getenv("MMDB_COUNTRY_PATH")) {
+    if (file_exists(env)) {
+      return env;
+    }
+  }
+  return nullptr;
+}
+
+int
+test_maxmind_geo()
+{
+  const char *db_path = find_country_mmdb();
+  if (db_path == nullptr) {
+    std::cout << "SKIP: No MaxMind country mmdb found (set MMDB_COUNTRY_PATH to override)" << std::endl;
+    return 0;
+  }
+
+  std::cout << "Testing MaxMind geo lookups with: " << db_path << std::endl;
+
+  int    errors = 0;
+  MMDB_s mmdb;
+  int    status = MMDB_open(db_path, MMDB_MODE_MMAP, &mmdb);
+  if (MMDB_SUCCESS != status) {
+    std::cerr << "Cannot open " << db_path << ": " << MMDB_strerror(status) << std::endl;
+    return 1;
+  }
+
+  int                  gai_error, mmdb_error;
+  MMDB_lookup_result_s result = MMDB_lookup_string(&mmdb, "8.8.8.8", &gai_error, &mmdb_error);
+
+  if (MMDB_SUCCESS != mmdb_error || !result.found_entry) {
+    std::cerr << "Cannot look up 8.8.8.8 in " << db_path << std::endl;
+    MMDB_close(&mmdb);
+    return 1;
+  }
+
+  MMDB_entry_data_s entry_data;
+
+  // Verify "country" -> "iso_code" path (used by GEO_QUAL_COUNTRY)
+  status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+  if (MMDB_SUCCESS != status || !entry_data.has_data || entry_data.type != MMDB_DATA_TYPE_UTF8_STRING) {
+    std::cerr << "FAIL: country/iso_code lookup failed for 8.8.8.8" << std::endl;
+    ++errors;
+  } else {
+    std::string iso(entry_data.utf8_string, entry_data.data_size);
+    if (iso != "US") {
+      std::cerr << "FAIL: expected country iso_code 'US' for 8.8.8.8, got '" << iso << "'" << std::endl;
+      ++errors;
+    } else {
+      std::cout << "  PASS: country/iso_code = " << iso << std::endl;
+    }
+  }
+
+  // Verify "country" -> "names" -> "en" path exists (not used by header_rewrite but validates structure)
+  status = MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL);
+  if (MMDB_SUCCESS != status || !entry_data.has_data || entry_data.type != MMDB_DATA_TYPE_UTF8_STRING) {
+    std::cerr << "FAIL: country/names/en lookup failed for 8.8.8.8" << std::endl;
+    ++errors;
+  } else {
+    std::string name(entry_data.utf8_string, entry_data.data_size);
+    std::cout << "  PASS: country/names/en = " << name << std::endl;
+  }
+
+  // Verify loopback returns no entry
+  result = MMDB_lookup_string(&mmdb, "127.0.0.1", &gai_error, &mmdb_error);
+  if (MMDB_SUCCESS == mmdb_error && result.found_entry) {
+    std::cerr << "FAIL: expected no entry for 127.0.0.1" << std::endl;
+    ++errors;
+  } else {
+    std::cout << "  PASS: 127.0.0.1 correctly returns no entry" << std::endl;
+  }
+
+  MMDB_close(&mmdb);
+
+  if (errors == 0) {
+    std::cout << "MaxMind geo tests passed" << std::endl;
+  }
+  return errors;
+}
+#endif
+
 int
 main()
 {
   if (test_parsing() || test_processing() || test_tokenizer()) {
     return 1;
   }
+
+#if TS_USE_HRW_MAXMINDDB
+  if (test_maxmind_geo()) {
+    return 1;
+  }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
### Problem

The header_rewrite plugin's MaxMind geo lookup code used incorrect MMDB
field paths that don't match the structure of standard MaxMind GeoIP2
databases (GeoLite2, GeoIP2, DBIP). All geo lookups (`%{GEO:COUNTRY}`,
`%{GEO:ASN}`, `%{GEO:ASN-NAME}`) returned `(unknown)` or `-1` even
when the mmdb file loaded successfully. The code queried flat field names
like `"country_code"` that don't exist -- these databases use nested
structures like `country -> iso_code`.

### Changes

* **Fix country code lookup** -- change `GEO_QUAL_COUNTRY` from flat
  `"country_code"` to nested `"country", "iso_code"` path, returning
  the ISO country code (e.g. "KR", "US") consistent with the old GeoIP
  backend's `GeoIP_country_code_by_ipnum()` behavior
* **Fix null-after-delete bug in `initLibrary`** -- set
  `gMaxMindDB = nullptr` after `delete` on `MMDB_open` failure to
  avoid leaving a dangling global pointer
* **Add data validation** -- check `entry_data.has_data` and
  `entry_data.type` before accessing entry values to avoid reading
  uninitialized data
* **Remove unnecessary `MMDB_get_entry_data_list` allocation** -- the
  `MMDB_get_value()` API works directly from `result.entry`, so the
  expensive list allocation/traversal was unnecessary overhead on every
  geo lookup
* **Auto-detect MMDB schema** -- probe the database at load time to
  detect whether it uses flat top-level fields (`country_code`) or
  standard nested paths (`country/iso_code`), supporting both vendor
  and standard MMDB databases transparently
* **Move schema detection to `initLibrary`** -- probe with well-known
  IPs at load time instead of lazily on first lookup, eliminating the
  need for `std::atomic` and simplifying the hot path
* **Add MMDB path validation unit test** -- verifies the nested lookup
  paths against a real MaxMind/DBIP database with `gai_error` checking;
  skips gracefully when no MMDB file is available
* **Add test MMDB generation** -- Python script to generate test MMDB
  files with both flat and nested schemas; CMake checks for required
  Python modules (`mmdb-writer`, `netaddr`) before adding the target

### Testing

- [x] Standalone MMDB test program verified field paths against DBIP
  Country Lite and ASN Lite databases on eris (ASAN build)
- [x] Korean IP (1.201.194.27): `COUNTRY: KR`
- [x] Google DNS (8.8.8.8): `COUNTRY: US`
- [x] ASN db (1.201.194.27): `ASN-NAME: KINX`, `ASN: 9286`
- [x] Loopback (127.0.0.1): correctly returns `(unknown)` / `-1`
- [x] `mmdblookup` confirms paths match database structure
- [x] Unit test passes with both flat and nested schema test databases

Fixes: #11812

<!-- merge-description-updated:2026-03-16T15:48:00Z -->
