### PR TITLE
10.2: Proxy Verifier: use concise stack protocol specification (#13003)

### DIFF
--- a/tests/gold_tests/cache/replay/bg_fill.yaml
+++ b/tests/gold_tests/cache/replay/bg_fill.yaml
@@ -25,13 +25,9 @@ meta:
   version: '1.0'
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
   - client-request:
       frames:
@@ -65,13 +61,9 @@ sessions:
             size: 11
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
   - client-request:
       delay: 3s

--- a/tests/gold_tests/chunked_encoding/replays/chunked.replay.yaml
+++ b/tests/gold_tests/chunked_encoding/replays/chunked.replay.yaml
@@ -48,12 +48,7 @@ sessions:
         size: 32
 
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-  - name: tcp
-  - name: ip
-
+    stack: https
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/client_connection/http2_slow_origins.replay.yaml
+++ b/tests/gold_tests/client_connection/http2_slow_origins.replay.yaml
@@ -33,13 +33,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -75,13 +71,9 @@ sessions:
         - [ X-Response, {value: 'first-response', as: equal } ]
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -117,13 +109,9 @@ sessions:
         - [ X-Response, {value: 'second-response', as: equal } ]
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -160,16 +148,12 @@ sessions:
 
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
-  # Make sure this is the last attempted transaction by giving the above
-  # three transactions, all executed in parallel, a one second head start.
-  # This connection should be aborted.
+    # Make sure this is the last attempted transaction by giving the above
+    # three transactions, all executed in parallel, a one second head start.
+    # This connection should be aborted.
+    stack: http2
+    tls:
+      sni: test_sni
   delay: 1s
 
   transactions:
@@ -198,13 +182,9 @@ sessions:
 # Note that this will delay after the previous 1s delay, so this is really
 # a delay of 3s.
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: test_sni
   delay: 2s
 
   transactions:

--- a/tests/gold_tests/client_connection/https_slow_origins.replay.yaml
+++ b/tests/gold_tests/client_connection/https_slow_origins.replay.yaml
@@ -33,11 +33,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -75,11 +73,9 @@ sessions:
         - [ X-Response, {value: 'first-response', as: equal } ]
 
 - protocol:
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -117,11 +113,9 @@ sessions:
         - [ X-Response, {value: 'second-response', as: equal } ]
 
 - protocol:
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -160,14 +154,12 @@ sessions:
 
 
 - protocol:
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
-  # Make sure this is the last attempted transaction by giving the above
-  # three transactions, all executed in parallel, a one second head start.
-  # This connection should be aborted.
+    # Make sure this is the last attempted transaction by giving the above
+    # three transactions, all executed in parallel, a one second head start.
+    # This connection should be aborted.
+    stack: https
+    tls:
+      sni: test_sni
   delay: 1s
 
   transactions:
@@ -198,11 +190,9 @@ sessions:
 # Note that this will delay after the previous 1s delay, so this is really
 # a delay of 3s.
 - protocol:
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: test_sni
   delay: 2s
 
   transactions:

--- a/tests/gold_tests/connect/replays/connect_h2.replay.yaml
+++ b/tests/gold_tests/connect/replays/connect_h2.replay.yaml
@@ -23,13 +23,9 @@ meta:
 
 sessions:
   - protocol:
-      - name: http
-        version: 2
-      - name: tls
+      stack: http2
+      tls:
         sni: www.example.com
-      - name: tcp
-      - name: ip
-
     transactions:
       - client-request:
           frames:

--- a/tests/gold_tests/h2/expect_100_continue.yaml
+++ b/tests/gold_tests/h2/expect_100_continue.yaml
@@ -19,15 +19,10 @@ meta:
 
 sessions:
   - protocol:
-      - name: http
-        version: '2'
-      - name: tls
+      stack: http2
+      tls:
         version: TLSv1.3
         sni: data.brian.example.com
-      - name: tcp
-      - name: ip
-        version: '4'
-
     transactions:
       - client-request:
           headers:

--- a/tests/gold_tests/h2/h2get_with_body.yaml
+++ b/tests/gold_tests/h2/h2get_with_body.yaml
@@ -25,13 +25,9 @@ meta:
   version: '1.0'
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
   - client-request:
       frames:

--- a/tests/gold_tests/h2/http2_close_connection.yaml
+++ b/tests/gold_tests/h2/http2_close_connection.yaml
@@ -25,13 +25,9 @@ meta:
   version: '1.0'
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
   - client-request:
       frames:

--- a/tests/gold_tests/h2/http2_flow_control.replay.yaml
+++ b/tests/gold_tests/h2/http2_flow_control.replay.yaml
@@ -23,13 +23,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: www.example.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: www.example.com
   transactions:
 
   - client-request:

--- a/tests/gold_tests/h2/http2_flow_control_chunked.replay.yaml
+++ b/tests/gold_tests/h2/http2_flow_control_chunked.replay.yaml
@@ -23,13 +23,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: www.example.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: www.example.com
   transactions:
 
   - client-request:

--- a/tests/gold_tests/h2/replay/http2_concurrent_streams.replay.yaml
+++ b/tests/gold_tests/h2/replay/http2_concurrent_streams.replay.yaml
@@ -25,12 +25,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
   # Stream 1
   - client-request:

--- a/tests/gold_tests/h2/replay_h2origin/h1-client-h2-origin.yaml
+++ b/tests/gold_tests/h2/replay_h2origin/h1-client-h2-origin.yaml
@@ -3,17 +3,12 @@ meta:
 
 sessions:
   - protocol:
-      - name: http
-        version: '1.1'
-      - name: tls
+      stack: https
+      tls:
         version: TLSv1.3
         sni: data.brian.example.com
         proxy-verify-mode: 0
         proxy-provided-cert: true
-      - name: tcp
-      - name: ip
-        version: '4'
-
     transactions:
       #
       # Test 1: Zero length response.
@@ -36,17 +31,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: GET
@@ -105,17 +95,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: GET
@@ -153,17 +138,12 @@ sessions:
             size: 16
 
   - protocol:
-      - name: http
-        version: '1.1'
-      - name: tls
+      stack: https
+      tls:
         version: TLSv1.3
         sni: data.brian.example.com
         proxy-verify-mode: 0
         proxy-provided-cert: true
-      - name: tcp
-      - name: ip
-        version: '4'
-
     transactions:
       #
       # Test 3: 8 byte post with a 404 response.
@@ -186,17 +166,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -253,17 +228,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -321,17 +291,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -389,17 +354,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '1.1'
           scheme: https
           method: POST
@@ -457,17 +417,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST

--- a/tests/gold_tests/h2/replay_h2origin/h2-origin.yaml
+++ b/tests/gold_tests/h2/replay_h2origin/h2-origin.yaml
@@ -3,17 +3,12 @@ meta:
 
 sessions:
   - protocol:
-      - name: http
-        version: '2'
-      - name: tls
+      stack: http2
+      tls:
         version: TLSv1.3
         sni: data.brian.example.com
         proxy-verify-mode: 0
         proxy-provided-cert: true
-      - name: tcp
-      - name: ip
-        version: '4'
-
     transactions:
       #
       # Test 1: Zero length response.
@@ -35,17 +30,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: GET
@@ -105,17 +95,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: GET
@@ -153,17 +138,12 @@ sessions:
             size: 16
 
   - protocol:
-      - name: http
-        version: '2'
-      - name: tls
+      stack: http2
+      tls:
         version: TLSv1.3
         sni: data.brian.example.com
         proxy-verify-mode: 0
         proxy-provided-cert: true
-      - name: tcp
-      - name: ip
-        version: '4'
-
     transactions:
       #
       # Test 3: 8 byte post with a 404 response.
@@ -186,17 +166,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -266,17 +241,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -333,17 +303,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -410,17 +375,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST
@@ -477,17 +437,12 @@ sessions:
 
         proxy-request:
           protocol:
-            - name: http
-              version: '2'
-            - name: tls
+            stack: http2
+            tls:
               version: TLSv1.2
               sni: data.brian.example.com
               proxy-verify-mode: 1
               proxy-provided-cert: false
-            - name: tcp
-            - name: ip
-              version: '4'
-
           version: '2'
           scheme: https
           method: POST

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_data.yaml
@@ -2,13 +2,9 @@ meta:
   version: '1.0'
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   keep-connection-open: 2s
   transactions:
   - client-request:

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_client_after_headers.yaml
@@ -2,13 +2,9 @@ meta:
   version: '1.0'
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   keep-connection-open: 2s
   transactions:
   - client-request:

--- a/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_server_after_headers.yaml
+++ b/tests/gold_tests/h2/replay_rst_stream/http2_rst_stream_server_after_headers.yaml
@@ -2,13 +2,9 @@ meta:
   version: '1.0'
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-    version: 4
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
   - client-request:
       headers:

--- a/tests/gold_tests/h3/replays/h3_sni.replay.yaml
+++ b/tests/gold_tests/h3/replays/h3_sni.replay.yaml
@@ -19,10 +19,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 3
-  - name: tls
-    sni: test_sni
+    stack: http3
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:
@@ -46,10 +45,8 @@ sessions:
       status: 200
 
 - protocol:
-  - name: http
-    version: 3
-  # Note that the SNI is not specified for this connection.
-  - name: tls
+    # Note that the SNI is not specified for this connection.
+    stack: http3
   transactions:
   - client-request:
       version: "3"

--- a/tests/gold_tests/ip_allow/replays/h3.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/h3.replay.yaml
@@ -19,10 +19,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 3
-  - name: tls
-    sni: test_sni
+    stack: http3
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:

--- a/tests/gold_tests/ip_allow/replays/http_proxy_protocol.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/http_proxy_protocol.replay.yaml
@@ -30,12 +30,11 @@ meta:
           - [ Content-Length, 20 ]
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: proxy-protocol
-    version: 2
-    src-addr: "1.2.3.4:1111"
-    dst-addr: "5.6.7.8:2222"
+    stack: http
+    proxy-protocol:
+      version: 2
+      src-addr: "1.2.3.4:1111"
+      dst-addr: "5.6.7.8:2222"
   transactions:
 
   # GET

--- a/tests/gold_tests/ip_allow/replays/https_categories_all.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_all.replay.yaml
@@ -31,10 +31,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: test_sni
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   # GET rejected

--- a/tests/gold_tests/ip_allow/replays/https_categories_external.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_external.replay.yaml
@@ -31,10 +31,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: test_sni
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   # GET allowed

--- a/tests/gold_tests/ip_allow/replays/https_categories_external_remap.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_external_remap.replay.yaml
@@ -31,10 +31,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: test_sni
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:

--- a/tests/gold_tests/ip_allow/replays/https_categories_internal.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_internal.replay.yaml
@@ -30,10 +30,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: test_sni
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   # GET allowed

--- a/tests/gold_tests/ip_allow/replays/https_categories_server.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_categories_server.replay.yaml
@@ -31,10 +31,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: test_sni
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   # GET rejected

--- a/tests/gold_tests/ip_allow/replays/https_multiple_methods.replay.yaml
+++ b/tests/gold_tests/ip_allow/replays/https_multiple_methods.replay.yaml
@@ -30,10 +30,9 @@ meta:
           - [ Content-Length, 20 ]
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: test_sni
+    stack: https
+    tls:
+      sni: test_sni
   transactions:
 
   # GET

--- a/tests/gold_tests/logging/replay/basic1.replay.yaml
+++ b/tests/gold_tests/logging/replay/basic1.replay.yaml
@@ -19,10 +19,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 3
-  - name: tls
-    sni: test_sni
+    stack: http3
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:

--- a/tests/gold_tests/pluginTest/access_control/replays/access_control.replay.yaml
+++ b/tests/gold_tests/pluginTest/access_control/replays/access_control.replay.yaml
@@ -15,7 +15,10 @@
 #  limitations under the License.
 
 sessions:
-- protocol: [{ name: tls, sni: test }]
+- protocol:
+    stack: https
+    tls:
+      sni: test
 
   transactions:
   # 1: Regular request

--- a/tests/gold_tests/pluginTest/cache_promote/replay/cache_promote.replay.yaml.tmpl
+++ b/tests/gold_tests/pluginTest/cache_promote/replay/cache_promote.replay.yaml.tmpl
@@ -22,11 +22,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tcp
-  - name: ip
-
+    stack: http
   transactions:
   #
   # test case 0-0 : simple LRU policy case - 3rd request is expected to hit the cache

--- a/tests/gold_tests/pluginTest/certifier/replays/https-two-sessions.replay.yaml
+++ b/tests/gold_tests/pluginTest/certifier/replays/https-two-sessions.replay.yaml
@@ -18,7 +18,10 @@ meta:
   version: "1.0"
 
 sessions:
-  - protocol: [{ name: tls, sni: www.tls.com }, { name: tcp }, { name: ip }]
+  - protocol:
+      stack: https
+      tls:
+        sni: www.tls.com
 
     transactions:
       - client-request:
@@ -42,7 +45,10 @@ sessions:
           status: 200
 
   # separate session to trigger a new TLS handshake to engage the certifier
-  - protocol: [{ name: tls, sni: www.tls.com }, { name: tcp }, { name: ip }]
+  - protocol:
+      stack: https
+      tls:
+        sni: www.tls.com
 
     transactions:
       - client-request:

--- a/tests/gold_tests/pluginTest/certifier/replays/https.replay.yaml
+++ b/tests/gold_tests/pluginTest/certifier/replays/https.replay.yaml
@@ -18,7 +18,10 @@ meta:
   version: "1.0"
 
 sessions:
-  - protocol: [{ name: tls, sni: www.tls.com }, { name: tcp }, { name: ip }]
+  - protocol:
+      stack: https
+      tls:
+        sni: www.tls.com
 
     transactions:
       - client-request:

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_global.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_global.replay.yaml
@@ -20,11 +20,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: tls
-    sni: https.server.com
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: https.server.com
   transactions:
 
   - client-request:
@@ -62,13 +60,9 @@ sessions:
         - [ X-Response, { value: 'https-response', as: equal } ]
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: http2.server.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: http2.server.com
   transactions:
 
   - client-request:

--- a/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_remap.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja3_fingerprint/ja3_fingerprint_remap.replay.yaml
@@ -20,11 +20,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: tls
-    sni: https.server.com
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: https.server.com
   transactions:
 
   - client-request:
@@ -64,13 +62,9 @@ sessions:
         - [ X-Response, { value: 'https-response', as: equal } ]
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: http2.server.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: http2.server.com
   transactions:
 
   - client-request:

--- a/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.replay.yaml
+++ b/tests/gold_tests/pluginTest/ja4_fingerprint/ja4_fingerprint.replay.yaml
@@ -21,11 +21,7 @@ sessions:
 
 # Session 1: No pre-existing JA4 headers - new headers should be added.
 - protocol:
-  - name: http
-    version: 1
-  - name: tcp
-  - name: ip
-
+    stack: http
   transactions:
   - client-request:
       method: "GET"
@@ -52,11 +48,7 @@ sessions:
 
 # Session 2: Pre-existing JA4 headers - with preserve, no new headers added.
 - protocol:
-  - name: http
-    version: 1
-  - name: tcp
-  - name: ip
-
+    stack: http
   transactions:
   - client-request:
       method: "GET"
@@ -86,11 +78,7 @@ sessions:
 
 # Session 3: Only x-ja4-via exists - should still trigger preserve for all.
 - protocol:
-  - name: http
-    version: 1
-  - name: tcp
-  - name: ip
-
+    stack: http
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy.replay.yaml
@@ -19,11 +19,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-  - name: tls
-  - name: tcp
-  - name: ip
-
+    stack: https
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy_skip_post.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_copy_skip_post.replay.yaml
@@ -19,11 +19,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-  - name: tls
-  - name: tcp
-  - name: ip
-
+    stack: https
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original.replay.yaml
@@ -19,11 +19,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-  - name: tls
-  - name: tcp
-  - name: ip
-
+    stack: https
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original_skip_post.replay.yaml
+++ b/tests/gold_tests/pluginTest/multiplexer/replays/multiplexer_original_skip_post.replay.yaml
@@ -19,11 +19,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-  - name: tls
-  - name: tcp
-  - name: ip
-
+    stack: https
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/http3.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/http3.yaml
@@ -28,10 +28,10 @@ meta:
           - [ Connection, close ]
 
 sessions:
-- protocol: [ {name: http, version: 3},
-              {name: tls, sni: www.tls.com},
-              {name: udp},
-              {name: ip} ]
+- protocol:
+    stack: http3
+    tls:
+      sni: www.tls.com
 
   transactions:
   - client-request:

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/response_body.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/response_body.yaml
@@ -110,10 +110,10 @@ sessions:
 #
 # Test 3: An HTTP/2 request body.
 #
-- protocol: [ {name: http, version: 2},
-              {name: tls, sni: www.tls.com},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: http2
+    tls:
+      sni: www.tls.com
 
   transactions:
   - client-request:

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/traffic_dump.yaml
@@ -259,9 +259,10 @@ sessions:
     proxy-response:
       status: 200
 
-- protocol: [ {name: tls, sni: www.tls.com },
-              {name: tcp },
-              {name: ip} ]
+- protocol:
+    stack: https
+    tls:
+      sni: www.tls.com
 
   transactions:
   - client-request:
@@ -279,10 +280,10 @@ sessions:
     proxy-response:
       status: 200
 
-- protocol: [ {name: http, version: 2},
-              {name: tls, sni: www.tls.com},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: http2
+    tls:
+      sni: www.tls.com
 
   transactions:
   - client-request:
@@ -313,9 +314,10 @@ sessions:
     proxy-response:
       status: 200
 
-- protocol: [ {name: tls, sni: www.client_only_tls.com},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: https
+    tls:
+      sni: www.client_only_tls.com
 
   transactions:
   - client-request:

--- a/tests/gold_tests/pluginTest/traffic_dump/replay/various_sni.yaml
+++ b/tests/gold_tests/pluginTest/traffic_dump/replay/various_sni.yaml
@@ -38,10 +38,10 @@ sessions:
 #
 # Test 1: Create a session using an SNI of "bob".
 #
-- protocol: [ {name: http, version: 2},
-              {name: tls, sni: bob.com},
-              {name: tcp },
-              {name: ip} ]
+- protocol:
+    stack: http2
+    tls:
+      sni: bob.com
 
   transactions:
 
@@ -63,10 +63,10 @@ sessions:
 #
 # Test 2: Create a session using an SNI of "dave.com".
 #
-- protocol: [ {name: http, version: 2},
-              {name: tls, sni: dave.com},
-              {name: tcp },
-              {name: ip} ]
+- protocol:
+    stack: http2
+    tls:
+      sni: dave.com
 
   transactions:
 
@@ -88,10 +88,8 @@ sessions:
 #
 # Test 3: Create a session using no SNI.
 #
-- protocol: [ {name: http, version: 2},
-              {name: tls},
-              {name: tcp },
-              {name: ip} ]
+- protocol:
+    stack: http2
 
   transactions:
 

--- a/tests/gold_tests/pluginTest/transform/transaction-with-body.replays.yaml
+++ b/tests/gold_tests/pluginTest/transform/transaction-with-body.replays.yaml
@@ -157,13 +157,9 @@ sessions:
       status: 200
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: test_sni
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: test_sni
   transactions:
 
   #---------------------------------------------------------------------------

--- a/tests/gold_tests/pluginTest/txn_box/basic/basic.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/basic.replay.yaml
@@ -180,7 +180,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, ts-uuid]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/cmp.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/cmp.replay.yaml
@@ -88,7 +88,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ] # plain text sessions
+- protocol: # plain text sessions
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/ip-addr.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/ip-addr.replay.yaml
@@ -46,7 +46,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4 } ] # plain text sessions
+- protocol: # plain text sessions
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/mod.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/mod.replay.yaml
@@ -61,7 +61,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   ## Checks for the concat modifier.
@@ -172,7 +173,8 @@ sessions:
     proxy-response:
       <<: *base-rsp
 
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   ## Checks for regular expression modifier.

