### PR TITLE
Fix memory leaks in plugins

### DIFF
--- a/example/plugins/c-api/client_context_dump/client_context_dump.cc
+++ b/example/plugins/c-api/client_context_dump/client_context_dump.cc
@@ -163,6 +163,7 @@ CB_context_dump(TSCont, TSEvent, void *edata)
       for (int i = 0; i < count; i += 2) {
         dump_context(results[i], results[i + 1]);
       }
+      free(results);
     }
   }
   TSTextLogObjectFlush(context_dump_log);

--- a/plugins/experimental/stale_response/stale_response.h
+++ b/plugins/experimental/stale_response/stale_response.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cstdlib>
+
 #include "ts/apidefs.h"
 #include "ts_wrap.h"
 #include "ts/ts.h"
@@ -62,6 +64,9 @@ struct ConfigInfo {
     }
     if (this->body_data_mutex) {
       TSMutexDestroy(this->body_data_mutex);
+    }
+    if (this->log_info.filename != PLUGIN_TAG) {
+      free(const_cast<char *>(this->log_info.filename));
     }
   }
   UintBodyMap *body_data = nullptr;

--- a/plugins/healthchecks/healthchecks.cc
+++ b/plugins/healthchecks/healthchecks.cc
@@ -287,6 +287,32 @@ hc_thread(void *data ATS_UNUSED)
   return nullptr; /* Yeah, that never happens */
 }
 
+/* Free all HCFileInfo nodes and their associated allocations */
+static void
+free_config(HCFileInfo *head)
+{
+  while (head) {
+    HCFileInfo *next = head->_next;
+
+    TSfree(const_cast<char *>(head->ok));
+    TSfree(const_cast<char *>(head->miss));
+    TSfree(head->data.load());
+    TSfree(head);
+    head = next;
+  }
+}
+
+/* Shutdown handler to clean up the global config */
+static int
+hc_shutdown_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
+{
+  if (event == TS_EVENT_LIFECYCLE_SHUTDOWN) {
+    free_config(g_config);
+    g_config = nullptr;
+  }
+  return 0;
+}
+
 /* Config file parsing */
 static const char HEADER_TEMPLATE[] = "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nCache-Control: no-cache\r\n";
 
@@ -621,6 +647,9 @@ TSPluginInit(int argc, const char *argv[])
     TSError("[healthchecks] Failure in thread creation");
     return;
   }
+
+  /* Register shutdown handler to free config memory */
+  TSLifecycleHookAdd(TS_LIFECYCLE_SHUTDOWN_HOOK, TSContCreate(hc_shutdown_handler, nullptr));
 
   /* Create a continuation with a mutex as there is a shared global structure
      containing the headers to add */

--- a/plugins/healthchecks/healthchecks.cc
+++ b/plugins/healthchecks/healthchecks.cc
@@ -287,32 +287,6 @@ hc_thread(void *data ATS_UNUSED)
   return nullptr; /* Yeah, that never happens */
 }
 
-/* Free all HCFileInfo nodes and their associated allocations */
-static void
-free_config(HCFileInfo *head)
-{
-  while (head) {
-    HCFileInfo *next = head->_next;
-
-    TSfree(const_cast<char *>(head->ok));
-    TSfree(const_cast<char *>(head->miss));
-    TSfree(head->data.load());
-    TSfree(head);
-    head = next;
-  }
-}
-
-/* Shutdown handler to clean up the global config */
-static int
-hc_shutdown_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void * /* edata ATS_UNUSED */)
-{
-  if (event == TS_EVENT_LIFECYCLE_SHUTDOWN) {
-    free_config(g_config);
-    g_config = nullptr;
-  }
-  return 0;
-}
-
 /* Config file parsing */
 static const char HEADER_TEMPLATE[] = "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nCache-Control: no-cache\r\n";
 
@@ -647,9 +621,6 @@ TSPluginInit(int argc, const char *argv[])
     TSError("[healthchecks] Failure in thread creation");
     return;
   }
-
-  /* Register shutdown handler to free config memory */
-  TSLifecycleHookAdd(TS_LIFECYCLE_SHUTDOWN_HOOK, TSContCreate(hc_shutdown_handler, nullptr));
 
   /* Create a continuation with a mutex as there is a shared global structure
      containing the headers to add */

--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -154,6 +154,8 @@ class S3Config;
 class ConfigCache
 {
 public:
+  ~ConfigCache();
+
   S3Config *get(const char *fname);
 
 private:
@@ -600,6 +602,13 @@ private:
   int       _conf_reload_count   = 0;
   int       _invalid_file_count  = 0;
 };
+
+ConfigCache::~ConfigCache()
+{
+  for (auto &[key, data] : _cache) {
+    delete data.config.load();
+  }
+}
 
 bool
 S3Config::parse_config(const std::string &config_fname)


### PR DESCRIPTION
### Problem

Several experimental plugins leak memory on shutdown, detected via ASAN-enabled autest runs on Fedora 43.

### Changes

- **`client_context_dump`** — Free `results` array after iterating context names in `CB_context_dump`.

- **`s3_auth` (ConfigCache)** — Add destructor to delete all cached `S3Config` pointers on shutdown.

- **`stale_response`** — Free `log_info.filename` in `ConfigInfo` destructor when it was `strdup()`'d (not the static default).

- **`healthchecks`** *(reverted)* — Added a shutdown handler to free the `g_config` linked list, but it raced with `hc_thread`'s inotify loop. Reverted; the leak only occurs at process exit.

### Testing

- [x] Built with `ENABLE_ASAN=ON` and ran full autest suite — no new LSAN reports
- [x] CI (all 15 jobs green)

<!-- merge-description-updated:2026-03-30T21:55:00Z -->