### PR TITLE
Fix crash in HttpSM::tunnel_handler on unhandled VC events

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -3136,7 +3136,8 @@ HttpSM::tunnel_handler(int event, void * /* data ATS_UNUSED */)
     return 0;
   }
 
-  ink_assert(event == HTTP_TUNNEL_EVENT_DONE || event == VC_EVENT_INACTIVITY_TIMEOUT);
+  ink_assert(event == HTTP_TUNNEL_EVENT_DONE || event == VC_EVENT_INACTIVITY_TIMEOUT || event == VC_EVENT_ACTIVE_TIMEOUT ||
+             event == VC_EVENT_ERROR || event == VC_EVENT_EOS);
   // The tunnel calls this when it is done
   terminate_sm = true;
 


### PR DESCRIPTION
## Summary

Fix a fatal crash in `HttpSM::tunnel_handler` caused by an overly narrow assertion.

The assertion on line 3117 acts as a whitelist of expected events — it passes silently when the event matches, and **crashes the process when it doesn't**:

```cpp
ink_assert(event == HTTP_TUNNEL_EVENT_DONE || event == VC_EVENT_INACTIVITY_TIMEOUT);
```

The problem is that `VC_EVENT_ACTIVE_TIMEOUT`, `VC_EVENT_ERROR`, and `VC_EVENT_EOS` are all legitimate events that can arrive here (particularly via HTTP/2 code paths), but they weren't in the whitelist. When one of these events arrived, the assertion evaluated to `false` and aborted the process.

The code immediately after the assertion already handles all events correctly — it sets `terminate_sm = true` and returns. So the behavior was already right; the assertion was just too narrow and killed the process before the correct code could run.

The fix adds these three events to the assertion whitelist so they pass through to the existing (correct) termination logic.

## Root Cause

This was exposed by #5824 ("Reactivate active timeout enforcement"), which changed the InactivityCop to dispatch specific `VC_EVENT_ACTIVE_TIMEOUT` events instead of the generic `EVENT_IMMEDIATE` that was used before. That PR also added active timeout checking to the InactivityCop for the first time — before it, `VC_EVENT_ACTIVE_TIMEOUT` was never dispatched from the cop, so handlers like `tunnel_handler` never saw it. The assertion was never updated to account for the new event types.

## Background

Observed as a fatal crash on `controller.trafficserver.org` (ATS 10.2.0, ASAN build) through an HTTP/2 code path:

```
Fatal: HttpSM.cc:3083: failed assertion `event == HTTP_TUNNEL_EVENT_DONE || event == VC_EVENT_INACTIVITY_TIMEOUT`

HttpSM::tunnel_handler
HttpSM::main_handler
Continuation::handleEvent
Http2Stream::main_event_handler
```

Every other VC handler in HttpSM already accepts these events — `tunnel_handler` was the only one missing them.

Fixes #12958

## Test plan

- Verify existing CI tests pass
- Confirm the assertion no longer fires under HTTP/2 timeout/error conditions