--- a/tests/gold_tests/pluginTest/txn_box/basic/multi-cfg.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/multi-cfg.replay.yaml
@@ -17,7 +17,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, 0 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/redirect.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/redirect.replay.yaml
@@ -63,7 +63,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 101 ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/basic/reply.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/reply.replay.yaml
@@ -41,7 +41,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, delain ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/rxp.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/rxp.replay.yaml
@@ -35,7 +35,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/stat.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/stat.replay.yaml
@@ -62,7 +62,8 @@ meta:
 sessions:
 
 # Plain text
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 101 ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/basic/tls-cert.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/tls-cert.replay.yaml
@@ -37,7 +37,10 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} , { name: "tls", sni: "alpha.ex" } ]
+- protocol:
+    stack: https
+    tls:
+      sni: "alpha.ex"
   transactions:
   - all: { headers: { fields: [[ uuid, 101 ]]}}
     client-request:
@@ -59,7 +62,8 @@ sessions:
         fields:
         - [ "target-cert-subject", { value: "server_cn", as: equal } ]
 
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   # Verify the outbound client cert is there with the expected values.
   - all: { headers: { fields: [[ uuid, outbound-TLS ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/tls.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/tls.replay.yaml
@@ -30,7 +30,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ] # plain text sessions
+- protocol: # plain text sessions
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 101 ]]}}
     client-request:
