### PR TITLE
Add AuTest for large chunked contents

### DIFF
--- a/tests/gold_tests/autest-site/ats_replay.test.ext
+++ b/tests/gold_tests/autest-site/ats_replay.test.ext
@@ -35,8 +35,36 @@ def configure_ats(obj: 'TestRun', server: 'Process', ats_config: dict, dns: Opti
     name = ats_config.get('name', 'ts')
     process_config = ats_config.get('process_config', {})
     ts = obj.MakeATSProcess(name, **process_config)
+
+    # Configure records_config if specified.
     records_config = ats_config.get('records_config', {})
     ts.Disk.records_config.update(records_config)
+
+    # TLS configs
+    enable_tls = process_config.get('enable_tls', False)
+    if enable_tls:
+        # Configure ssl_multicert.config if specified.
+        ssl_multicert_config = ats_config.get('ssl_multicert_config', [])
+
+        # setup default cert and key ssl_multicert_config is empty
+        if ssl_multicert_config == []:
+            ts.addDefaultSSLFiles()
+
+            ts.Disk.records_config.update(
+                {
+                    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+                    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+                })
+
+            ssl_multicert_config = ["dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key"]
+
+        for line in ssl_multicert_config:
+            ts.Disk.ssl_multicert_config.AddLine(line)
+
+        # Configure sni.yaml if specified.
+        sni_yaml = ats_config.get('sni_yaml')
+        if sni_yaml != None:
+            ts.Disk.sni_yaml.AddLines(yaml.dump(sni_yaml).split('\n'))
 
     # Configure plugin_config if specified.
     plugin_config = ats_config.get('plugin_config', [])
@@ -230,7 +258,8 @@ def ATSReplayTest(obj, replay_file: str):
     if not 'ats' in autest_config:
         raise ValueError(f"Replay file {replay_file} does not contain 'autest.ats' section")
     ats_config = autest_config['ats']
-    enable_tls = ats_config.get('enable_tls', False)
+    process_config = ats_config.get('process_config', {})
+    enable_tls = process_config.get('enable_tls', False)
     metric_checks = ats_config.get('metric_checks', [])
     log_validation = ats_config.get('log_validation', None)
 

--- a/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
+++ b/tests/gold_tests/chunked_encoding/chunked_encoding.test.py
@@ -255,3 +255,6 @@ class TestChunkedTrailers:
 
 TestChunkedTrailers(configure_drop_trailers=True)
 TestChunkedTrailers(configure_drop_trailers=False)
+
+# Large chunked response from origin server
+Test.ATSReplayTest(replay_file="replays/large_chunked.replay.yaml")

--- a/tests/gold_tests/chunked_encoding/replays/large_chunked.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/large_chunked.replay.yaml
@@ -1,0 +1,170 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+# Configuration section for autest integration
+autest:
+  description: 'Large chunked response from origin server'
+
+  dns:
+    name: 'dns-chunked-origin'
+
+  server:
+    name: 'server-chunked-origin'
+
+  client:
+    name: 'client-chunked-origin'
+
+  ats:
+    name: 'ts-chunked-large'
+    process_config:
+      enable_tls: true
+      enable_cache: true
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'http'
+      proxy.config.http.response_via_str: 2
+
+    remap_config:
+      - from: "http://www.example.com/"
+        to: "http://backend.example.com:{SERVER_HTTP_PORT}/"
+      - from: "https://www.example.com/"
+        to: "http://backend.example.com:{SERVER_HTTP_PORT}/"
+
+sessions:
+
+# HTTP/1.0 - dechunk
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /stream/1.0/
+      version: '1.0'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, http-1.0-chunk ]
+
+    server-response:
+      status: 200
+      version: '1.1'
+      headers:
+        fields:
+        - [ Content-Type, text/plain ]
+        - [ Transfer-Encoding, chunked ]
+        - [ Cache-Control, "public, max-age=3600" ]
+      content:
+        size: 131072
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Transfer-Encoding, { as: absent } ]
+      content:
+        size: 131072
+
+# HTTP/1.1 - pass-through for user agent & dechunk for cache write
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /stream/1.1/
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, http-1.1-chunk-0 ]
+
+    server-response:
+      status: 200
+      version: '1.1'
+      headers:
+        fields:
+        - [ Content-Type, text/plain ]
+        - [ Transfer-Encoding, chunked ]
+        - [ Cache-Control, "public, max-age=3600" ]
+      content:
+        size: 131072
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Transfer-Encoding, { value: chunked, as: equal } ]
+      content:
+        size: {value: 131072, as: equal}
+
+  # Expect: hit dechunked contents in the cache
+  - client-request:
+      method: GET
+      url: /stream/1.1/
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, http-1.1-chunk-1 ]
+
+    server-response:
+      status: 503
+      version: '1.1'
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+          - [ Content-Length, { value: 131072, as: equal} ]
+          - [ Transfer-Encoding, { as: absent } ]
+      content:
+        size: {value: 131072, as: equal}
+
+# HTTP/2 - dechunk
+
+- protocol:
+  - name: http
+    version: 2
+  transactions:
+  - client-request:
+      headers:
+        fields:
+        - [ ":method", "GET" ]
+        - [ ":scheme", https ]
+        - [ ":authority", www.example.com ]
+        - [ ":path", /stream/2/ ]
+        - [ uuid, http-2-chunk ]
+
+    server-response:
+      status: 200
+      version: 1.1
+      headers:
+        fields:
+        - [ Content-Type, text/plain ]
+        - [ Transfer-Encoding, chunked ]
+        - [ Cache-Control, "public, max-age=3600" ]
+      content:
+        size: 131072
+
+    proxy-response:
+      headers:
+        fields:
+        - [ ":status", {value: '200', as: equal } ]
+        - [ transfer-encoding, { as: absent } ]
+        - [ content-length, { as: absent } ]
+      content:
+        size: {value: 131072, as: equal}


### PR DESCRIPTION
This covers 131072 (=128KB) chunked contents handling in HTTP/1.0, HTTP/1.1 and HTTP/2.

Also, this includes extention of `ats_replay` for HTTP/2 (TLS) cases.