### PR TITLE
Fix flaky autests for timeout, sigusr2, and thread_config

### DIFF
--- a/tests/gold_tests/logging/sigusr2.test.py
+++ b/tests/gold_tests/logging/sigusr2.test.py
@@ -130,9 +130,9 @@ rotate_diags_log = tr1.Processes.Process("rotate_diags_log", "mv {} {}".format(d
 # Configure the signaling of SIGUSR2 to traffic_server.
 tr1.Processes.Default.Command = diags_test.get_sigusr2_signal_command()
 tr1.Processes.Default.Return = 0
-# Configure process order: ts starts first, then rotate moves diags.log,
-# then Default sends SIGUSR2. No Ready condition needed on Default since the
-# StartBefore chain already ensures ts is fully started before rotate runs.
+tr1.Processes.Default.Ready = When.FileExists(diags_test.diags_log)
+
+# Configure process order.
 tr1.Processes.Default.StartBefore(rotate_diags_log)
 rotate_diags_log.StartBefore(diags_test.ts)
 tr1.StillRunningAfter = diags_test.ts

--- a/tests/gold_tests/logging/sigusr2.test.py
+++ b/tests/gold_tests/logging/sigusr2.test.py
@@ -130,9 +130,9 @@ rotate_diags_log = tr1.Processes.Process("rotate_diags_log", "mv {} {}".format(d
 # Configure the signaling of SIGUSR2 to traffic_server.
 tr1.Processes.Default.Command = diags_test.get_sigusr2_signal_command()
 tr1.Processes.Default.Return = 0
-tr1.Processes.Default.Ready = When.FileExists(diags_test.diags_log)
-
-# Configure process order.
+# Configure process order: ts starts first, then rotate moves diags.log,
+# then Default sends SIGUSR2. No Ready condition needed on Default since the
+# StartBefore chain already ensures ts is fully started before rotate runs.
 tr1.Processes.Default.StartBefore(rotate_diags_log)
 rotate_diags_log.StartBefore(diags_test.ts)
 tr1.StillRunningAfter = diags_test.ts

--- a/tests/gold_tests/thread_config/check_threads.py
+++ b/tests/gold_tests/thread_config/check_threads.py
@@ -36,13 +36,16 @@ def _count_threads_once(ts_path, etnet_threads, accept_threads, task_threads, ai
             # Find the pid corresponding to the ats process we started in autest.
             # It needs to match the process name and the binary path.
             # If autest can expose the pid of the process this is not needed anymore.
+            # Match by CWD or command line containing ts_path, since under
+            # ASAN the CWD may differ from the expected path.
             process_name = p.name()
             process_cwd = p.cwd()
             process_exe = p.exe()
-            if process_cwd != ts_path:
-                continue
-            if process_name != '[TS_MAIN]' and process_name != 'traffic_server' and os.path.basename(
-                    process_exe) != 'traffic_server':
+            is_ts = process_name == '[TS_MAIN]' or process_name == 'traffic_server' or os.path.basename(
+                process_exe) == 'traffic_server'
+            match_by_cwd = process_cwd == ts_path
+            match_by_cmdline = any(ts_path in arg for arg in (p.cmdline() or []))
+            if not is_ts or not (match_by_cwd or match_by_cmdline):
                 continue
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             continue

--- a/tests/gold_tests/timeout/ssl-delay-server.cc
+++ b/tests/gold_tests/timeout/ssl-delay-server.cc
@@ -39,6 +39,7 @@
 #include <sys/time.h>
 #include <sys/select.h>
 #include <cerrno>
+#include <csignal>
 
 char req_buf[10000];
 char post_buf[1000];
@@ -156,6 +157,10 @@ main(int argc, char *argv[])
   ttfb_delay           = atoi(argv[3]);
   const char *pem_file = argv[4];
 
+  // Ignore SIGPIPE which can be raised when a client disconnects during
+  // the handshake delay, killing the process unexpectedly.
+  signal(SIGPIPE, SIG_IGN);
+
   fprintf(stderr, "Listen on %d connect delay=%d ttfb delay=%d\n", listen_port, connect_delay, ttfb_delay);
 
   int                listenfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -199,8 +204,10 @@ main(int argc, char *argv[])
   for (;;) {
     sfd = accept(listenfd, (struct sockaddr *)nullptr, nullptr);
     if (sfd <= 0) {
-      // Failure
-      printf("Listen failure\n");
+      if (errno == EINTR) {
+        continue;
+      }
+      printf("Listen failure errno=%d\n", errno);
       exit(1);
     }
 

--- a/tests/gold_tests/timeout/ssl-delay-server.cc
+++ b/tests/gold_tests/timeout/ssl-delay-server.cc
@@ -203,7 +203,7 @@ main(int argc, char *argv[])
 
   for (;;) {
     sfd = accept(listenfd, (struct sockaddr *)nullptr, nullptr);
-    if (sfd <= 0) {
+    if (sfd < 0) {
       if (errno == EINTR) {
         continue;
       }


### PR DESCRIPTION
### Problem

The `tls_conn_timeout` and `thread_config` autests fail intermittently under parallel ASAN runs. The `ssl-delay-server` helper dies when a client disconnects during the handshake delay (SIGPIPE) or when `accept()` is interrupted (EINTR), failing the `StillRunningAfter` check. The `thread_config` test can't find the correct `traffic_server` process under ASAN because the process CWD differs from the expected `ts_path`.

### Changes

* **Handle SIGPIPE in `ssl-delay-server`** -- ignore SIGPIPE to prevent the helper from dying when a client disconnects during the TLS handshake delay.
* **Retry `accept()` on EINTR** -- under heavy parallel load, `accept()` can return EINTR; retry instead of treating it as a fatal error.
* **Fix `accept()` error check** -- use `< 0` instead of `<= 0` since fd 0 is a valid descriptor when stdin is closed.
* **Add cmdline matching for ASAN in `check_threads.py`** -- fall back to matching `ts_path` in process command line arguments when the CWD doesn't match, which happens under ASAN.

### Testing

- [x] Run AuTests in ASAN configuration
- [x] No production code paths changed (test-only PR)
- [x] All 15 CI platforms green

<!-- merge-description-updated:2026-03-25T20:16:00Z -->