### PR TITLE
Align AuTests with latest proxy-verifier checks

### DIFF
--- a/tests/gold_tests/cache/replay/cache-read-retry.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-read-retry.replay.yaml
@@ -136,11 +136,6 @@ sessions:
               - [Host, example.com]
               - [X-Request, second-exhausted]
 
-        proxy-request:
-          headers:
-            fields:
-              - [X-Request, {value: 'second-exhausted', as: equal}]
-
         # This request should NOT reach the server if read-while-writer works
         # It should be served from Request 1's response
         server-response:
@@ -176,11 +171,6 @@ sessions:
               - [uuid, third-request-concurrent]
               - [Host, example.com]
               - [X-Request, third-concurrent]
-
-        proxy-request:
-          headers:
-            fields:
-              - [X-Request, {value: 'third-concurrent', as: equal}]
 
         # This request will also be served via read-while-writer
         server-response:

--- a/tests/gold_tests/cache/replay/varied_transactions.replay.yaml
+++ b/tests/gold_tests/cache/replay/varied_transactions.replay.yaml
@@ -372,11 +372,6 @@ sessions:
       # transaction.
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [ X-Vary-On-This, { value: sixth, as: equal } ]
-
     # This should be served out of the cache and not reach the origin.
     server-response:
       <<: *404_response

--- a/tests/gold_tests/h2/http2_close_connection.yaml
+++ b/tests/gold_tests/h2/http2_close_connection.yaml
@@ -92,9 +92,3 @@ sessions:
             encoding: plain
             data: server_test_2
             size: 13
-
-    proxy-response:
-      content:
-        encoding: plain
-        data: server_test_2
-        verify: {as: equal}

--- a/tests/gold_tests/h2/http2_flow_control.test.py
+++ b/tests/gold_tests/h2/http2_flow_control.test.py
@@ -103,8 +103,10 @@ class Http2FlowControlTest:
         Http2FlowControlTest._dns_counter += 1
         return dns
 
-    def _configure_server(self, tr: 'TestRun', server_type: ServerType) -> 'Process':
+    def _configure_server(self, tr: 'TestRun', server_type: ServerType) -> Optional['Process']:
         """Configure the test server."""
+        if self._flow_control_policy_is_malformed:
+            return None
         if server_type == self.ServerType.HTTP1_CHUNKED:
             replay_file = self._replay_chunked_file
         else:
