### PR TITLE
hrw: Refix loading geodb files

### DIFF
--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -705,17 +705,17 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     }
   }
 
-  if (!geoDBpath.empty() && !geoDBpath.starts_with('/')) {
-    geoDBpath = std::string(TSConfigDirGet()) + '/' + geoDBpath;
-  }
-
   if (!geoDBpath.empty()) {
+    if (!geoDBpath.starts_with('/')) {
+      geoDBpath = std::string(TSConfigDirGet()) + '/' + geoDBpath;
+    }
     Dbg(pi_dbg_ctl, "Remap geo db %s", geoDBpath.c_str());
-  }
 
-  // Always initialize the plugin factory, even if no geo DB is specified. This
-  // is needed for run-plugin to work with relative paths.
-  std::call_once(initHRWLibs, [&geoDBpath]() { initHRWLibraries(geoDBpath); });
+    // This MUST be called only if the geoDBpath is set.  If called without a geoDBPath (i.e. outside of this if) then
+    // NO hrw remap rule can load a mmdb file.
+    // The call_once applies to every remap instance as its a plugin global
+    std::call_once(initHRWLibs, [&geoDBpath]() { initHRWLibraries(geoDBpath); });
+  }
 
   auto *conf = new RulesConfig(timezone, inboundIpSource);
 

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -41,15 +41,20 @@
 // Debugs
 namespace header_rewrite_ns
 {
-std::once_flag initHRWLibs;
+std::once_flag initGeoLibs;
+std::once_flag initPlugin;
 PluginFactory  plugin_factory;
 } // namespace header_rewrite_ns
 
 static void
-initHRWLibraries(const std::string &dbPath)
+initPluginFactory()
 {
   header_rewrite_ns::plugin_factory.setRuntimeDir(RecConfigReadRuntimeDir()).addSearchDir(RecConfigReadPluginDir());
+}
 
+static void
+initGeoLibraries(const std::string &dbPath)
+{
   if (dbPath.empty()) {
     return;
   }
@@ -597,7 +602,8 @@ TSPluginInit(int argc, const char *argv[])
 
   Dbg(pi_dbg_ctl, "Global geo db %s", geoDBpath.c_str());
 
-  std::call_once(initHRWLibs, [&geoDBpath]() { initHRWLibraries(geoDBpath); });
+  std::call_once(initGeoLibs, [&geoDBpath]() { initGeoLibraries(geoDBpath); });
+  std::call_once(initPlugin, initPluginFactory);
 
   // Parse the global config file(s). All rules are just appended
   // to the "global" Rules configuration.
@@ -714,8 +720,10 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     // This MUST be called only if the geoDBpath is set.  If called without a geoDBPath (i.e. outside of this if) then
     // NO hrw remap rule can load a mmdb file.
     // The call_once applies to every remap instance as its a plugin global
-    std::call_once(initHRWLibs, [&geoDBpath]() { initHRWLibraries(geoDBpath); });
+    std::call_once(initGeoLibs, [&geoDBpath]() { initGeoLibraries(geoDBpath); });
   }
+
+  std::call_once(initPlugin, initPluginFactory);
 
   auto *conf = new RulesConfig(timezone, inboundIpSource);
 


### PR DESCRIPTION
PR #12855 reintroduced a bug that would cause remap rules with header_rewrite plugins configured with mmdb files to never load the mmdb file.  This is because the call_once utilitized to initialize the file is a global to the plugin, so applies to every remap instance.  This means the first remap instance to load the mmdb will also set it for every other remap instance.  If you call `call_once` without a path, then any remap instances that call mmdb after will silently fail to load.

See $11812 and #12126

Edit:

I decided to try my idea for better handling of mmdb files.  The last commit of this PR does just that and allows remap rules with hrw to specify different geo db files rather than the current "first wins" approach.  It also avoids the call_once issue that has cause initialization issues in the past.