### PR TITLE
Add TLS support to ats_replay.test.ext using ssl_multicert.yaml

### DIFF
--- a/tests/gold_tests/autest-site/ats_replay.test.ext
+++ b/tests/gold_tests/autest-site/ats_replay.test.ext
@@ -38,6 +38,37 @@ def configure_ats(obj: 'TestRun', server: 'Process', ats_config: dict, dns: Opti
     records_config = ats_config.get('records_config', {})
     ts.Disk.records_config.update(records_config)
 
+    # TLS configs
+    enable_tls = process_config.get('enable_tls', False)
+    if enable_tls:
+        # Configure ssl_multicert.yaml if specified.
+        ssl_multicert_yaml = ats_config.get('ssl_multicert_yaml', [])
+
+        # setup default cert and key if ssl_multicert_yaml is empty
+        if ssl_multicert_yaml == []:
+            ts.addDefaultSSLFiles()
+
+            ts.Disk.records_config.update(
+                {
+                    'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+                    'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+                })
+
+            ssl_multicert_yaml = [
+                "ssl_multicert:",
+                "  - ssl_cert_name: server.pem",
+                "    ssl_key_name: server.key",
+                '    dest_ip: "*"',
+            ]
+
+        for line in ssl_multicert_yaml:
+            ts.Disk.ssl_multicert_yaml.AddLine(line)
+
+        # Configure sni.yaml if specified.
+        sni_yaml = ats_config.get('sni_yaml')
+        if sni_yaml != None:
+            ts.Disk.sni_yaml.AddLines(yaml.dump(sni_yaml).split('\n'))
+
     # Configure plugin_config if specified.
     plugin_config = ats_config.get('plugin_config', [])
     for plugin_line in plugin_config:


### PR DESCRIPTION
## Summary

- The `ssl_multicert.config` → `ssl_multicert.yaml` migration (#12755) removed the TLS configuration block from `ats_replay.test.ext`, but `ATSReplayTest` still needs it for tests that use `enable_tls: true`
- Without this, when master's `chunked_encoding` test (which includes `large_chunked.replay.yaml` with `enable_tls: true`) is merged in via #12983, it hits `AttributeError: 'Disk' object has no attribute 'ssl_multicert_config'`
- Adds the TLS configuration back using the new `ssl_multicert.yaml` YAML format

## Test plan

- [x] Reproduced the exception in Fedora 42 CI Docker image
- [x] Verified `chunked_encoding` test passes (0 exceptions) with the fix
- [x] Verified `cache-auth` test still passes with the fix