@@ -66,7 +67,8 @@ sessions:
     proxy-response:
       status: 200
 
-- protocol: [ { name: "ip", version : 4} , { name: "tls" }] # TLS sessions
+- protocol: # TLS sessions
+    stack: https
   transactions:
   - all: { headers: { fields: [[ uuid, 1 ]] }}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/basic/tuple.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/tuple.replay.yaml
@@ -37,7 +37,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ] # plain text sessions
+- protocol: # plain text sessions
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/txn-error.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/txn-error.replay.yaml
@@ -42,7 +42,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, "base-case" ]]}}
@@ -60,7 +61,8 @@ sessions:
       status: 501
 
   # Must be a different session because the internal error forces a connection close.
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, "bypass-case" ]]}}
@@ -78,7 +80,8 @@ sessions:
       <<: *base-rsp
       status: 200
 
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, "no-fixup" ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/txn_open_1.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/txn_open_1.replay.yaml
@@ -24,7 +24,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/txn_open_2.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/txn_open_2.replay.yaml
@@ -33,7 +33,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/txn_open_3.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/txn_open_3.replay.yaml
@@ -30,7 +30,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   #
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/basic/with.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/basic/with.replay.yaml
@@ -61,7 +61,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   # Alpha cases use "none-of" so if the field isn't present, no with case should match and it should

