### PR TITLE
Fix memory leaks in core shutdown path

### DIFF
--- a/include/iocore/aio/AIO.h
+++ b/include/iocore/aio/AIO.h
@@ -83,6 +83,7 @@ struct AIOCallback : public Continuation {
   int64_t    aio_result = 0;
   AIO_Reqs  *aio_req    = nullptr;
   ink_hrtime sleep_time = 0;
+  bool       from_api   = false;
   SLINK(AIOCallback, alink); /* for AIO_Reqs::aio_temp_list */
 #if TS_USE_LINUX_IO_URING
   iovec        iov     = {}; // this is to support older kernels that only support readv/writev

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -7067,11 +7067,13 @@ TSAIORead(int fd, off_t offset, char *buf, size_t buffSize, TSCont contp)
   pAIO->aiocb.aio_buf = buf;
   pAIO->action        = pCont;
   pAIO->thread        = pCont->mutex->thread_holding;
+  pAIO->from_api      = true;
 
   if (ink_aio_read(pAIO, 1) == 1) {
     return TS_SUCCESS;
   }
 
+  delete pAIO;
   return TS_ERROR;
 }
 
@@ -7106,11 +7108,13 @@ TSAIOWrite(int fd, off_t offset, char *buf, const size_t bufSize, TSCont contp)
   pAIO->aiocb.aio_nbytes = bufSize;
   pAIO->action           = pCont;
   pAIO->thread           = pCont->mutex->thread_holding;
+  pAIO->from_api         = true;
 
   if (ink_aio_write(pAIO, 1) == 1) {
     return TS_SUCCESS;
   }
 
+  delete pAIO;
   return TS_ERROR;
 }
 

--- a/src/iocore/aio/AIO.cc
+++ b/src/iocore/aio/AIO.cc
@@ -99,6 +99,9 @@ AIOCallback::io_complete(int event, void *data)
   if (!action.cancelled && action.continuation) {
     action.continuation->handleEvent(AIO_EVENT_DONE, this);
   }
+  if (from_api) {
+    delete this;
+  }
   return EVENT_DONE;
 }
 

--- a/src/iocore/net/UnixNetProcessor.cc
+++ b/src/iocore/net/UnixNetProcessor.cc
@@ -167,9 +167,11 @@ void
 UnixNetProcessor::stop_accept()
 {
   SCOPED_MUTEX_LOCK(lock, naVecMutex, this_ethread());
-  for (auto &na : naVec) {
+  for (auto *na : naVec) {
     na->stop_accept();
+    delete na;
   }
+  naVec.clear();
 }
 
 Action *

--- a/src/proxy/http/HttpProxyServerMain.cc
+++ b/src/proxy/http/HttpProxyServerMain.cc
@@ -376,4 +376,16 @@ stop_HttpProxyServer()
 {
   sslNetProcessor.stop_accept();
   netProcessor.stop_accept();
+
+  for (auto &acceptor : HttpProxyAcceptors) {
+    delete acceptor._accept;
+    acceptor._accept = nullptr;
+  }
+  HttpProxyAcceptors.clear();
+
+  delete plugin_http_accept;
+  plugin_http_accept = nullptr;
+
+  delete plugin_http_transparent_accept;
+  plugin_http_transparent_accept = nullptr;
 }


### PR DESCRIPTION
### Problem

Several core objects are leaked during clean shutdown, detected via ASAN-enabled autest runs on Fedora 43.

### Changes

- **NetAccept leak in `stop_accept()`** — The `NetAccept` objects stored in the global `naVec` were never freed at shutdown. After stopping each `NetAccept`, delete it and clear the vector.

- **HTTP acceptor objects leak** — The acceptor objects (`SSLNextProtocolAccept`, `ProtocolProbeSessionAccept`, `QUICNextProtocolAccept`) created in `MakeHttpProxyAcceptor` and the global `plugin_http_accept` / `plugin_http_transparent_accept` were never freed. Delete them in `stop_HttpProxyServer()`.

- **AIOCallback leak for API-originated ops** — `AIOCallback` objects allocated by `TSAIOWrite` / `TSAIORead` via `new_AIOCallback()` were never freed after completion. Add a `from_api` flag to `AIOCallback`, set it in `TSAIORead` / `TSAIOWrite`, and delete the callback in `io_complete` after the handler returns. Also delete on the error path when `ink_aio_read` / `ink_aio_write` fails.

### Testing

- [x] Built with `ENABLE_ASAN=ON` and ran full autest suite — no new LSAN reports
- [x] CI (all 15 jobs green)

<!-- merge-description-updated:2026-03-30T21:57:00Z -->