### PR TITLE
Initialize uninitialized pointer and scalar members in QUIC and tscpp classes

### DIFF
--- a/include/iocore/net/quic/QUICTransferProgressProvider.h
+++ b/include/iocore/net/quic/QUICTransferProgressProvider.h
@@ -54,7 +54,7 @@ public:
   bool     is_cancelled() const override;
 
 private:
-  QUICStreamAdapter *_adapter;
+  QUICStreamAdapter *_adapter{nullptr};
 };
 
 class QUICTransferProgressProviderVIO : public QUICTransferProgressProvider

--- a/include/iocore/net/quic/QUICTypes.h
+++ b/include/iocore/net/quic/QUICTypes.h
@@ -214,7 +214,7 @@ public:
   QUICStreamError(const QUICStream *s, const QUICAppErrorCode error_code, const char *error_msg = nullptr)
     : QUICError(QUICErrorClass::APPLICATION, static_cast<uint16_t>(error_code), error_msg), stream(s){};
 
-  const QUICStream *stream;
+  const QUICStream *stream{nullptr};
 };
 
 using QUICErrorUPtr           = std::unique_ptr<QUICError>;
@@ -575,20 +575,20 @@ struct QUICSentPacketInfo {
 
   private:
     QUICFrameId         _id = 0;
-    QUICFrameGenerator *_generator;
+    QUICFrameGenerator *_generator{nullptr};
   };
 
   // Recovery A.1.1.  Sent Packet Fields
-  QUICPacketNumber packet_number;
-  bool             ack_eliciting;
-  bool             in_flight;
-  size_t           sent_bytes;
-  ink_hrtime       time_sent;
+  QUICPacketNumber packet_number{0};
+  bool             ack_eliciting{false};
+  bool             in_flight{false};
+  size_t           sent_bytes{0};
+  ink_hrtime       time_sent{0};
 
   // Additional fields
-  QUICPacketType         type;
+  QUICPacketType         type{QUICPacketType::UNINITIALIZED};
   std::vector<FrameInfo> frames;
-  QUICPacketNumberSpace  pn_space;
+  QUICPacketNumberSpace  pn_space{QUICPacketNumberSpace::INITIAL};
   // End of additional fields
 };
 

--- a/include/tscpp/api/AsyncTimer.h
+++ b/include/tscpp/api/AsyncTimer.h
@@ -86,7 +86,7 @@ public:
   void cancel() override;
 
 private:
-  AsyncTimerState *state_;
+  AsyncTimerState *state_{nullptr};
 };
 
 } // namespace atscppapi

--- a/include/tscpp/api/InterceptPlugin.h
+++ b/include/tscpp/api/InterceptPlugin.h
@@ -96,7 +96,7 @@ protected:
   bool setOutputComplete();
 
 private:
-  State *state_;
+  State *state_{nullptr};
 
   bool doRead();
   void handleEvent(int, void *);


### PR DESCRIPTION
## Summary

Add default member initializers for pointer, scalar, and enum members
that Coverity flagged as uninitialized in QUIC transport and C++ plugin
API classes:

- `QUICStreamError::stream` → `{nullptr}`
- `QUICSentPacketInfo` fields: `packet_number`, `ack_eliciting`, `in_flight`, `sent_bytes`, `time_sent`, `type`, `pn_space`
- `QUICSentPacketInfo::FrameInfo::_generator` → `{nullptr}`
- `QUICTransferProgressProviderSA::_adapter` → `{nullptr}`
- `InterceptPlugin::state_` → `{nullptr}`
- `AsyncTimer::state_` → `{nullptr}`

These are all simple in-class brace initializers with zero behavioral
change — every construction path already assigns these members, but
Coverity correctly notes that between base-class initialization and the
constructor body they are indeterminate.

## Test plan

- [x] Full build passes (macOS, default preset, ninja)
- [x] All pre-commit hooks pass (clang-format, yapf, cmake-format, whitespace, line endings)
- [ ] CI