### PR TITLE
Disable merge commit button after temporary release window

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,8 +29,8 @@ github:
     squash: true
     # Disable rebase button:
     rebase: false
-    # Enable merge button:
-    merge: true
+    # Disable merge commit button:
+    merge: false
   collaborators:
     - mtorluemke
     - c-taylor


### PR DESCRIPTION
## Summary
- Revert the temporary `.asf.yaml` change that enabled merge commits for the 11-dev to master history-preserving merge.
- Restore the normal setting by setting `merge: false`.
- Clarify the comment to explicitly say this controls the merge commit button.

## Test plan
- [x] Confirm `.asf.yaml` sets `enabled_merge_buttons.merge: false`
- [x] Confirm comment reads `Disable merge commit button`