--- a/tests/gold_tests/pluginTest/txn_box/ct_header/ct_header.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/ct_header/ct_header.replay.yaml
@@ -57,7 +57,8 @@ sessions:
   #
   # Test 1: For non-TLS connections, we should not add cross site fields.
   #
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields:  [[ uuid, 1 ]]}}
@@ -90,7 +91,8 @@ sessions:
   #
   # Test 2: Since this is TLS, expect the cross site fields.
   #
-- protocol: [ { name: tls } , { name: ip, version: 4 } ]
+- protocol:
+    stack: https
   transactions:
 
   - all: { headers: { fields: [[ uuid, 2 ]]}}
@@ -176,7 +178,8 @@ sessions:
         fields:
         - [ expect-ct, { value: "max-age=31536000, report-uri=\"http://cane.example.com/path/cane?src=examplecom-expect-ct-report-only\"", as: equal} ]
 
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   #

--- a/tests/gold_tests/pluginTest/txn_box/example/accept-encoding.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/example/accept-encoding.replay.yaml
@@ -25,7 +25,8 @@ meta:
         - [ Content-Length, 234 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 1 ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/prod/cors-origin.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/cors-origin.replay.yaml
@@ -38,7 +38,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, alpha ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/prod/cors-referrer.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/cors-referrer.replay.yaml
@@ -45,7 +45,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, alpha ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/prod/ip-acl.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/ip-acl.replay.yaml
@@ -43,7 +43,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - all: { headers: { fields: [[ uuid, 1 ]]}}

--- a/tests/gold_tests/pluginTest/txn_box/prod/mTLS-alpha.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/mTLS-alpha.replay.yaml
@@ -3,9 +3,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: tls
-    sni: "alpha"
-
+    stack: https
+    tls:
+      sni: "alpha"
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/txn_box/prod/mTLS-bravo.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/mTLS-bravo.replay.yaml
@@ -3,9 +3,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: tls
-    sni: "bravo"
-
+    stack: https
+    tls:
+      sni: "bravo"
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/pluginTest/txn_box/prod/query-delete.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/query-delete.replay.yaml
@@ -50,7 +50,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions: &txn-set
 
   # No query

--- a/tests/gold_tests/pluginTest/txn_box/prod/query.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/query.replay.yaml
@@ -23,7 +23,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   # No query -> no field.

--- a/tests/gold_tests/pluginTest/txn_box/prod/stanley.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/stanley.replay.yaml
@@ -38,7 +38,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, base-case ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/prod/vznith-1.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/vznith-1.replay.yaml
@@ -35,7 +35,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   # Base case - no path modification.

--- a/tests/gold_tests/pluginTest/txn_box/prod/yts-3489.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/yts-3489.replay.yaml
@@ -72,7 +72,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 101 ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/ramp/multi-ramp.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/ramp/multi-ramp.replay.yaml
@@ -21,7 +21,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: tls } , { name: ip, version: 4 } ]
+- protocol:
+    stack: https
   transactions:
   - client-request:
       <<: *base_request