@@ -172,7 +174,8 @@ ssl_multicert:
     ssl_key_name: server.key
 """.split("\n"))
 
-        ts.Disk.remap_config.AddLine(f'map / https://127.0.0.1:{self._server.Variables.https_port}')
+        if self._server is not None:
+            ts.Disk.remap_config.AddLine(f'map / https://127.0.0.1:{self._server.Variables.https_port}')
 
         if self._flow_control_policy_is_malformed:
             if is_outbound:

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
@@ -31,12 +31,6 @@ sessions:
       - RST_STREAM:
           error-code: INTERNAL_ERROR
 
-    proxy-request:
-      content:
-        encoding: plain
-        data: client_test
-        verify: {as: equal}
-
     server-response:
       headers:
         fields:
@@ -47,9 +41,3 @@ sessions:
         encoding: plain
         data: server_test
         size: 11
-
-    proxy-response:
-      content:
-        encoding: plain
-        data: server_test
-        verify: {as: equal}

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
@@ -31,12 +31,6 @@ sessions:
             data: client_test
             size: 11
 
-    proxy-request:
-      content:
-        encoding: plain
-        data: client_test
-        verify: {as: equal}
-
     server-response:
       headers:
         fields:
@@ -47,9 +41,3 @@ sessions:
         encoding: plain
         data: server_test
         size: 11
-
-    proxy-response:
-      content:
-        encoding: plain
-        data: server_test
-        verify: {as: equal}

--- a/tests/gold_tests/headers/normalized_ae_match_vary_cache.test.py
+++ b/tests/gold_tests/headers/normalized_ae_match_vary_cache.test.py
@@ -61,6 +61,38 @@ server.Streams.stdout += Testers.ExcludesExpression(
     "uuid: 38", "Verify br;q=1.1 request (uuid 38) is a cache hit and doesn't reach the server.")
 server.Streams.stdout += Testers.ExcludesExpression(
     "uuid: 39", "Verify br,gzip;q=0.8 request (uuid 39) is a cache hit and doesn't reach the server.")
+# Case 5 (normalize_ae:4) cache hits
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 42", "Verify empty Accept-Encoding (uuid 42) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 43", "Verify deflate request (uuid 43) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 47", "Verify zstd,br,compress,gzip request (uuid 47) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 48", "Verify br,compress,gzip request (uuid 48) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 49", "Verify compress,zstd request (uuid 49) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 410", "Verify compress,gzip request (uuid 410) is a cache hit and doesn't reach the server.")
+# Case 6 (normalize_ae:5) cache hits
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 52", "Verify empty Accept-Encoding (uuid 52) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 53", "Verify deflate request (uuid 53) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 510", "Verify compress,zstd request (uuid 510) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 511", "Verify compress,br request (uuid 511) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 512", "Verify compress,gzip request (uuid 512) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 513", "Verify zstd;q=1.1 request (uuid 513) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 514", "Verify br;q=1.1 request (uuid 514) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 515", "Verify zstd,br;q=0.8 request (uuid 515) is a cache hit and doesn't reach the server.")
+server.Streams.stdout += Testers.ExcludesExpression(
+    "uuid: 516", "Verify zstd,gzip;q=0.8 request (uuid 516) is a cache hit and doesn't reach the server.")
 
 ts = Test.MakeATSProcess("ts", enable_cache=True)
 ts.Disk.remap_config.AddLine(

--- a/tests/gold_tests/headers/replays/normalized_ae_varied_transactions.replay.yaml
+++ b/tests/gold_tests/headers/replays/normalized_ae_varied_transactions.replay.yaml
@@ -1046,11 +1046,6 @@ sessions:
         - [ Accept-Encoding, "zstd, br, compress, gzip" ]
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: zstd, as: equal }]
-
     server-response:
       <<: *404_response
 
@@ -1073,11 +1068,6 @@ sessions:
         - [ uuid, 48 ]
         - [ Accept-Encoding, "br, compress, gzip" ]
       delay: 100ms
-
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: br, as: equal }]
 
     server-response:
       <<: *404_response
@@ -1102,11 +1092,6 @@ sessions:
         - [ Accept-Encoding, "compress, zstd" ]
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: zstd, as: equal }]
-
     server-response:
       <<: *404_response
 
@@ -1129,11 +1114,6 @@ sessions:
         - [ uuid, 410 ]
         - [ Accept-Encoding, "compress, gzip" ]
       delay: 100ms
-
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: gzip, as: equal }]
 
     server-response:
       <<: *404_response
@@ -1474,11 +1454,6 @@ sessions:
         - [ Accept-Encoding, "compress, zstd" ]
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: zstd, as: equal }]
-
     server-response:
       <<: *404_response
 
@@ -1501,11 +1476,6 @@ sessions:
         - [ uuid, 511 ]
         - [ Accept-Encoding, "compress, br" ]
       delay: 100ms
-
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: br, as: equal }]
 
     server-response:
       <<: *404_response
@@ -1530,11 +1500,6 @@ sessions:
         - [ Accept-Encoding, "compress, gzip" ]
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: gzip, as: equal }]
-
     server-response:
       <<: *404_response
 
@@ -1557,11 +1522,6 @@ sessions:
         - [ uuid, 513 ]
         - [ Accept-Encoding, "zstd;q=1.1" ]
       delay: 100ms
-
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: zstd, as: equal }]
 
     server-response:
       <<: *404_response
@@ -1586,11 +1546,6 @@ sessions:
         - [ Accept-Encoding, "br;q=1.1" ]
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: br, as: equal }]
-
     server-response:
       <<: *404_response
 
@@ -1613,11 +1568,6 @@ sessions:
         - [ Accept-Encoding, "zstd, br;q=0.8" ]
       delay: 100ms
 
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: "zstd, br", as: equal }]
-
     server-response:
       <<: *404_response
 
@@ -1639,11 +1589,6 @@ sessions:
         - [ uuid, 516 ]
         - [ Accept-Encoding, "zstd, gzip;q=0.8" ]
       delay: 100ms
-
-    proxy-request:
-      headers:
-        fields:
-        - [Accept-Encoding, { value: "zstd, gzip", as: equal }]
 
     server-response:
       <<: *404_response

--- a/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr.test.py
+++ b/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr.test.py
@@ -53,6 +53,10 @@ class TestUpdateHostHeader:
         TestUpdateHostHeader.test_counter += 1
         self.disable_pristine_host_hdr = disable_pristine_host_hdr
         self.replay_file = f'disable_pristine_host_hdr_{"true" if disable_pristine_host_hdr else "false"}.replay.yaml'
+        self.canary_replay_file = (
+            'disable_pristine_host_hdr_server_canary_true.replay.yaml'
+            if disable_pristine_host_hdr else 'disable_pristine_host_hdr_server_canary_false.replay.yaml')
+        self.stable_replay_file = 'disable_pristine_host_hdr_server_stable.replay.yaml'
         self._setupDns()
         self._setupServers()
         self._setupTS(disable_pristine_host_hdr)
@@ -68,11 +72,11 @@ class TestUpdateHostHeader:
 
         Creates two servers to simulate canary and stable environments.
         """
