### PR TITLE
Enable merge button temporarily for 11-dev to master merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,8 +29,8 @@ github:
     squash: true
     # Disable rebase button:
     rebase: false
-    # Disable merge button:
-    merge: false
+    # Enable merge button:
+    merge: true
   collaborators:
     - mtorluemke
     - c-taylor


### PR DESCRIPTION
Enable the merge button so we can merge the 11-dev branch into master for the ATS 11 release. We need a true merge (not squash) to preserve the full commit history from 11-dev.

This can be reverted back to merge: false after the 11-dev branch has been merged into master.