### PR TITLE
Try to change uid/gid on plugin runtime dir before dropping privs, if POSIX not available

### DIFF
--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -1833,7 +1833,7 @@ chown_owned_dirs(const char *user)
     chown_dir_recursive(logdir.c_str(), pwd->pw_uid, pwd->pw_gid);
   }
 }
-#endif
+#endif // !TS_USE_POSIX_CAP
 
 /*
  * Binds stdout and stderr to files specified by the parameters


### PR DESCRIPTION
This is a workaround for systems that don't provide the same POSIX style permissions dropping, i.e. BSD.

This recursively changes the permissions on the runtime (usually var) and logging directories and files to be the user we are dropping to