### PR TITLE
Initialize uninitialized local variables in core production code

### DIFF
--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -102,7 +102,7 @@ private:
   void _build_name(const char *filename);
 
 public:
-  BaseMetaInfo(const char *filename) : _flags(0)
+  BaseMetaInfo(const char *filename) : _creation_time(0), _log_object_signature(0), _flags(0)
   {
     _build_name(filename);
     _read_from_file();

--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -91,18 +91,18 @@ public:
   };
 
 private:
-  char    *_filename;             // the name of the meta file
-  time_t   _creation_time;        // file creation time
-  uint64_t _log_object_signature; // log object signature
-  int      _flags;                // metainfo status flags
-  char     _buffer[BUF_SIZE];     // read/write buffer
+  char    *_filename;                 // the name of the meta file
+  time_t   _creation_time        = 0; // file creation time
+  uint64_t _log_object_signature = 0; // log object signature
+  int      _flags                = 0; // metainfo status flags
+  char     _buffer[BUF_SIZE];         // read/write buffer
 
   void _read_from_file();
   void _write_to_file();
   void _build_name(const char *filename);
 
 public:
-  BaseMetaInfo(const char *filename) : _creation_time(0), _log_object_signature(0), _flags(0)
+  BaseMetaInfo(const char *filename)
   {
     _build_name(filename);
     _read_from_file();

--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -91,11 +91,11 @@ public:
   };
 
 private:
-  char    *_filename;                 // the name of the meta file
-  time_t   _creation_time        = 0; // file creation time
-  uint64_t _log_object_signature = 0; // log object signature
-  int      _flags                = 0; // metainfo status flags
-  char     _buffer[BUF_SIZE];         // read/write buffer
+  char    *_filename;                // the name of the meta file
+  time_t   _creation_time{0};        // file creation time
+  uint64_t _log_object_signature{0}; // log object signature
+  int      _flags{0};                // metainfo status flags
+  char     _buffer[BUF_SIZE];        // read/write buffer
 
   void _read_from_file();
   void _write_to_file();

--- a/include/tscore/BaseLogFile.h
+++ b/include/tscore/BaseLogFile.h
@@ -91,7 +91,7 @@ public:
   };
 
 private:
-  char    *_filename;                // the name of the meta file
+  char    *_filename{nullptr};       // the name of the meta file
   time_t   _creation_time{0};        // file creation time
   uint64_t _log_object_signature{0}; // log object signature
   int      _flags{0};                // metainfo status flags

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -127,8 +127,8 @@ static const ConfigEnumPair<TSServerSessionSharingMatchType> SessionSharingMatch
 bool
 HttpConfig::load_server_session_sharing_match(std::string_view key, MgmtByte &mask)
 {
-  MgmtByte value;
-  mask = 0;
+  MgmtByte value = 0;
+  mask           = 0;
   // Parse through and build up mask
   size_t start  = 0;
   size_t offset = 0;

--- a/src/proxy/shared/DiagsConfig.cc
+++ b/src/proxy/shared/DiagsConfig.cc
@@ -41,9 +41,9 @@
 void
 DiagsConfig::reconfigure_diags()
 {
-  int              i;
+  int              i = 0;
   DiagsConfigState c{};
-  bool             found, all_found;
+  bool             found = false, all_found = false;
 
   static struct {
     const char *config_name;


### PR DESCRIPTION
## Summary

Fix three Coverity high-severity "Uninitialized scalar variable" defects in core production code:

- **CID 1497238** -- `DiagsConfig::reconfigure_diags()`: loop index `i` and booleans `found`/`all_found` declared without initializers
- **CID 1644237** -- `HttpConfig::load_server_session_sharing_match()`: `value` used in session sharing mask computation without initialization
- **CID 1497363** -- `BaseMetaInfo` single-arg constructor: `_creation_time` and `_log_object_signature` not initialized before `_read_from_file()` (the other two constructors already initialize these)

All three are simple initializer additions with zero behavioral change on correct paths.

## Testing

- Unit tests pass (`test_proxy`, `test_http`, `test_proxy_hdrs`, `test_http2`)
- Manual integration test: built with ASan, started ATS on eris, verified all three code paths exercised (session sharing match parsing, diags reconfiguration, log file metadata creation)