--- a/tests/gold_tests/pluginTest/txn_box/ramp/ramp.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/ramp/ramp.replay.yaml
@@ -18,7 +18,8 @@ meta:
       url: "/1"
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 1 ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/remap/remap-base.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/remap/remap-base.replay.yaml
@@ -58,7 +58,8 @@ meta:
         - [ Content-Length, 96 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   #
   - client-request:

--- a/tests/gold_tests/pluginTest/txn_box/smoke/smoke-2.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/smoke/smoke-2.replay.yaml
@@ -16,7 +16,8 @@ meta:
       method: "GET"
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/pluginTest/txn_box/smoke/smoke.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/smoke/smoke.replay.yaml
@@ -31,7 +31,8 @@ meta:
       method: "GET"
 
 sessions:
-- protocol: [ { name: ip, version : 4} ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 1 ]]}}
     client-request:

--- a/tests/gold_tests/pluginTest/txn_box/static_file/static_file.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/static_file/static_file.replay.yaml
@@ -141,7 +141,8 @@ meta:
         - [ Content-Length, 56 ]
 
 sessions:
-- protocol: [ { name: ip, version : 4 } ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 1 ]]}}
     client-request:
@@ -221,7 +222,8 @@ sessions:
     proxy-response:
       status: 200
 
-- protocol: [ { name: ip, version : 4 } ]
+- protocol:
+    stack: http
   transactions:
   - all: { headers: { fields: [[ uuid, 4 ]]}}
     client-request:

