### PR TITLE
Fix Coverity 1646593-1646605

### DIFF
--- a/src/config/storage.cc
+++ b/src/config/storage.cc
@@ -255,11 +255,11 @@ parse_legacy_storage_config(std::string_view content)
     span.name      = path_tok;
     span.path      = path_tok;
     span.size      = size;
-    span.hash_seed = hash_seed;
+    span.hash_seed = std::move(hash_seed);
     result.spans.push_back(std::move(span));
 
     if (volume_num > 0) {
-      vol_span_map[volume_num].push_back(path_tok);
+      vol_span_map[volume_num].push_back(std::move(path_tok));
     }
   }
 
@@ -276,7 +276,7 @@ parse_legacy_storage_config(std::string_view content)
     result.volumes.push_back(std::move(vol));
   }
 
-  return {result, std::move(errata)};
+  return {std::move(result), std::move(errata)};
 }
 
 /**
@@ -435,7 +435,7 @@ parse_legacy_volume_config(std::string_view content)
     result.volumes.push_back(std::move(vol));
   }
 
-  return {result, std::move(errata)};
+  return {std::move(result), std::move(errata)};
 }
 
 } // namespace
@@ -511,8 +511,8 @@ template <> struct convert<config::StorageVolumeEntry> {
       throw ParserException(node.Mark(), "missing 'id' argument in cache.volumes[]");
     }
     vol.id = node[KEY_ID].as<int>();
-    if (vol.id < 1 || vol.id > MAX_VOLUME_IDX) {
-      throw ParserException(node.Mark(), "volume id out of range [1, 255]: " + std::to_string(vol.id));
+    if (vol.id < 1 || MAX_VOLUME_IDX < vol.id) {
+      throw ParserException(node.Mark(), "volume id out of range [1, 255]: " + node[KEY_ID].as<std::string>());
     }
 
     if (node[KEY_SCHEME]) {
@@ -520,7 +520,7 @@ template <> struct convert<config::StorageVolumeEntry> {
       if (s != "http") {
         throw ParserException(node.Mark(), "unsupported scheme '" + s + "' in cache.volumes[]");
       }
-      vol.scheme = s;
+      vol.scheme = std::move(s);
     }
 
     if (node[KEY_SIZE]) {
@@ -692,10 +692,10 @@ StorageParser::parse_content(std::string_view content)
     }
 
   } catch (std::exception const &ex) {
-    return {result, swoc::Errata(ERRATA_ERROR_SEV, "YAML parse error: {}", ex.what())};
+    return {std::move(result), swoc::Errata(ERRATA_ERROR_SEV, "YAML parse error: {}", ex.what())};
   }
 
-  return {result, std::move(errata)};
+  return {std::move(result), std::move(errata)};
 }
 
 ConfigResult<StorageConfig>

--- a/src/config/unit_tests/test_storage.cc
+++ b/src/config/unit_tests/test_storage.cc
@@ -786,14 +786,14 @@ TEST_CASE("StorageMarshaller produces valid YAML", "[storage][marshaller][yaml]"
   span1.name = "span-1";
   span1.path = "/var/cache/span1";
   span1.size = 10LL * 1024 * 1024 * 1024;
-  config.spans.push_back(span1);
+  config.spans.push_back(std::move(span1));
 
   StorageVolumeEntry vol1;
   vol1.id              = 1;
   vol1.scheme          = "http";
   vol1.size.in_percent = true;
   vol1.size.percent    = 100;
-  config.volumes.push_back(vol1);
+  config.volumes.push_back(std::move(vol1));
 
   StorageMarshaller marshaller;
   std::string       yaml = marshaller.to_yaml(config);
@@ -826,11 +826,11 @@ TEST_CASE("StorageMarshaller produces valid JSON", "[storage][marshaller][json]"
   StorageSpanEntry span1;
   span1.name = "span-1";
   span1.path = "/var/cache/span1";
-  config.spans.push_back(span1);
+  config.spans.push_back(std::move(span1));
 
   StorageVolumeEntry vol1;
   vol1.id = 1;
-  config.volumes.push_back(vol1);
+  config.volumes.push_back(std::move(vol1));
 
   StorageMarshaller marshaller;
   std::string       json = marshaller.to_json(config);

--- a/src/iocore/cache/unit_tests/test_ConfigVolumes.cc
+++ b/src/iocore/cache/unit_tests/test_ConfigVolumes.cc
@@ -143,9 +143,11 @@ TEST_CASE("ConfigVolumes::complement")
     //   - id: 2
     //     size: 34%
     ConfigVol *v1 = config.cp_queue.head;
+    REQUIRE(v1 != nullptr);
     CHECK(v1->size.percent == 66);
 
     ConfigVol *v2 = config.cp_queue.next(v1);
+    REQUIRE(v2 != nullptr);
     CHECK(v2->size.percent == 34);
   }
 
@@ -170,6 +172,7 @@ TEST_CASE("ConfigVolumes::complement")
     //         size: 100%
     ConfigVol *v1 = config.cp_queue.head;
 
+    REQUIRE(v1 != nullptr);
     CHECK(v1->size.is_empty());
     REQUIRE(v1->spans.size() == 1);
     CHECK(v1->spans[0].size.in_percent);
@@ -247,16 +250,19 @@ TEST_CASE("ConfigVolumes::complement")
     //         size: 70%
     ConfigVol *v1 = config.cp_queue.head;
 
+    REQUIRE(v1 != nullptr);
     CHECK(v1->size.is_empty());
     CHECK(v1->spans[0].size.percent == 10);
 
     ConfigVol *v2 = config.cp_queue.next(v1);
 
+    REQUIRE(v2 != nullptr);
     CHECK(v2->size.is_empty());
     CHECK(v2->spans[0].size.percent == 20);
 
     ConfigVol *v3 = config.cp_queue.next(v2);
 
+    REQUIRE(v3 != nullptr);
     CHECK(v3->size.is_empty());
     CHECK(v3->spans[0].size.percent == 70);
   }
@@ -307,6 +313,7 @@ TEST_CASE("ConfigVolumes::complement")
     //             size: 17%
     ConfigVol *v1 = config.cp_queue.head;
 
+    REQUIRE(v1 != nullptr);
     CHECK(v1->size.is_empty());
     REQUIRE(v1->spans.size() == 2);
 
@@ -348,6 +355,7 @@ TEST_CASE("ConfigVolumes::complement")
     //     size: 100%
     ConfigVol *v1 = config.cp_queue.head;
 
+    REQUIRE(v1 != nullptr);
     CHECK(v1->size.is_empty());
     REQUIRE(v1->spans.size() == 1);
     CHECK(v1->spans[0].size.in_percent);
@@ -355,6 +363,7 @@ TEST_CASE("ConfigVolumes::complement")
 
     ConfigVol *v2 = config.cp_queue.next(v1);
 
+    REQUIRE(v2 != nullptr);
     CHECK(v2->size.in_percent);
     CHECK(v2->size.percent == 100);
   }


### PR DESCRIPTION
src/config/storage.cc:
- CID 1646599: span.hash_seed = std::move(hash_seed)
- CID 1646594: vol_span_map[...].push_back(std::move(path_tok))
- CID 1646604: return {std::move(result), std::move(errata)} in parse_legacy_storage_config
- CID 1646603: return {std::move(result), std::move(errata)} in parse_legacy_volume_config
- CID 1646598: vol.scheme = std::move(s)
- CID 1646593: both returns in parse_content use std::move(result)
- CID 1646601: print original string

src/config/unit_tests/test_storage.cc:
- CID 1646605: config.spans.push_back(std::move(span1))
- CID 1646600: config.volumes.push_back(std::move(vol1)) (YAML test)
- CID 1646595: config.spans.push_back(std::move(span1))
- CID 1646602: config.volumes.push_back(std::move(vol1)) (JSON test)

src/iocore/cache/unit_tests/test_ConfigVolumes.cc:
- CID 1646596 & 1646597: Added REQUIRE(vN != nullptr) guards