### PR TITLE
Fix memory leaks in SSL subsystem

### DIFF
--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -453,8 +453,7 @@ SSLConfigParams::initialize()
   SSLConfigParams::origin_session_cache      = ssl_origin_session_cache;
   SSLConfigParams::origin_session_cache_size = ssl_origin_session_cache_size;
 
-  if (ssl_origin_session_cache == 1 && ssl_origin_session_cache_size > 0) {
-    delete origin_sess_cache;
+  if (ssl_origin_session_cache == 1 && ssl_origin_session_cache_size > 0 && origin_sess_cache == nullptr) {
     origin_sess_cache = new SSLOriginSessionCache();
   }
 

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -454,6 +454,7 @@ SSLConfigParams::initialize()
   SSLConfigParams::origin_session_cache_size = ssl_origin_session_cache_size;
 
   if (ssl_origin_session_cache == 1 && ssl_origin_session_cache_size > 0) {
+    delete origin_sess_cache;
     origin_sess_cache = new SSLOriginSessionCache();
   }
 
@@ -472,6 +473,7 @@ SSLConfigParams::initialize()
     set_paths_helper(ssl_ocsp_response_path, nullptr, &ssl_ocsp_response_path_only, nullptr);
   }
   if (auto rec_str{RecGetRecordStringAlloc("proxy.config.http.request_via_str")}; rec_str) {
+    ats_free(ssl_ocsp_user_agent);
     ssl_ocsp_user_agent = ats_stringdup(rec_str);
   }
 
@@ -861,6 +863,11 @@ SSLTicketParams::cleanup()
 void
 cleanup_bio(BIO *&biop)
 {
+  // BIO_new_mem_buf sets BIO_FLAGS_MEM_RDONLY which prevents BIO_free from
+  // cleaning up internal BUF_MEM structures. Clear this flag so BIO_free
+  // properly releases them. BIO_NOCLOSE ensures the external data buffer
+  // (owned by the caller's std::string) is not freed.
+  BIO_clear_flags(biop, BIO_FLAGS_MEM_RDONLY);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
   BIO_set_close(biop, BIO_NOCLOSE);

--- a/src/iocore/net/SSLSessionCache.cc
+++ b/src/iocore/net/SSLSessionCache.cc
@@ -43,7 +43,13 @@ SSLSessDeleter(SSL_SESSION *_p)
 
 SSLOriginSessionCache::SSLOriginSessionCache() {}
 
-SSLOriginSessionCache::~SSLOriginSessionCache() {}
+SSLOriginSessionCache::~SSLOriginSessionCache()
+{
+  while (auto *node = orig_sess_que.pop()) {
+    delete node;
+  }
+  orig_sess_map.clear();
+}
 
 void
 SSLOriginSessionCache::insert_session(const std::string &lookup_key, SSL_SESSION *sess, SSL *ssl)


### PR DESCRIPTION
### Problem

ASAN-enabled autest runs on Fedora 43 revealed three categories of memory leaks in the SSL subsystem: leaked `SSLOriginSession` objects on cache teardown, double-allocations of origin session cache and OCSP user-agent string on config reload, and OpenSSL `BUF_MEM` structures not freed because of read-only BIO flags.

### Changes

* **Fix SSLOriginSessionCache destructor** -- drain all `SSLOriginSession` nodes from the `CountQueue` and delete them before the map is implicitly destroyed. The destructor was previously empty.
* **Allocate origin session cache once** -- remove the delete/new cycle on config reload since concurrent TLS handshakes hold bare pointers to the global cache. Let entries age out naturally when the configured size shrinks.
* **Free `ssl_ocsp_user_agent` before overwrite** -- prevent leak on config reload.
* **Fix BIO cleanup** -- clear `BIO_FLAGS_MEM_RDONLY` before `BIO_free` so internal `BUF_MEM` structures are properly released.

### Testing

- [x] Built with `ENABLE_ASAN=ON` and ran full autest suite -- no new LSAN reports for these symbols
- [x] CI (all 15 checks green)

<!-- merge-description-updated:2026-04-13T20:33:00Z -->