--- a/tests/gold_tests/proxy_protocol/replay/proxy_protocol_in.replay.yaml
+++ b/tests/gold_tests/proxy_protocol/replay/proxy_protocol_in.replay.yaml
@@ -24,13 +24,8 @@ meta:
 sessions:
   # Test 1: Incoming PROXY Protocol v1 on TCP port
   - protocol:
-      - name: http
-        version: 1
-      - name: proxy-protocol
-        version: 1
-      - name: tcp
-      - name: ip
-
+      stack: http
+      proxy-protocol: 1
     transactions:
       - client-request:
           method: GET
@@ -57,14 +52,8 @@ sessions:
 
   # Test 2: Incoming PROXY Protocol v1 on SSL port
   - protocol:
-      - name: http
-        version: 1
-      - name: tls
-      - name: proxy-protocol
-        version: 1
-      - name: tcp
-      - name: ip
-
+      stack: https
+      proxy-protocol: 1
     transactions:
       - client-request:
           method: GET
@@ -92,13 +81,8 @@ sessions:
 
   # Test 3: Incoming PROXY Protocol v2 on TCP port
   - protocol:
-      - name: http
-        version: 1
-      - name: proxy-protocol
-        version: 2
-      - name: tcp
-      - name: ip
-
+      stack: http
+      proxy-protocol: 2
     transactions:
       - client-request:
           method: GET
