### PR TITLE
Remove unused member variables across multiple subsystems

### DIFF
--- a/include/iocore/aio/AIO.h
+++ b/include/iocore/aio/AIO.h
@@ -58,7 +58,6 @@ struct ink_aiocb {
   off_t  aio_offset = 0;       /* file offset */
 
   int aio_lio_opcode = 0; /* listio operation */
-  int aio_state      = 0; /* state flag for List I/O */
 };
 
 bool ink_aio_thread_num_set(int thread_num);

--- a/include/iocore/eventsystem/Event.h
+++ b/include/iocore/eventsystem/Event.h
@@ -267,20 +267,6 @@ public:
   | UNIX/non-NT Interface                                   |
   \*-------------------------------------------------------*/
 
-#ifdef ONLY_USED_FOR_FIB_AND_BIN_HEAP
-  void *node_pointer;
-  void
-  set_node_pointer(void *x)
-  {
-    node_pointer = x;
-  }
-  void *
-  get_node_pointer()
-  {
-    return node_pointer;
-  }
-#endif
-
 #if defined(__GNUC__)
   ~Event() override {}
 #endif

--- a/include/proxy/ParentConsistentHash.h
+++ b/include/proxy/ParentConsistentHash.h
@@ -41,7 +41,6 @@ class ParentConsistentHash : public ParentSelectionStrategy
   std::unique_ptr<ATSHash64>         hash[2];
   std::unique_ptr<ATSConsistentHash> chash[2];
   pRecord                           *parents[2];
-  bool                               foundParents[2][MAX_PARENTS];
   bool                               ignore_query;
   int                                secondary_mode;
   ParentHashAlgorithm                selected_algorithm;

--- a/include/proxy/http/ConnectingEntry.h
+++ b/include/proxy/http/ConnectingEntry.h
@@ -54,7 +54,6 @@ private:
   MIOBuffer      *_netvc_read_buffer = nullptr;
   IOBufferReader *_netvc_reader      = nullptr;
   Action         *_pending_action    = nullptr;
-  NetVCOptions    opt;
 };
 
 struct IpHelper {

--- a/include/proxy/http/Http1ClientTransaction.h
+++ b/include/proxy/http/Http1ClientTransaction.h
@@ -41,10 +41,4 @@ public:
   void transaction_done() override;
   void increment_transactions_stat() override;
   void decrement_transactions_stat() override;
-
-  ////////////////////
-  // Variables
-
-protected:
-  bool outbound_transparent{false};
 };

--- a/include/proxy/http/Http1ServerTransaction.h
+++ b/include/proxy/http/Http1ServerTransaction.h
@@ -44,10 +44,4 @@ public:
   void transaction_done() override;
 
   void force_close();
-
-  ////////////////////
-  // Variables
-
-protected:
-  bool outbound_transparent{false};
 };

--- a/include/proxy/http/HttpSM.h
+++ b/include/proxy/http/HttpSM.h
@@ -483,10 +483,9 @@ private:
    */
   void setup_client_request_plugin_agents(HttpTunnelProducer *p, int num_header_bytes = 0);
 
-  HttpTransact::StateMachineAction_t last_action     = HttpTransact::StateMachineAction_t::UNDEFINED;
-  int (HttpSM::*m_last_state)(int event, void *data) = nullptr;
-  virtual void set_next_state();
-  void         call_transact_and_set_next_state(TransactEntryFunc_t f);
+  HttpTransact::StateMachineAction_t last_action = HttpTransact::StateMachineAction_t::UNDEFINED;
+  virtual void                       set_next_state();
+  void                               call_transact_and_set_next_state(TransactEntryFunc_t f);
 
   bool    is_http_server_eos_truncation(HttpTunnelProducer *);
   bool    is_bg_fill_necessary(HttpTunnelConsumer *c);
@@ -564,11 +563,7 @@ private:
   APIHook const *cur_hook    = nullptr;
   HttpHookState  hook_state;
 
-  // Continuation time keeper
-  int64_t prev_hook_start_time = 0;
-
   int            reentrancy_count = 0;
-  int            cur_hooks        = 0;
   HttpApiState_t callout_state    = HttpApiState_t::NO_CALLOUT;
 
   // api_hooks must not be changed directly

