### PR TITLE
Fix uninitialized variables in test and benchmark code

### DIFF
--- a/src/iocore/aio/test_AIO.cc
+++ b/src/iocore/aio/test_AIO.cc
@@ -93,23 +93,19 @@ int    seq_write_size         = 0;
 int    rand_read_size         = 0;
 
 struct AIO_Device : public Continuation {
-  char                        *path;
-  int                          fd;
-  int                          id;
-  char                        *buf;
-  ink_hrtime                   time_start, time_end;
-  int                          seq_reads;
-  int                          seq_writes;
-  int                          rand_reads;
-  int                          hotset_idx;
-  int                          mode;
+  char                        *path{nullptr};
+  int                          fd{-1};
+  int                          id{0};
+  char                        *buf{nullptr};
+  ink_hrtime                   time_start{0};
+  ink_hrtime                   time_end{0};
+  int                          seq_reads{0};
+  int                          seq_writes{0};
+  int                          rand_reads{0};
+  int                          hotset_idx{0};
+  int                          mode{0};
   std::unique_ptr<AIOCallback> io;
-  AIO_Device(ProxyMutex *m) : Continuation(m), io{new_AIOCallback()}
-  {
-    hotset_idx = 0;
-    time_start = 0;
-    SET_HANDLER(&AIO_Device::do_hotset);
-  }
+  AIO_Device(ProxyMutex *m) : Continuation(m), io{new_AIOCallback()} { SET_HANDLER(&AIO_Device::do_hotset); }
   int
   select_mode(double p)
   {

--- a/src/iocore/hostdb/benchmark_HostDB.cc
+++ b/src/iocore/hostdb/benchmark_HostDB.cc
@@ -149,7 +149,7 @@ struct StartDNS : Continuation {
   HostList::iterator it;
   ResultList         results;
   Clock::time_point  start_time;
-  bool               is_callback;
+  bool               is_callback{false};
 
   StartDNS(const std::vector<std::string> &hlist, int id, latch &l)
     : Continuation(new_ProxyMutex()), hostlist(hlist), id(id), done_latch(l)

--- a/src/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/src/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -65,8 +65,8 @@ public:
   }
 
   /* Input fields used to set the test behavior of the plugin call-backs */
-  bool  fail = false; /* tell the plugin call-back to fail for testing purposuses */
-  void *input_ih;     /* the value to be returned by the plugin instance init function */
+  bool  fail{false};       /* tell the plugin call-back to fail for testing purposuses */
+  void *input_ih{nullptr}; /* the value to be returned by the plugin instance init function */
 
   /* Output fields showing what happend during the test */
   const PluginThreadContext *contextInit            = nullptr;                /* plugin initialization context */

--- a/src/proxy/http/remap/unit-tests/plugin_testing_common.h
+++ b/src/proxy/http/remap/unit-tests/plugin_testing_common.h
@@ -65,7 +65,7 @@ public:
   }
 
   /* Input fields used to set the test behavior of the plugin call-backs */
-  bool  fail{false};       /* tell the plugin call-back to fail for testing purposuses */
+  bool  fail{false};       /* tell the plugin call-back to fail for testing purposes */
   void *input_ih{nullptr}; /* the value to be returned by the plugin instance init function */
 
   /* Output fields showing what happend during the test */


### PR DESCRIPTION
Add default member initializers to fix Coverity-reported uninitialized variable defects in test and benchmark code.

**Files changed:**

| File | Fix | CID |
|------|-----|-----|
| `src/iocore/aio/test_AIO.cc` | Initialize `AIO_Device` members (`path`, `fd`, `id`, `buf`, `time_end`, `seq_reads`, `seq_writes`, `rand_reads`, `mode`) | 1523656 |
| `src/iocore/hostdb/benchmark_HostDB.cc` | Initialize `StartDNS::is_callback` | 1587260 |
| `src/proxy/http/remap/unit-tests/plugin_testing_common.h` | Initialize `PluginDebugObject::input_ih` | 1497312 |

**Verification:** Builds clean with ASAN, all nexthop and plugin unit tests pass.