### PR TITLE
Fix remaining uninitialized variable and field Coverity defects

### DIFF
--- a/include/iocore/net/TLSSNISupport.h
+++ b/include/iocore/net/TLSSNISupport.h
@@ -84,7 +84,7 @@ public:
     ClientHelloContainer _chc;
 #if HAVE_SSL_CTX_SET_CLIENT_HELLO_CB
     int   *_ext_ids = nullptr;
-    size_t _ext_len;
+    size_t _ext_len{0};
 #endif
   };
 

--- a/include/proxy/HostStatus.h
+++ b/include/proxy/HostStatus.h
@@ -99,17 +99,17 @@ struct HostStatuses {
 
 // host status POD
 struct HostStatRec {
-  TSHostStatus status;
-  unsigned int reasons;
+  TSHostStatus status{TSHostStatus::TS_HOST_STATUS_INIT};
+  unsigned int reasons{0};
   // time the host was marked down for a given reason.
-  time_t active_marked_down;
-  time_t local_marked_down;
-  time_t manual_marked_down;
-  time_t self_detect_marked_down;
+  time_t active_marked_down{0};
+  time_t local_marked_down{0};
+  time_t manual_marked_down{0};
+  time_t self_detect_marked_down{0};
   // number of seconds that the host should be marked down for a given reason.
-  unsigned int active_down_time;
-  unsigned int local_down_time;
-  unsigned int manual_down_time;
+  unsigned int active_down_time{0};
+  unsigned int local_down_time{0};
+  unsigned int manual_down_time{0};
 
   HostStatRec();
   HostStatRec(std::string str);

--- a/include/proxy/http/HttpTunnel.h
+++ b/include/proxy/http/HttpTunnel.h
@@ -132,7 +132,7 @@ struct ChunkedHandler {
   //@{
   /// The maximum chunk size.
   /// This is the preferred size as well, used whenever possible.
-  int64_t max_chunk_size;
+  int64_t max_chunk_size{DEFAULT_MAX_CHUNK_SIZE};
   /// Caching members to avoid using printf on every chunk.
   /// It holds the header for a maximal sized chunk which will cover
   /// almost all output chunks.

--- a/include/proxy/http/HttpVCTable.h
+++ b/include/proxy/http/HttpVCTable.h
@@ -41,17 +41,17 @@ enum class HttpVC_t {
 };
 
 struct HttpVCTableEntry {
-  VConnection  *vc;
-  MIOBuffer    *read_buffer;
-  MIOBuffer    *write_buffer;
-  VIO          *read_vio;
-  VIO          *write_vio;
-  HttpSMHandler vc_read_handler;
-  HttpSMHandler vc_write_handler;
-  HttpVC_t      vc_type;
-  HttpSM       *sm;
-  bool          eos;
-  bool          in_tunnel;
+  VConnection  *vc{nullptr};
+  MIOBuffer    *read_buffer{nullptr};
+  MIOBuffer    *write_buffer{nullptr};
+  VIO          *read_vio{nullptr};
+  VIO          *write_vio{nullptr};
+  HttpSMHandler vc_read_handler{};
+  HttpSMHandler vc_write_handler{};
+  HttpVC_t      vc_type{HttpVC_t::UNKNOWN};
+  HttpSM       *sm{nullptr};
+  bool          eos{false};
+  bool          in_tunnel{false};
 };
 
 struct HttpVCTable {

--- a/plugins/experimental/cache_fill/configs.cc
+++ b/plugins/experimental/cache_fill/configs.cc
@@ -157,7 +157,7 @@ BgFetchConfig::readConfig(const char *config_file)
           swoc::bwprint(ts::bw_dbg, "adding background_fetch address range rule {} for {}: {}", exclude, cfg_name, cfg_value);
           Dbg(dbg_ctl, "%s", ts::bw_dbg.c_str());
         } else if ("Content-Length"_tv == cfg_name) {
-          BgFetchRule::size_cmp_type::OP op;
+          BgFetchRule::size_cmp_type::OP op{BgFetchRule::size_cmp_type::LESS_THAN_OR_EQUAL};
           if (cfg_value[0] == '<') {
             op = BgFetchRule::size_cmp_type::LESS_THAN_OR_EQUAL;
           } else if (cfg_value[0] == '>') {

--- a/plugins/experimental/txn_box/plugin/src/Ex_Base.cc
+++ b/plugins/experimental/txn_box/plugin/src/Ex_Base.cc
@@ -299,7 +299,7 @@ Ex_txn_conf::validate(Config &cfg, Spec &spec, const TextView &arg)
 Feature
 Ex_txn_conf::extract(Context &ctx, const Extractor::Spec &spec)
 {
-  Feature zret{};
+  Feature zret{NIL_FEATURE};
   auto    var            = spec._data.span.rebind<store_type>()[0];
   auto &&[value, errata] = ctx._txn.override_fetch(*var);
   if (errata.is_ok()) {

--- a/src/proxy/http/HttpVCTable.cc
+++ b/src/proxy/http/HttpVCTable.cc
@@ -30,11 +30,7 @@
 
 class HttpSM;
 
-HttpVCTable::HttpVCTable(HttpSM *mysm)
-{
-  memset(&vc_table, 0, sizeof(vc_table));
-  sm = mysm;
-}
+HttpVCTable::HttpVCTable(HttpSM *mysm) : sm(mysm) {}
 
 HttpVCTableEntry *
 HttpVCTable::new_entry()


### PR DESCRIPTION
### Problem
Coverity reported several uninitialized variable and field defects in core HTTP/TLS code and experimental plugins, which could lead to undefined behavior and non-deterministic runtime state.

### Changes
- **Initialize core proxy structs** -- add in-class brace defaults for `HttpVCTableEntry` and `HostStatRec` fields so entries and host state begin in a deterministic state.
- **Initialize protocol parsing fields** -- default `ChunkedHandler::max_chunk_size` and `TLSSNISupport::ClientHello::_ext_len` to known values.
- **Initialize plugin locals** -- set explicit initial values for `cache_fill` parsing enum and `txn_box` feature return state.
- **Address portability in constructor init** -- remove `memset` from `HttpVCTable` construction and rely on proper initialization, avoiding non-portable treatment of pointer-to-member-function types.

### Testing
- [x] CI passed on GitHub checks
- [ ] Verify Coverity marks CIDs 1021690, 1508845, 1533658, 1534712, 1544456, and 1645800 as fixed on next analysis run

<!-- merge-description-updated:2026-03-23T00:00:00Z -->