-        self._server_canary = Test.MakeVerifierServerProcess(f"server_canary_{self.test_id}", self.replay_file)
+        self._server_canary = Test.MakeVerifierServerProcess(f"server_canary_{self.test_id}", self.canary_replay_file)
         expected_host = 'canary.com' if self.disable_pristine_host_hdr else 'example.com'
         self._server_canary.Streams.All += Testers.ContainsExpression(expected_host, f'Host header should be {expected_host}')
 
-        self._server_stable = Test.MakeVerifierServerProcess(f"server_stable_{self.test_id}", self.replay_file)
+        self._server_stable = Test.MakeVerifierServerProcess(f"server_stable_{self.test_id}", self.stable_replay_file)
         # The else path always preserves pristine host header (example.com).
         expected_host = 'example.com'
         self._server_stable.Streams.All += Testers.ContainsExpression(expected_host, f'Host header should be {expected_host}')

--- a/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr_server_canary_false.replay.yaml
+++ b/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr_server_canary_false.replay.yaml
@@ -1,0 +1,43 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: GET
+      url: /app/test
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ Cookie, "SessionID=333" ]
+        - [ uuid, 1 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ Host, { value: example.com, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, "0" ]
+        - [ Connection, close ]

--- a/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr_server_canary_true.replay.yaml
+++ b/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr_server_canary_true.replay.yaml
@@ -1,0 +1,43 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: GET
+      url: /app/test
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ Cookie, "SessionID=333" ]
+        - [ uuid, 1 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ Host, { value: "canary.com", as: contains } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, "0" ]
+        - [ Connection, close ]

--- a/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr_server_stable.replay.yaml
+++ b/tests/gold_tests/pluginTest/cookie_remap/disable_pristine_host_hdr_server_stable.replay.yaml
@@ -1,0 +1,42 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: GET
+      url: /app/test
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, 2 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ Host, { value: example.com, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, "0" ]
+        - [ Connection, close ]

--- a/tests/gold_tests/pluginTest/escalate/escalate.test.py
+++ b/tests/gold_tests/pluginTest/escalate/escalate.test.py
@@ -34,6 +34,8 @@ class EscalateTest:
 
     _replay_original_file: str = 'escalate_original.replay.yaml'
     _replay_failover_file: str = 'escalate_failover.replay.yaml'
+    _server_original_file: str = 'escalate_original_server_default.replay.yaml'
+    _server_failover_file: str = 'escalate_failover_server_default.replay.yaml'
     _process_counter: int = 0
 
     def __init__(self, disable_redirect_header: bool = False) -> None:
