### PR TITLE
Initialize remaining Coverity uninit members in core and ESI

### DIFF
--- a/include/iocore/net/TLSEventSupport.h
+++ b/include/iocore/net/TLSEventSupport.h
@@ -78,7 +78,7 @@ protected:
 
 private:
   static int _ex_data_index;
-  SSL       *_ssl;
+  SSL       *_ssl{nullptr};
 
   bool _first_handshake_hooks_pre          = true;
   bool _first_handshake_hooks_outbound_pre = true;

--- a/include/proxy/hdrs/HdrHeap.h
+++ b/include/proxy/hdrs/HdrHeap.h
@@ -148,7 +148,7 @@ private:
   HdrStrHeap(uint32_t total_size) : _total_size{total_size} {}
 
   uint32_t const _total_size;
-  uint32_t       _avail_size;
+  uint32_t       _avail_size{0};
 };
 
 inline bool

--- a/plugins/esi/lib/EsiGunzip.cc
+++ b/plugins/esi/lib/EsiGunzip.cc
@@ -30,15 +30,6 @@
 using std::string;
 using namespace EsiLib;
 
-EsiGunzip::EsiGunzip() : _downstream_length(0), _total_data_length(0)
-{
-  _init    = false;
-  _success = true;
-  // zlib _zstrm variables are initialized when they are required in stream_decode
-  // coverity[uninit_member]
-  // coverity[uninit_ctor]
-}
-
 bool
 EsiGunzip::stream_finish()
 {

--- a/plugins/esi/lib/EsiGunzip.h
+++ b/plugins/esi/lib/EsiGunzip.h
@@ -30,7 +30,7 @@
 class EsiGunzip
 {
 public:
-  EsiGunzip();
+  EsiGunzip() = default;
 
   ~EsiGunzip();
 
@@ -45,10 +45,10 @@ public:
   bool stream_finish();
 
 private:
-  int64_t  _downstream_length;
-  int64_t  _total_data_length;
-  z_stream _zstrm;
+  int64_t  _downstream_length{0};
+  int64_t  _total_data_length{0};
+  z_stream _zstrm{};
 
-  bool _init;
-  bool _success;
+  bool _init{false};
+  bool _success{true};
 };

--- a/plugins/esi/lib/EsiGzip.cc
+++ b/plugins/esi/lib/EsiGzip.cc
@@ -30,13 +30,6 @@
 using std::string;
 using namespace EsiLib;
 
-EsiGzip::EsiGzip() : _downstream_length(0), _total_data_length(0), _crc(0)
-{
-  // Zlib _zstrm variables are initialized when they are required in runDeflateLoop
-  // coverity[uninit_member]
-  // coverity[uninit_ctor]
-}
-
 template <typename T>
 inline void
 append(string &out, T data)

--- a/plugins/esi/lib/EsiGzip.h
+++ b/plugins/esi/lib/EsiGzip.h
@@ -31,7 +31,7 @@
 class EsiGzip
 {
 public:
-  EsiGzip();
+  EsiGzip() = default;
 
   ~EsiGzip();
 
@@ -65,12 +65,12 @@ public:
 
 private:
   /** The cumulative total number of bytes for the compressed stream. */
-  int64_t _downstream_length;
+  int64_t _downstream_length{0};
 
   /** The cumulative total number of uncompressed bytes that have been
    * compressed.
    */
-  int64_t  _total_data_length;
-  z_stream _zstrm;
-  uLong    _crc;
+  int64_t  _total_data_length{0};
+  z_stream _zstrm{};
+  uLong    _crc{0};
 };

--- a/plugins/experimental/txn_box/plugin/src/Ex_HTTP.cc
+++ b/plugins/experimental/txn_box/plugin/src/Ex_HTTP.cc
@@ -557,7 +557,7 @@ Ex_ua_req_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_ua_req_port::extract(Context &ctx, Spec const &)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (ts::URL url{hdr.url()}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
@@ -585,7 +585,7 @@ Ex_proxy_req_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_proxy_req_port::extract(Context &ctx, Spec const &)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (ts::URL url{hdr.url()}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
@@ -1022,7 +1022,7 @@ Ex_pre_remap_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_pre_remap_port::extract(Context &ctx, Spec const &)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   if (auto url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     zret = static_cast<feature_type_for<INTEGER>>(url.port());
   }
@@ -1048,7 +1048,7 @@ Ex_remap_target_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_remap_target_port::extract(Context &ctx, Spec const &)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   if (ctx._remap_info) {
     if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
@@ -1077,7 +1077,7 @@ Ex_remap_replacement_port::validate(Config &, Spec &, const swoc::TextView &)
 Feature
 Ex_remap_replacement_port::extract(Context &ctx, Spec const &)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   if (ctx._remap_info) {
     if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());

--- a/plugins/experimental/txn_box/plugin/src/text_block.cc
+++ b/plugins/experimental/txn_box/plugin/src/text_block.cc
@@ -480,7 +480,7 @@ Mod_as_text_block::load(Config &cfg, YAML::Node, TextView, TextView, YAML::Node 
 Rv<Feature>
 Mod_as_text_block::operator()(Context &ctx, Feature &feature)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   if (IndexFor(STRING) == feature.index()) {
     auto const &tag = std::get<IndexFor(STRING)>(feature); // get the name.
     zret            = Ex_text_block::extract_block(ctx, tag);

--- a/src/iocore/net/P_SSLConfig.h
+++ b/src/iocore/net/P_SSLConfig.h
@@ -68,8 +68,8 @@ struct SSLConfigParams : public ConfigInfo {
   int   configExitOnLoadError;
   int   clientCertLevel;
   int   verify_depth;
-  int   ssl_origin_session_cache;
-  int   ssl_origin_session_cache_size;
+  int   ssl_origin_session_cache{0};
+  int   ssl_origin_session_cache_size{0};
 
   char                   *clientCertPath;
   char                   *clientCertPathOnly;
@@ -80,7 +80,6 @@ struct SSLConfigParams : public ConfigInfo {
   int                     clientCertExitOnLoadError;
   YamlSNIConfig::Policy   verifyServerPolicy;
   YamlSNIConfig::Property verifyServerProperties;
-  bool                    tls_server_connection;
   int                     client_verify_depth;
   long                    ssl_ctx_options;
   long                    ssl_client_ctx_options;


### PR DESCRIPTION
## Summary
- Initialize remaining uninitialized members in core networking and header heap paths using explicit brace initialization.
- Move ESI gzip/gunzip member defaults to in-class brace initialization and default the constructors.
- Initialize remaining txn_box local `Feature` defaults to `NIL_FEATURE` where Coverity had flagged unresolved uninitialized paths.
- Keep construction-time defaults explicit so object state is defined before use.

CIDs targeted:
- Core/ESI: 1295339, 1587251, 1533662, 1521595, 1521596
- txn_box follow-up: 1534699, 1534717, 1534727, 1534732, 1534738, 1644248

## Test plan
- `cmake --build build-dev-asan -j8 --target traffic_server`
- `cmake --build build-dev-asan -j8 --target esicore`
- Verify branch diff is limited to intended files.