### PR TITLE
Fix uninitialized pointer/field members in core classes

### DIFF
--- a/include/proxy/FetchSM.h
+++ b/include/proxy/FetchSM.h
@@ -165,7 +165,7 @@ private:
   HTTPParser           http_parser;
   HTTPHdr              client_response_hdr;
   ChunkedHandler       chunked_handler;
-  TSFetchEvent         callback_events{};
+  TSFetchEvent         callback_events{}; // TODO: ATS 11 - add default member initializers to TSFetchEvent in apidefs.h (C API)
   TSFetchWakeUpOptions callback_options    = NO_CALLBACK;
   bool                 req_finished        = false;
   bool                 header_done         = false;

--- a/include/proxy/FetchSM.h
+++ b/include/proxy/FetchSM.h
@@ -165,7 +165,7 @@ private:
   HTTPParser           http_parser;
   HTTPHdr              client_response_hdr;
   ChunkedHandler       chunked_handler;
-  TSFetchEvent         callback_events{}; // TODO: ATS 11 - add default member initializers to TSFetchEvent in apidefs.h (C API)
+  TSFetchEvent         callback_events{};
   TSFetchWakeUpOptions callback_options    = NO_CALLBACK;
   bool                 req_finished        = false;
   bool                 header_done         = false;

--- a/include/proxy/FetchSM.h
+++ b/include/proxy/FetchSM.h
@@ -165,7 +165,7 @@ private:
   HTTPParser           http_parser;
   HTTPHdr              client_response_hdr;
   ChunkedHandler       chunked_handler;
-  TSFetchEvent         callback_events;
+  TSFetchEvent         callback_events{};
   TSFetchWakeUpOptions callback_options    = NO_CALLBACK;
   bool                 req_finished        = false;
   bool                 header_done         = false;

--- a/include/proxy/ProxySession.h
+++ b/include/proxy/ProxySession.h
@@ -184,7 +184,7 @@ public:
 
   IpAllow::ACL acl; ///< IpAllow based method ACL.
 
-  HttpSessionAccept::Options const *accept_options = nullptr; ///< connection info
+  HttpSessionAccept::Options const *accept_options{nullptr}; ///< connection info
 
 protected:
   // Hook dispatching state

--- a/include/proxy/ProxySession.h
+++ b/include/proxy/ProxySession.h
@@ -184,7 +184,7 @@ public:
 
   IpAllow::ACL acl; ///< IpAllow based method ACL.
 
-  HttpSessionAccept::Options const *accept_options; ///< connection info // L7R TODO: set in constructor
+  HttpSessionAccept::Options const *accept_options = nullptr; ///< connection info
 
 protected:
   // Hook dispatching state

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -658,7 +658,7 @@ public:
     bool             handled = false;
     TSResponseAction action;
 
-    _ResponseAction() {}
+    _ResponseAction() : action{} {}
   };
 
   struct State {

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -656,9 +656,7 @@ public:
 
   using ResponseAction = struct _ResponseAction {
     bool             handled = false;
-    TSResponseAction action;
-
-    _ResponseAction() : action{} {}
+    TSResponseAction action  = {};
   };
 
   struct State {

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -655,7 +655,7 @@ public:
   };
 
   using ResponseAction = struct _ResponseAction {
-    bool             handled{};
+    bool             handled{false};
     TSResponseAction action{};
   };
 

--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -655,8 +655,8 @@ public:
   };
 
   using ResponseAction = struct _ResponseAction {
-    bool             handled = false;
-    TSResponseAction action  = {};
+    bool             handled{};
+    TSResponseAction action{};
   };
 
   struct State {

--- a/plugins/experimental/http_stats/http_stats.cc
+++ b/plugins/experimental/http_stats/http_stats.cc
@@ -89,7 +89,7 @@ struct HTTPStatsConfig {
   bool integer_counters = false;
   bool wrap_counters    = false;
 
-  TSCont cont = nullptr;
+  TSCont cont{nullptr};
 };
 
 struct HTTPStatsRequest;

--- a/plugins/experimental/http_stats/http_stats.cc
+++ b/plugins/experimental/http_stats/http_stats.cc
@@ -81,7 +81,12 @@ struct HTTPStatsFormatter {
 struct HTTPStatsConfig {
   explicit HTTPStatsConfig() {}
 
-  ~HTTPStatsConfig() { TSContDestroy(cont); }
+  ~HTTPStatsConfig()
+  {
+    if (cont) {
+      TSContDestroy(cont);
+    }
+  }
   std::string mimeType;
 
   int  maxAge           = 0;

--- a/plugins/experimental/http_stats/http_stats.cc
+++ b/plugins/experimental/http_stats/http_stats.cc
@@ -89,7 +89,7 @@ struct HTTPStatsConfig {
   bool integer_counters = false;
   bool wrap_counters    = false;
 
-  TSCont cont;
+  TSCont cont = nullptr;
 };
 
 struct HTTPStatsRequest;


### PR DESCRIPTION
## Summary

Initialize members that Coverity flagged as uninitialized:

- **HttpTransact::_ResponseAction**: value-init `TSResponseAction action` in constructor (CID 1497424)
- **ProxySession::accept_options**: init pointer to `nullptr` (CID 1497385, 1497345)
- **FetchSM::callback_events**: value-init `TSFetchEvent` struct (CID 1021718)
- **HTTPStatsConfig::cont**: init `TSCont` to `nullptr` (CID 1508857)

These are all trivial one-line initializer additions — no behavioral changes.

## Test Plan

- [x] Builds cleanly with ASAN (dev-asan preset)
- [x] All proxy/http unit tests pass (test_proxy, test_http, test_proxy_http, test_http2, test_proxy_hdrs, test_proxy_hdrs_xpack)
- [x] Manual integration test: ATS proxy on eris proxying to origin on zeus, requests from hera — no ASAN errors, no crashes