@@ -125,14 +109,8 @@ sessions:
 
   # Test 4: Incoming PROXY Protocol v2 on SSL port
   - protocol:
-      - name: http
-        version: 1
-      - name: tls
-      - name: proxy-protocol
-        version: 2
-      - name: tcp
-      - name: ip
-
+      stack: https
+      proxy-protocol: 2
     transactions:
       - client-request:
           method: GET
@@ -160,15 +138,11 @@ sessions:
   # Test 3: Incoming PROXY Protocol v1 on TCP port, with arbitrary source and
   # destination address in PROXY message
   - protocol:
-      - name: http
-        version: 1
-      - name: proxy-protocol
+      stack: http
+      proxy-protocol:
         version: 1
         src-addr: 198.51.100.1:51137
         dst-addr: 198.51.100.2:80
-      - name: tcp
-      - name: ip
-
     transactions:
       - client-request:
           method: GET
@@ -201,12 +175,8 @@ sessions:
   # Test 4: Verify ATS with :pp: server_ports designation can handle a
   # connection without Proxy Protocol.
   - protocol:
-      - name: http
-        version: 1
       # not sending Proxy Protcol
-      - name: tcp
-      - name: ip
-
+      stack: http
     transactions:
       - client-request:
           method: GET
@@ -234,13 +204,8 @@ sessions:
   # Test 5: Verify ATS with :pp: server_ports designation can handle a TLS
   # connection without Proxy Protocol.
   - protocol:
-      - name: http
-        version: 1
-      - name: tls
       # not sending Proxy Protcol
-      - name: tcp
-      - name: ip
-
+      stack: https
     transactions:
       - client-request:
           method: GET

--- a/tests/gold_tests/proxy_protocol/replay/proxy_protocol_out.replay.yaml
+++ b/tests/gold_tests/proxy_protocol/replay/proxy_protocol_out.replay.yaml
@@ -23,13 +23,9 @@ meta:
 sessions:
   # Basic https transaction
   - protocol:
-      - name: http
-        version: 1
-      - name: tls
+      stack: https
+      tls:
         sni: pp.origin.com
-      - name: tcp
-      - name: ip
-
     transactions:
       - client-request:
           method: GET

--- a/tests/gold_tests/redirect/replay/redirect_to_same_origin_on_cache.replay.yaml
+++ b/tests/gold_tests/redirect/replay/redirect_to_same_origin_on_cache.replay.yaml
@@ -19,11 +19,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tcp
-  - name: ip
-
+    stack: http
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/remap/base.replay.yaml
+++ b/tests/gold_tests/remap/base.replay.yaml
@@ -22,8 +22,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/deny_head_post.replay.yaml
+++ b/tests/gold_tests/remap/deny_head_post.replay.yaml
@@ -31,8 +31,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/remap_acl_all_allowed.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_all_allowed.replay.yaml
@@ -30,8 +30,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/remap_acl_all_denied.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_all_denied.replay.yaml
@@ -30,8 +30,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/remap_acl_get_allowed.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_get_allowed.replay.yaml
@@ -31,8 +31,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/remap_acl_get_post_allowed.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_get_post_allowed.replay.yaml
@@ -31,8 +31,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/remap_acl_get_post_allowed_pp.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_get_post_allowed_pp.replay.yaml
@@ -31,12 +31,11 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: proxy-protocol
-    version: 2
-    src-addr: "1.2.3.4:1111"
-    dst-addr: "5.6.7.8:2222"
+    stack: http
+    proxy-protocol:
+      version: 2
+      src-addr: "1.2.3.4:1111"
+      dst-addr: "5.6.7.8:2222"
   transactions:
 
   - client-request:

--- a/tests/gold_tests/remap/remap_acl_get_post_denied.replay.yaml
+++ b/tests/gold_tests/remap/remap_acl_get_post_denied.replay.yaml
@@ -31,8 +31,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
+    stack: http
   transactions:
 
   - client-request:

--- a/tests/gold_tests/timeout/replay/http2_no_activity_timeout.replay.yaml
+++ b/tests/gold_tests/timeout/replay/http2_no_activity_timeout.replay.yaml
@@ -19,10 +19,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: example.com
+    stack: http2
+    tls:
+      sni: example.com
   transactions:
 
   - client-request:

--- a/tests/gold_tests/timeout/replay/quic_no_activity_timeout.replay.yaml
+++ b/tests/gold_tests/timeout/replay/quic_no_activity_timeout.replay.yaml
@@ -19,10 +19,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 3
-  - name: tls
-    sni: test_sni
+    stack: http3
+    tls:
+      sni: test_sni
   transactions:
 
   - client-request:

--- a/tests/gold_tests/timeout/slow_server.yaml
+++ b/tests/gold_tests/timeout/slow_server.yaml
@@ -85,9 +85,8 @@ sessions:
 #
 # An HTTPS GET request.
 #