--- a/include/proxy/logging/LogBuffer.h
+++ b/include/proxy/logging/LogBuffer.h
@@ -284,7 +284,7 @@ public:
 class LogBufferIterator
 {
 public:
-  LogBufferIterator(LogBufferHeader *header, bool in_network_order = false);
+  LogBufferIterator(LogBufferHeader *header);
   ~LogBufferIterator();
 
   LogEntryHeader *next();
@@ -295,7 +295,6 @@ public:
   LogBufferIterator &operator=(const LogBufferIterator &) = delete;
 
 private:
-  bool     m_in_network_order;
   char    *m_next;
   unsigned m_iter_entry_count;
   unsigned m_buffer_entry_count;
@@ -311,8 +310,8 @@ private:
   within a given LogBuffer.
   -------------------------------------------------------------------------*/
 
-inline LogBufferIterator::LogBufferIterator(LogBufferHeader *header, bool in_network_order)
-  : m_in_network_order(in_network_order), m_next(nullptr), m_iter_entry_count(0), m_buffer_entry_count(0)
+inline LogBufferIterator::LogBufferIterator(LogBufferHeader *header)
+  : m_next(nullptr), m_iter_entry_count(0), m_buffer_entry_count(0)
 {
   ink_assert(header);
 

--- a/include/tscore/ink_aiocb.h
+++ b/include/tscore/ink_aiocb.h
@@ -49,6 +49,4 @@ struct ink_aiocb {
   off_t  aio_offset; /* file offset */
 
   int aio_lio_opcode; /* listio operation */
-  int aio_state;      /* state flag for List I/O */
-  int aio__pad[1];    /* extension padding */
 };

--- a/src/iocore/aio/AIO.cc
+++ b/src/iocore/aio/AIO.cc
@@ -112,7 +112,6 @@ struct AIO_Reqs {
   ASLL(AIOCallback, alink) aio_temp_list;
   ink_mutex aio_mutex;
   ink_cond  aio_cond;
-  int       index           = 0;  /* position of this struct in the aio_reqs array */
   int       pending         = 0;  /* number of outstanding requests on the disk */
   int       queued          = 0;  /* total number of aio_todo requests */
   int       filedes         = -1; /* the file descriptor for the requests or status IO_NOT_IN_PROGRESS */
@@ -301,13 +300,11 @@ aio_init_fildes(int fildes, int fromAPI = 0)
   RecInt thread_num;
 
   if (fromAPI) {
-    request->index    = 0;
     request->filedes  = -1;
     aio_reqs[0]       = request;
     thread_is_created = 1;
     thread_num        = api_config_threads_per_disk;
   } else {
-    request->index        = num_filedes;
     request->filedes      = fildes;
     aio_reqs[num_filedes] = request;
     thread_num            = cache_config_threads_per_disk;

--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -123,7 +123,6 @@ OpenDir::signal_readers(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   while ((c = delayed_readers.dequeue())) {
     CACHE_TRY_LOCK(lock, c->mutex, t);
     if (lock.is_locked()) {
-      c->f.open_read_timeout = 0;
       c->handleEvent(EVENT_IMMEDIATE, nullptr);
       continue;
     }

--- a/src/iocore/cache/CacheVC.h
+++ b/src/iocore/cache/CacheVC.h
@@ -289,26 +289,26 @@ struct CacheVC : public CacheVConnection {
   union {
     uint32_t flags;
     struct {
-      unsigned int use_first_key           : 1;
-      unsigned int overwrite               : 1; // overwrite first_key Dir if it exists
-      unsigned int close_complete          : 1; // WRITE_COMPLETE is final
-      unsigned int sync                    : 1; // write to be committed to durable storage before WRITE_COMPLETE
-      unsigned int evacuator               : 1;
-      unsigned int single_fragment         : 1;
-      unsigned int evac_vector             : 1;
-      unsigned int lookup                  : 1;
-      unsigned int update                  : 1;
-      unsigned int remove                  : 1;
-      unsigned int remove_aborted_writers  : 1;
-      unsigned int open_read_timeout       : 1; // UNUSED
-      unsigned int data_done               : 1;
-      unsigned int read_from_writer_called : 1;
-      unsigned int rewrite_resident_alt    : 1;
-      unsigned int readers                 : 1;
-      unsigned int doc_from_ram_cache      : 1;
-      unsigned int hit_evacuate            : 1;
-      unsigned int compressed_in_ram       : 1; // compressed state in ram cache
-      unsigned int allow_empty_doc         : 1; // used for cache empty http document
+      unsigned int use_first_key            : 1;
+      unsigned int overwrite                : 1; // overwrite first_key Dir if it exists
+      unsigned int close_complete           : 1; // WRITE_COMPLETE is final
+      unsigned int sync                     : 1; // write to be committed to durable storage before WRITE_COMPLETE
+      unsigned int evacuator                : 1;
+      unsigned int single_fragment          : 1;
+      unsigned int evac_vector              : 1;
+      unsigned int lookup                   : 1;
+      unsigned int update                   : 1;
+      unsigned int remove                   : 1;
+      unsigned int remove_aborted_writers   : 1;
+      unsigned int unused_open_read_timeout : 1; // UNUSED, reserved for bitfield layout
+      unsigned int data_done                : 1;
+      unsigned int read_from_writer_called  : 1;
+      unsigned int rewrite_resident_alt     : 1;
+      unsigned int readers                  : 1;
+      unsigned int doc_from_ram_cache       : 1;
+      unsigned int hit_evacuate             : 1;
+      unsigned int compressed_in_ram        : 1; // compressed state in ram cache
+      unsigned int allow_empty_doc          : 1; // used for cache empty http document
     } f;
   };
   // BTF optimization used to skip reading stuff in cache partition that doesn't contain any

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -254,9 +254,6 @@ public:
   SSLNetVConnection(const SSLNetVConnection &)            = delete;
   SSLNetVConnection &operator=(const SSLNetVConnection &) = delete;
 
-  bool          protocol_mask_set = false;
-  unsigned long protocol_mask     = 0;
-
   bool
   peer_provided_cert() const override
   {

--- a/src/proxy/ParentConsistentHash.cc
+++ b/src/proxy/ParentConsistentHash.cc
@@ -42,10 +42,8 @@ ParentConsistentHash::ParentConsistentHash(ParentRecord *parent_record)
   selected_algorithm = parent_record->consistent_hash_algorithm;
   hash_seed0         = parent_record->consistent_hash_seed0;
   hash_seed1         = parent_record->consistent_hash_seed1;
-  ink_zero(foundParents);
-
-  hash[PRIMARY]  = createHashInstance(selected_algorithm, hash_seed0, hash_seed1);
-  chash[PRIMARY] = std::make_unique<ATSConsistentHash>(parent_record->consistent_hash_replicas);
+  hash[PRIMARY]      = createHashInstance(selected_algorithm, hash_seed0, hash_seed1);
+  chash[PRIMARY]     = std::make_unique<ATSConsistentHash>(parent_record->consistent_hash_replicas);
 
   for (i = 0; i < parent_record->num_parents; i++) {
     chash[PRIMARY]->insert(&(parent_record->parents[i]), parent_record->parents[i].weight, hash[PRIMARY].get());

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5902,8 +5902,7 @@ HttpSM::do_api_callout_internal()
   }
 
   hook_state.init(cur_hook_id, http_global_hooks, _ua.get_txn() ? _ua.get_txn()->feature_hooks() : nullptr, &api_hooks);
-  cur_hook  = nullptr;
-  cur_hooks = 0;
+  cur_hook = nullptr;
   return state_api_callout(0, nullptr);
 }
 


### PR DESCRIPTION
### Problem

Static analysis identified a number of unused member variables, flags, and dead code paths accumulated across core, cache, net, proxy, and plugin subsystems. Carrying these fields around inflates object sizes, misleads readers about what state is actually live, and complicates future refactors.

### Changes

- **`Event.h`**: Remove permanently dead `#ifdef ONLY_USED_FOR_FIB_AND_BIN_HEAP` block (`node_pointer`, `set_node_pointer`, `get_node_pointer`).
- **`HttpSM.h` / `HttpSM.cc`**: Remove unused `m_last_state`, `prev_hook_start_time`, and `cur_hooks` fields and drop their resets in the API callout path.
- **`CacheVC.h`**: Reorder member field alignment and rename unused `open_read_timeout` to `unused_open_read_timeout` for clarity.
- **`CacheDir.cc`**: Remove write to the now-unused `f.open_read_timeout` flag.
- **`AIO.h` / `ink_aiocb.h` / `AIO.cc`**: Remove unused `aio_state` field, `aio__pad[1]`, and the `index` bookkeeping. `aio_state` and the padding were cargo-culted from the POSIX `struct aiocb` definition when `ink_aiocb` was created. POSIX implementations include padding for future ABI compatibility, but `ink_aiocb` is entirely internal to ATS -- never shared across a binary interface or persisted to disk, and nothing reads or writes `aio_state`. Leif removed the other dead POSIX fields (`aio_reqprio`, `aio_sigevent`, `aio_resultp`) in 2019 (`e4398187`) but these two survived the cleanup.
- **`LogBuffer.h`**: Remove unused `m_in_network_order` field and simplify the `LogBufferIterator` constructor.
- **`Http1ClientTransaction.h` / `Http1ServerTransaction.h`**: Remove unused `outbound_transparent` fields.
- **`ConnectingEntry.h`**: Remove unused `opt` (`NetVCOptions`) field.
- **`ParentConsistentHash.h` / `ParentConsistentHash.cc`**: Remove unused `foundParents` member and its initialization.
- **`P_SSLNetVConnection.h`**: Remove unused `protocol_mask_set` and `protocol_mask` fields from `SSLNetVConnection`. Note: the `protocol_mask` in `TLSValidProtocols` used by SNI configuration is a different field on a different class and is not affected.

### Testing

Tested on Eris (home lab, Fedora, ASAN build):

- [x] Clean compile (844 targets `dev-asan`, 1431 targets `autest` preset)
- [x] Unit tests: 110 / 110 passed
- [x] AuTests: 390 passed, 30 skipped, 9 failed (all known flaky: `tls_conn_timeout`, `tls_client_versions`, `thread_config`, `cripts`, `allow-plain`, `sigusr2`, `per_client_connection_max`)
- [x] CI: all 15 checks green (CentOS, Clang-Analyzer, Debian, Docs, Fedora, Format, FreeBSD, OSX, RAT, Rocky, Ubuntu, AuTest 0-3of4)

<!-- merge-description-updated:2026-04-17T15:58:31Z -->