@@ -63,10 +65,12 @@ class EscalateTest:
         '''
         tr.Setup.Copy(self._replay_original_file)
         tr.Setup.Copy(self._replay_failover_file)
+        tr.Setup.Copy(self._server_original_file)
+        tr.Setup.Copy(self._server_failover_file)
         process_name = f"server_origin_{EscalateTest._process_counter}"
-        self._server_origin = tr.AddVerifierServerProcess(process_name, self._replay_original_file)
+        self._server_origin = tr.AddVerifierServerProcess(process_name, self._server_original_file)
         process_name = f"server_failover_{EscalateTest._process_counter}"
-        self._server_failover = tr.AddVerifierServerProcess(process_name, self._replay_failover_file)
+        self._server_failover = tr.AddVerifierServerProcess(process_name, self._server_failover_file)
 
         self._server_origin.Streams.All += Testers.ContainsExpression(
             'uuid: GET', "Verify the origin server received the GET request.")
@@ -176,6 +180,8 @@ class EscalateNonGetMethodsTest:
 
     _replay_get_method_file: str = 'escalate_non_get_methods.replay.yaml'
     _replay_failover_file: str = 'escalate_failover.replay.yaml'
+    _server_origin_file: str = 'escalate_original_server_non_get.replay.yaml'
+    _server_failover_file: str = 'escalate_failover_server_non_get.replay.yaml'
 
     def __init__(self):
         '''Configure the test run for escalating non-GET methods testing.'''
@@ -193,8 +199,10 @@ class EscalateNonGetMethodsTest:
         '''Set up the origin and failover servers for non-GET methods testing.'''
         tr.Setup.Copy(self._replay_get_method_file)
         tr.Setup.Copy(self._replay_failover_file)
-        self._server_origin = tr.AddVerifierServerProcess("server_origin_non_get_methods", self._replay_get_method_file)
-        self._server_failover = tr.AddVerifierServerProcess("server_failover_non_get_methods", self._replay_failover_file)
+        tr.Setup.Copy(self._server_origin_file)
+        tr.Setup.Copy(self._server_failover_file)
+        self._server_origin = tr.AddVerifierServerProcess("server_origin_non_get_methods", self._server_origin_file)
+        self._server_failover = tr.AddVerifierServerProcess("server_failover_non_get_methods", self._server_failover_file)
 
         # Verify the origin server received all requests
         self._server_origin.Streams.All += Testers.ContainsExpression(

--- a/tests/gold_tests/pluginTest/escalate/escalate_failover_server_default.replay.yaml
+++ b/tests/gold_tests/pluginTest/escalate/escalate_failover_server_default.replay.yaml
@@ -1,0 +1,72 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_failed
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third ]
+        - [ uuid, GET_failed ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: third, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, third ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_down
+      headers:
+        fields:
+        - [ Host, down_origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fourth ]
+        - [ uuid, GET_down_origin ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: fourth, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Response, fourth ]
+      content:
+        size: 320000

--- a/tests/gold_tests/pluginTest/escalate/escalate_failover_server_non_get.replay.yaml
+++ b/tests/gold_tests/pluginTest/escalate/escalate_failover_server_non_get.replay.yaml
@@ -1,0 +1,96 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_failed
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third ]
+        - [ uuid, GET_failed ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: third, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, third ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_down
+      headers:
+        fields:
+        - [ Host, down_origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, fourth ]
+        - [ uuid, GET_down_origin ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: fourth, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Response, fourth ]
+      content:
+        size: 320000
+
+  - client-request:
+      method: "HEAD"
+      version: "1.1"
+      url: /api/head/data
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ X-Request, head_fail_escalated ]
+        - [ uuid, HEAD_fail_escalated ]
+
+    proxy-request:
+      method: "HEAD"
+      headers:
+        fields:
+        - [ X-Request, { value: head_fail_escalated, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ X-Response, head_fail_escalated ]

--- a/tests/gold_tests/pluginTest/escalate/escalate_original_server_default.replay.yaml
+++ b/tests/gold_tests/pluginTest/escalate/escalate_original_server_default.replay.yaml
@@ -1,0 +1,149 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, first ]
+        - [ uuid, GET ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: first, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, first ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_chunked
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, second ]
+        - [ uuid, GET_chunked ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: second, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Response, second ]
+      content:
+        size: 320000
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_failed
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third ]
+        - [ uuid, GET_failed ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: third, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+  - client-request:
+      method: "HEAD"
+      version: "1.1"
+      url: /api/head/fail_not_escalated
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ X-Request, head_fail_not_escalated ]
+        - [ uuid, HEAD_fail_not_escalated ]
+
+    proxy-request:
+      method: "HEAD"
+      headers:
+        fields:
+        - [ X-Request, { value: head_fail_not_escalated, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ X-Response, head_fail_not_escalated ]
+
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /api/post/fail_not_escalated
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Type, "application/json" ]
+        - [ Content-Length, 1234 ]
+        - [ X-Request, post_fail_not_escalated ]
+        - [ uuid, POST_fail_not_escalated ]
+      content:
+        encoding: plain
+        size: 1234
+
+    proxy-request:
+      method: "POST"
+      headers:
+        fields:
+        - [ X-Request, { value: post_fail_not_escalated, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ X-Response, post_fail_not_escalated ]

--- a/tests/gold_tests/pluginTest/escalate/escalate_original_server_non_get.replay.yaml
+++ b/tests/gold_tests/pluginTest/escalate/escalate_original_server_non_get.replay.yaml
@@ -1,0 +1,149 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, first ]
+        - [ uuid, GET ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: first, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 320000 ]
+        - [ X-Response, first ]
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_chunked
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, second ]
+        - [ uuid, GET_chunked ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: second, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Transfer-Encoding, chunked ]
+        - [ X-Response, second ]
+      content:
+        size: 320000
+
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /path/get_failed
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Length, 0 ]
+        - [ X-Request, third ]
+        - [ uuid, GET_failed ]
+
+    proxy-request:
+      method: "GET"
+      headers:
+        fields:
+        - [ X-Request, { value: third, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /api/upload/data
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ Content-Type, "application/json" ]
+        - [ Content-Length, 32 ]
+        - [ X-Request, post_success ]
+        - [ uuid, POST_success ]
+      content:
+        encoding: plain
+        size: 32
+
+    proxy-request:
+      method: "POST"
+      headers:
+        fields:
+        - [ X-Request, { value: post_success, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 32 ]
+        - [ X-Response, post_success ]
+
+  - client-request:
+      method: "HEAD"
+      version: "1.1"
+      url: /api/head/data
+      headers:
+        fields:
+        - [ Host, origin.server.com ]
+        - [ X-Request, head_fail_escalated ]
+        - [ uuid, HEAD_fail_escalated ]
+
+    proxy-request:
+      method: "HEAD"
+      headers:
+        fields:
+        - [ X-Request, { value: head_fail_escalated, as: equal } ]
+
+    server-response:
+      status: 502
+      reason: Bad Gateway
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+        - [ X-Response, head_fail_escalated ]

--- a/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.test.py
@@ -34,6 +34,7 @@ class TestJA4Fingerprint:
     '''Configure a test for ja4_fingerprint.'''
 
     replay_filepath: str = 'ja4_fingerprint.replay.yaml'
+    basic_server_replay_filepath: str = 'ja4_fingerprint_basic_server.replay.yaml'
     client_counter: int = 0
     server_counter: int = 0
     ts_counter: int = 0
@@ -51,7 +52,8 @@ class TestJA4Fingerprint:
     def _init_run(self) -> 'TestRun':
         '''Initialize processes for the test run.'''
 
-        server_one = TestJA4Fingerprint.configure_server('yay.com')
+        replay_filepath = self.replay_filepath if self.use_preserve else self.basic_server_replay_filepath
+        server_one = TestJA4Fingerprint.configure_server('yay.com', replay_filepath=replay_filepath)
         self._configure_traffic_server(server_one)
 
         tr = Test.AddTestRun(self.name)
@@ -96,11 +98,9 @@ class TestJA4Fingerprint:
         return wrapper
 
     @staticmethod
-    def configure_server(domain: str):
+    def configure_server(domain: str, replay_filepath: str):
         server = Test.MakeVerifierServerProcess(
-            f'server{TestJA4Fingerprint.server_counter + 1}.{domain}',
-            TestJA4Fingerprint.replay_filepath,
-            other_args='--format \'{url}\'')
+            f'server{TestJA4Fingerprint.server_counter + 1}.{domain}', replay_filepath, other_args="--format '{url}'")
         TestJA4Fingerprint.server_counter += 1
 
         return server

--- a/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint_basic_server.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint_basic_server.replay.yaml
@@ -1,0 +1,49 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- protocol:
+  - name: http
+    version: 1
+  - name: tcp
+  - name: ip
+
+  transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /resource
+      headers:
+        fields:
+        - [ Connection, keep-alive ]
+        - [ Content-Length, 0 ]
+        - [ uuid, no-existing-headers ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ ja4, { as: present } ]
+        - [ x-ja4-via, { value: 'test.proxy.com', as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      content:
+        encoding: plain
+        data: Yay!

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump_ip_filter_server.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump_ip_filter_server.yaml
@@ -1,0 +1,44 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: GET
+      url: /one
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ X-Request-1, ultra_sensitive ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 1 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request-1, { value: ultra_sensitive, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, classified_not_for_logging ]

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump_server.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump_server.yaml
@@ -1,0 +1,239 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+  blocks:
+  - 200_ok_response: &200_ok_response
+      server-response:
+        status: 200
+        reason: OK
+        headers:
+          fields:
+          - [ Content-Length, 16 ]
+          - [ Connection, close ]
+
+sessions:
+- transactions:
+  - client-request:
+      method: GET
+      url: /one
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ X-Request-1, ultra_sensitive ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 1 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request-1, { value: ultra_sensitive, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, classified_not_for_logging ]
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /two
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ X-Request-2, also_very_sensitive ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 2 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Request-2, { value: also_very_sensitive, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, classified_not_for_logging ]
+
+- transactions:
+  - client-request:
+      method: GET
+      url: "http://www.some.host.com/candy"
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.some.host.com ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 3 ]
+
+    proxy-request:
+      url:
+      - [ scheme, { as: absent } ]
+      - [ host, { as: absent } ]
+      - [ path, { value: /candy, as: equal } ]
+      headers:
+        fields:
+        - [ Host, { value: www.some.host.com, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, classified_not_for_logging ]
+
+- transactions:
+  - client-request:
+      method: POST
+      url: /post/with/body
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ Content-Length, 12345 ]
+        - [ uuid, 4 ]
+
+    proxy-request:
+      url:
+      - [ path, { value: /post/with/body, as: equal } ]
+      headers:
+        fields:
+        - [ Host, { value: www.notls.com, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Set-Cookie, classified_not_for_logging ]
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /expect/this/to/be/cached
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 5 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 16 ]
+        - [ Cache-Control, max-age=300 ]
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /first
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 7 ]
+
+    <<: *200_ok_response
+
+  - client-request:
+      method: GET
+      url: /second
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.notls.com ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 8 ]
+
+    <<: *200_ok_response
+
+- protocol: [ {name: tls, sni: www.tls.com },
+              {name: tcp },
+              {name: ip} ]
+
+  transactions:
+  - client-request:
+      method: GET
+      url: /tls
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.tls.com ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 9 ]
+
+    <<: *200_ok_response
+
+- protocol: [ {name: http, version: 2},
+              {name: tls, sni: www.tls.com},
+              {name: tcp},
+              {name: ip} ]
+
+  transactions:
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.tls.com ]
+        - [ :path, /h2_first ]
+        - [ uuid, 10 ]
+
+    <<: *200_ok_response
+
+  - client-request:
+      headers:
+        fields:
+        - [ :method, GET ]
+        - [ :scheme, https ]
+        - [ :authority, www.tls.com ]
+        - [ :path, /h2_second ]
+        - [ uuid, 11 ]
+
+    <<: *200_ok_response
+
+- protocol: [ {name: tls, sni: www.client_only_tls.com},
+              {name: tcp},
+              {name: ip} ]
+
+  transactions:
+  - client-request:
+      method: GET
+      url: /client_only_tls
+      version: 1.1
+      headers:
+        fields:
+        - [ Host, www.client_only_tls.com ]
+        - [ Content-Length, 0 ]
+        - [ uuid, 12 ]
+
+    <<: *200_ok_response

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump.test.py
@@ -30,7 +30,8 @@ schema_path = os.path.join(Test.Variables.AtsTestToolsDir, 'lib', 'replay_schema
 
 # Configure the origin server.
 replay_file = "replay/traffic_dump.yaml"
-server = Test.MakeVerifierServerProcess("server", replay_file, ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem")
+server = Test.MakeVerifierServerProcess(
+    "server", "replay/traffic_dump_server.yaml", ssl_cert="ssl/server_combined.pem", ca_cert="ssl/signer.pem")
 
 # Define ATS and configure it.
 ts = Test.MakeATSProcess("ts", enable_tls=True)

--- a/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
+++ b/tests/gold_tests/pluginTest/traffic_dump/traffic_dump_ip_filter.test.py
@@ -28,7 +28,7 @@ Test.SkipUnless(Condition.PluginExists('traffic_dump.so'),)
 
 # Configure the origin server.
 replay_file = "replay/traffic_dump.yaml"
-server = Test.MakeVerifierServerProcess("server", replay_file)
+server = Test.MakeVerifierServerProcess("server", "replay/traffic_dump_ip_filter_server.yaml")
 
 
 def get_common_ats_process(name, plugin_command, replay_exists):

--- a/tests/gold_tests/pluginTest/txn_box/basic/redirect.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/redirect.replay.yaml
@@ -72,8 +72,6 @@ sessions:
       headers:
         fields:
         - [ Host, base.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -89,8 +87,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -106,8 +102,6 @@ sessions:
       headers:
         fields:
         - [ Host, base.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -123,8 +117,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -140,8 +132,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -158,8 +148,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -194,8 +182,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -211,8 +197,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -228,8 +212,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "encode.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -244,8 +226,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "decode.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/tests/gold_tests/pluginTest/txn_box/basic/reply.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/reply.replay.yaml
@@ -65,8 +65,6 @@ sessions:
       headers:
         fields:
         - [ Host, bad.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -79,8 +77,6 @@ sessions:
       headers:
         fields:
         - [ Host, bad.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -93,8 +89,6 @@ sessions:
       headers:
         fields:
         - [ Host, bad.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/tests/gold_tests/pluginTest/txn_box/prod/cors-origin.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/cors-origin.replay.yaml
@@ -67,8 +67,6 @@ sessions:
       headers:
         fields:
         - [ Host, api.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -83,8 +81,6 @@ sessions:
         fields:
         - [ Host, api.ex ]
         - [ Origin, "https://echo.ex" ]
-    proxy-request:
-        <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -107,4 +103,3 @@ sessions:
       headers:
         fields:
         - [ "CORS", { value: "https://delta.ex", as: equal }]
-

--- a/tests/gold_tests/pluginTest/txn_box/prod/cors-referrer.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/cors-referrer.replay.yaml
@@ -74,8 +74,6 @@ sessions:
       headers:
         fields:
         - [ Host, api.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -90,8 +88,6 @@ sessions:
         fields:
         - [ Host, api.ex ]
         - [ Referrer, "http://echo.ex/ui/demo" ]
-    proxy-request:
-        <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -114,4 +110,3 @@ sessions:
       headers:
         fields:
         - [ "CORS", { value: "delta.ex", as: equal }]
-

--- a/tests/gold_tests/pluginTest/txn_box/prod/ip-acl.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/ip-acl.replay.yaml
@@ -84,8 +84,6 @@ sessions:
         fields:
         - [ Host, base.ex ]
         - [ addr, "192.168.2.3" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -122,4 +120,3 @@ sessions:
       <<: *base-rsp
     proxy-response:
       status: 200
-

--- a/tests/gold_tests/pluginTest/txn_box/prod/stanley.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/stanley.replay.yaml
@@ -48,8 +48,6 @@ sessions:
         fields:
         - [ Host, "nowhere.com" ]
         - [ ycal-host, "calendar.yahoo.com" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -66,8 +64,6 @@ sessions:
         fields:
         - [ Host, "notepad.mail.yahoo.com" ]
         - [ ycal-host, "bop.yahoo.com" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -75,4 +71,3 @@ sessions:
       headers:
         fields:
         - [ Location, { value: "view=notepad", as: "contains" } ]
-

--- a/tests/gold_tests/pluginTest/txn_box/prod/yts-3489.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/yts-3489.replay.yaml
@@ -81,8 +81,6 @@ sessions:
       headers:
         fields:
         - [ Host, base.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -98,8 +96,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -115,8 +111,6 @@ sessions:
       headers:
         fields:
         - [ Host, base.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -132,8 +126,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -149,8 +141,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -167,8 +157,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -203,8 +191,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "base.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -221,8 +207,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "alt.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -239,8 +223,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "alt.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -257,8 +239,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "join.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -275,8 +255,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "join.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -293,8 +271,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "concat.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -311,8 +287,6 @@ sessions:
       headers:
         fields:
         - [ "Host", "concat.ex" ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/tests/gold_tests/pluginTest/txn_box/static_file/static_file.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/static_file/static_file.replay.yaml
@@ -341,8 +341,6 @@ sessions:
       headers:
         fields:
         - [ Host, unmapped.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -356,8 +354,6 @@ sessions:
       headers:
         fields:
         - [ Host, unmapped.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -371,8 +367,6 @@ sessions:
       headers:
         fields:
         - [ Host, unmapped.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -386,8 +380,6 @@ sessions:
       headers:
         fields:
         - [ Host, base.ex ]
-    proxy-request:
-      <<: *base-req
     server-response:
       status: 404
       reason: "Missing"


### PR DESCRIPTION
The latest proxy-verifier now fails a run when a verifier server or
client is given proxy-side checks for traffic that ATS never produces.
Most tests only needed stale proxy-request or proxy-response nodes
removed, but the shared replay cases below need server-specific files
so each verifier only owns traffic it can actually observe.

- disable_pristine_host_hdr_server_canary_false.replay.yaml keeps
  the canary server on uuid 1 when pristine_host_hdr stays enabled.
- disable_pristine_host_hdr_server_canary_true.replay.yaml keeps the
  canary server on uuid 1 when the Host header is rewritten.
- disable_pristine_host_hdr_server_stable.replay.yaml keeps the
  stable server on uuid 2, which the canary server never receives.
- escalate_original_server_default.replay.yaml keeps only the
  requests that the default-mode origin server really handles.
- escalate_failover_server_default.replay.yaml keeps only the GET
  requests that default-mode escalation sends to failover.
- escalate_original_server_non_get.replay.yaml keeps the origin-side
  subset when --escalate-non-get-methods is enabled.
- escalate_failover_server_non_get.replay.yaml keeps the failover
  subset, including the escalated HEAD request in that mode.
- ja4_fingerprint_basic_server.replay.yaml limits the non-preserve
  test to its one real request instead of preserve-only checks.
- traffic_dump_server.yaml keeps origin verification only for the
  sessions that really reach origin in the main traffic_dump test.
- traffic_dump_ip_filter_server.yaml keeps only the /one request
  used by the traffic_dump IP filter test.

These per-server replays preserve fallback server-response directives
and client-side coverage while dropping only the proxy-side checks
that latest proxy-verifier now correctly reports as unprocessed.