-- protocol: [ {name: tls},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: https
 
   transactions:
   - client-request:
@@ -111,9 +110,8 @@ sessions:
 #
 # An HTTPS POST request.
 #
-- protocol: [ {name: tls},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: https
 
   transactions:
   - client-request:
@@ -138,10 +136,8 @@ sessions:
 #
 # An HTTP/2 GET request.
 #
-- protocol: [ {name: http, version: 2},
-              {name: tls},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: http2
 
   transactions:
 
@@ -166,10 +162,8 @@ sessions:
 #
 # An HTTP/2 POST request.
 #
-- protocol: [ {name: http, version: 2},
-              {name: tls},
-              {name: tcp},
-              {name: ip} ]
+- protocol:
+    stack: http2
 
   transactions:
 

--- a/tests/gold_tests/tls/replay/ip_allow.replay.yaml
+++ b/tests/gold_tests/tls/replay/ip_allow.replay.yaml
@@ -20,13 +20,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: block.me.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: block.me.com
   transactions:
 
   #
@@ -56,13 +52,9 @@ sessions:
         size: 3432
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: allow.me.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: allow.me.com
   transactions:
 
   #

--- a/tests/gold_tests/tls/replay/ip_allow_proxy.replay.yaml
+++ b/tests/gold_tests/tls/replay/ip_allow_proxy.replay.yaml
@@ -20,17 +20,13 @@ meta:
 sessions:
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: pp.block.me.com
-  - name: proxy-protocol
-    version: 2
-    src-addr: "1.2.3.4:1111"
-    dst-addr: "5.6.7.8:2222"
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: pp.block.me.com
+    proxy-protocol:
+      version: 2
+      src-addr: "1.2.3.4:1111"
+      dst-addr: "5.6.7.8:2222"
   transactions:
 
   #
@@ -60,17 +56,13 @@ sessions:
         size: 3432
 
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: pp.allow.me.com
-  - name: proxy-protocol
-    version: 2
-    src-addr: "1.2.3.4:1111"
-    dst-addr: "5.6.7.8:2222"
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: pp.allow.me.com
+    proxy-protocol:
+      version: 2
+      src-addr: "1.2.3.4:1111"
+      dst-addr: "5.6.7.8:2222"
   transactions:
 
   #

--- a/tests/gold_tests/tls/replay/ip_allow_tunnel.replay.yaml
+++ b/tests/gold_tests/tls/replay/ip_allow_tunnel.replay.yaml
@@ -20,11 +20,9 @@ meta:
 sessions:
 
 - protocol:
-  - name: tls
-    sni: block.me.com
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: block.me.com
   transactions:
 
   #
@@ -72,11 +70,9 @@ sessions:
           - [ X-Response, { as: absent } ]
 
 - protocol:
-  - name: tls
-    sni: allow.me.com
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: allow.me.com
   transactions:
   #
   # This should also be configured for tunneling, but allowed per sni.yaml ip_allow.

--- a/tests/gold_tests/tls/tls_client_alpn_configuration.replay.yaml
+++ b/tests/gold_tests/tls/tls_client_alpn_configuration.replay.yaml
@@ -27,11 +27,9 @@ sessions:
 
 # HTTP/1.1 over TLS.
 - protocol:
-  - name: tls
-    sni: www.example.com
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: www.example.com
   transactions:
 
   # This test has more to do with ALPN configuration than the transactions. The
@@ -68,13 +66,9 @@ sessions:
 
 # HTTP/2 over TLS.
 - protocol:
-  - name: http
-    version: 2
-  - name: tls
-    sni: www.example.com
-  - name: tcp
-  - name: ip
-
+    stack: http2
+    tls:
+      sni: www.example.com
   transactions:
 
   # This test has more to do with ALPN configuration than the transactions. The

--- a/tests/gold_tests/tls/tls_session_key_logging.replay.yaml
+++ b/tests/gold_tests/tls/tls_session_key_logging.replay.yaml
@@ -19,12 +19,7 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-  - name: tcp
-  - name: ip
-
+    stack: https
   transactions:
   - client-request:
       method: "GET"

--- a/tests/gold_tests/tls/tls_sni_with_port.replay.yaml
+++ b/tests/gold_tests/tls/tls_sni_with_port.replay.yaml
@@ -19,13 +19,9 @@ meta:
 
 sessions:
 - protocol:
-  - name: http
-    version: 1
-  - name: tls
-    sni: yay.example.com
-  - name: tcp
-  - name: ip
-
+    stack: https
+    tls:
+      sni: yay.example.com
   transactions:
   - client-request:
       method: "GET"


### PR DESCRIPTION
Proxy Verifier v3.0.0 has a more concise `stack` configurable for `protocol` specification. This makes use of that over the more verbose full `protocol` sequence.

(cherry picked from commit 3e5eff66c291ff556202f2cde0f24cfa3316d657)