### PR TITLE
Fix uninitialized variables in txn_box plugin

### DIFF
--- a/plugins/experimental/txn_box/plugin/src/Context.cc
+++ b/plugins/experimental/txn_box/plugin/src/Context.cc
@@ -215,7 +215,7 @@ Context::extract(Expr const &expr)
 FeatureView
 Context::extract_view(const Expr &expr, std::initializer_list<ViewOption> opts)
 {
-  FeatureView zret;
+  FeatureView zret{};
 
   bool commit_p = false;
   bool cstr_p   = false;

--- a/plugins/experimental/txn_box/plugin/src/Ex_HTTP.cc
+++ b/plugins/experimental/txn_box/plugin/src/Ex_HTTP.cc
@@ -354,7 +354,7 @@ public:
 Feature
 Ex_proxy_req_scheme::extract(Context &ctx, Spec const &)
 {
-  FeatureView zret;
+  FeatureView zret{};
   zret._direct_p = true;
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (ts::URL url{hdr.url()}; url.is_valid()) {
@@ -964,7 +964,7 @@ Ex_ua_req_url_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_ua_req_url_port::extract(Context &ctx, Spec const &)
 {
-  FeatureView zret;
+  FeatureView zret{};
   zret._direct_p = true;
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (ts::URL url{hdr.url()}; url.is_valid()) {
@@ -993,7 +993,7 @@ Ex_proxy_req_url_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_proxy_req_url_port::extract(Context &ctx, Spec const &)
 {
-  FeatureView zret;
+  FeatureView zret{};
   zret._direct_p = true;
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (ts::URL url{hdr.url()}; url.is_valid()) {

--- a/plugins/experimental/txn_box/plugin/src/text_block.cc
+++ b/plugins/experimental/txn_box/plugin/src/text_block.cc
@@ -121,7 +121,7 @@ protected:
   std::optional<TextView>      _text;                                         ///< Default literal text (optional)
   feature_type_for<DURATION>   _duration;                                     ///< Time between update checks.
   std::atomic<Clock::duration> _last_check = Clock::now().time_since_epoch(); ///< Absolute time of the last alert.
-  Clock::time_point            _last_modified;                                ///< Last modified time of the file.
+  Clock::time_point            _last_modified{};                              ///< Last modified time of the file.
   std::shared_ptr<std::string> _content;                                      ///< Content of the file.
   int                          _line_no = 0;                                  ///< For debugging name conflicts.
   std::shared_mutex            _content_mutex;                                ///< Lock for access @a content.


### PR DESCRIPTION
## Summary

Value-initialize FeatureView and time_point members that Coverity flagged as uninitialized:

- **Ex_HTTP.cc**: value-init `FeatureView zret{}` in 3 extract functions (CID 1534699, 1534717, 1534727, 1534732, 1534738)
- **text_block.cc**: value-init `_last_modified{}` member (CID 1644248)
- **Context.cc**: value-init `FeatureView zret{}` in `extract_view`

## Test Plan

- [x] Builds cleanly with ASAN (dev-asan preset, txn_box enabled)
- [x] All 3 txn_box unit tests pass (test_txn_box, verify_global_txn_box, verify_remap_txn_box)