### PR TITLE
proxy-request.expect: absent in PV replays

### DIFF
--- a/tests/gold_tests/cache/cache_volume_defaults.replay.yaml
+++ b/tests/gold_tests/cache/cache_volume_defaults.replay.yaml
@@ -137,6 +137,9 @@ sessions:
           - [X-Test-ID, "cache-hit-verify"]
           - [uuid, default-hit]
 
+    proxy-request:
+      expect: absent
+
     # Server should not be contacted for a cache hit
     server-response:
       status: 404

--- a/tests/gold_tests/cache/replay/auth-s-maxage.replay.yaml
+++ b/tests/gold_tests/cache/replay/auth-s-maxage.replay.yaml
@@ -94,6 +94,9 @@ sessions:
               - [Host, example.com]
               - [Authorization, "Basic ZGVtbzphdHNAc3Ryb25ncHc="]
 
+        proxy-request:
+          expect: absent
+
         # The server should NOT be reached because the cached response
         # with s-maxage should be served. Return 400 to verify caching.
         server-response:
@@ -140,6 +143,9 @@ sessions:
               - [uuid, public-with-auth]
               - [Host, example.com]
               - [Authorization, "Basic ZGVtbzphdHNAc3Ryb25ncHc="]
+
+        proxy-request:
+          expect: absent
 
         # The server should NOT be reached because the cached response
         # with public should be served. Return 400 to verify caching.
@@ -201,4 +207,3 @@ sessions:
         # response.
         proxy-response:
           status: 404
-

--- a/tests/gold_tests/cache/replay/cache-control-basic.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-basic.replay.yaml
@@ -102,6 +102,9 @@ sessions:
         - [x-debug, "x-cache,x-cache-key,via"]
         - [uuid, cache-hit]
 
+    proxy-request:
+      expect: absent
+
     # Server should not receive this request (it's cached)
     server-response:
       status: 404
@@ -202,6 +205,9 @@ sessions:
         - [x-debug, "x-cache,x-cache-key,via"]
         - [uuid, only-if-cached]
 
+    proxy-request:
+      expect: absent
+
     # Server should not be contacted for only-if-cached requests
     server-response:
       status: 200
@@ -215,4 +221,3 @@ sessions:
         fields:
         - [X-Cache, { value: "miss", as: equal }]
         - [Cache-Control, { value: "no-store", as: equal }]
-

--- a/tests/gold_tests/cache/replay/cache-control-max-age.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-max-age.replay.yaml
@@ -141,6 +141,9 @@ sessions:
   - all: { headers: { fields: [[ uuid, 2 ]]}}
     <<: *request_for_positive_max_age
 
+    proxy-request:
+      expect: absent
+
     # This should not go through to the server. Return a non-200 response to
     # verify it is served from cache.
     server-response:
@@ -297,6 +300,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # This should be replied to out of the cache, therefore this 400 response
     # should not make it to the client.

--- a/tests/gold_tests/cache/replay/cache-control-s-maxage.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-control-s-maxage.replay.yaml
@@ -137,6 +137,9 @@ sessions:
   - all: { headers: { fields: [[ uuid, 2 ]]}}
     <<: *request_for_positive_s_maxage
 
+    proxy-request:
+      expect: absent
+
     # This should not go through to the server. Return a non-200 response to
     # verify it is served from cache.
     server-response:

--- a/tests/gold_tests/cache/replay/cache-range-response.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-range-response.replay.yaml
@@ -82,6 +82,8 @@ sessions:
               - [ Host, example.com ]
               - [ uuid, 2 ]
               - [ Range, bytes=0-5 ]
+        proxy-request:
+          expect: absent
         server-response:
           status: 500
           reason: OK
@@ -103,6 +105,8 @@ sessions:
             fields:
               - [ Host, example.com ]
               - [ uuid, 3 ]
+        proxy-request:
+          expect: absent
         server-response:
           status: 500
           reason: OK

--- a/tests/gold_tests/cache/replay/cache-read-retry-stale.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-read-retry-stale.replay.yaml
@@ -114,6 +114,9 @@ sessions:
               - [uuid, cache-hit]
               - [Host, example.com]
 
+        proxy-request:
+          expect: absent
+
         # Should NOT reach origin (cache hit)
         server-response:
           status: 500

--- a/tests/gold_tests/cache/replay/cache-read-retry.replay.yaml
+++ b/tests/gold_tests/cache/replay/cache-read-retry.replay.yaml
@@ -207,6 +207,9 @@ sessions:
               - [Host, example.com]
               - [X-Request, fourth-verify]
 
+        proxy-request:
+          expect: absent
+
         # Server should NOT receive this request (should be cache hit)
         server-response:
           status: 400

--- a/tests/gold_tests/cache/replay/cookie-all-but-text-with-excp.replay.yaml
+++ b/tests/gold_tests/cache/replay/cookie-all-but-text-with-excp.replay.yaml
@@ -94,6 +94,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -150,6 +153,9 @@ sessions:
               - [uuid, set-cookie-vid-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200
@@ -265,6 +271,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -321,6 +330,9 @@ sessions:
               - [uuid, cookie-vid-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200
@@ -379,6 +391,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -435,6 +450,9 @@ sessions:
               - [uuid, cookie-response-text-has-cc-public-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200

--- a/tests/gold_tests/cache/replay/cookie-all-but-text.replay.yaml
+++ b/tests/gold_tests/cache/replay/cookie-all-but-text.replay.yaml
@@ -92,6 +92,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -147,6 +150,9 @@ sessions:
               - [uuid, set-cookie-vid-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200
@@ -262,6 +268,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -318,6 +327,9 @@ sessions:
               - [uuid, cookie-vid-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200

--- a/tests/gold_tests/cache/replay/cookie-cache-img-only.replay.yaml
+++ b/tests/gold_tests/cache/replay/cookie-cache-img-only.replay.yaml
@@ -149,6 +149,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -262,6 +265,9 @@ sessions:
               - [uuid, cookie-img-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200

--- a/tests/gold_tests/cache/replay/cookie-default.replay.yaml
+++ b/tests/gold_tests/cache/replay/cookie-default.replay.yaml
@@ -90,6 +90,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -147,6 +150,9 @@ sessions:
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK
@@ -202,6 +208,9 @@ sessions:
               - [uuid, cookie-text-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200
@@ -259,6 +268,9 @@ sessions:
               - [uuid, cookie-img-response-verify]
               - [Host, example.com]
               - [Cookie, "tasty_cookie=strawberry"]
+
+        proxy-request:
+          expect: absent
 
         server-response:
           status: 200

--- a/tests/gold_tests/cache/replay/delete_cached.replay.yaml
+++ b/tests/gold_tests/cache/replay/delete_cached.replay.yaml
@@ -82,6 +82,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # The request should be served out of cache, so this 403 should not be
     # received.
     server-response:
@@ -123,6 +126,9 @@ sessions:
         fields:
         - [ Host, example.com ]
         - [ uuid, 4 ]
+
+    proxy-request:
+      expect: absent
 
     # The request should be served out of cache, so this 403 should not be
     # received.

--- a/tests/gold_tests/cache/replay/get_then_post.replay.yaml
+++ b/tests/gold_tests/cache/replay/get_then_post.replay.yaml
@@ -57,6 +57,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # The request should be served out of cache, so this 403 should not be
     # received.
     server-response:
@@ -147,6 +150,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # This should be served out of cache, so we do not expect for the server
     # to reply with this.
     server-response:
@@ -208,6 +214,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The server should not receive this request because ATS should reply out
     # of the cache.

--- a/tests/gold_tests/cache/replay/head_with_get_cached.replay.yaml
+++ b/tests/gold_tests/cache/replay/head_with_get_cached.replay.yaml
@@ -82,6 +82,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # The request should be served out of cache, so this 403 should not be
     # received.
     server-response:
@@ -111,6 +114,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The request should be served out of cache, so this 403 should not be
     # received.
@@ -142,6 +148,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The server should not receive this request because ATS should reply out
     # of the cache.
@@ -232,8 +241,8 @@ sessions:
       # transaction.
       delay: 100ms
 
-    # The server should not receive this request because ATS should reply out
-    # of the cache.
+    # The HEAD responses above should not populate cache, so this GET must go
+    # to origin and establish the cached GET entry for later requests.
     server-response:
       status: 200
       reason: OK
@@ -262,6 +271,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The request should be served out of cache, so this 403 should not be
     # received.
@@ -292,6 +304,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The request should be served out of cache, so this 403 should not be
     # received.

--- a/tests/gold_tests/cache/replay/negative-caching-300-second-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-300-second-timeout.replay.yaml
@@ -61,6 +61,9 @@ sessions:
   - all: { headers: { fields: [[ uuid, 22 ]]}}
     <<: *request_404_item
 
+    proxy-request:
+      expect: absent
+
     # 404 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 200 so the test
     # knows that something went wrong.

--- a/tests/gold_tests/cache/replay/negative-caching-customized.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-customized.replay.yaml
@@ -191,6 +191,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # This should not go to the server since the 200 response is cached.
     server-response:
       status: 400

--- a/tests/gold_tests/cache/replay/negative-caching-default.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-default.replay.yaml
@@ -100,6 +100,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # 404 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 200 so the test
     # knows that something went wrong.
@@ -187,6 +190,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # This should not go to the server, but if it does return a 400 so we catch
     # it.

--- a/tests/gold_tests/cache/replay/negative-caching-disabled.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-disabled.replay.yaml
@@ -129,6 +129,9 @@ sessions:
   - all: { headers: { fields: [[ uuid, 2 ]]}}
     <<: *request_for_path_200
 
+    proxy-request:
+      expect: absent
+
     # This should not go through to the server. Return a non-200 response to
     # verify it is served from cache.
     server-response:
@@ -230,6 +233,9 @@ sessions:
 
   - all: { headers: { fields: [[ uuid, 8 ]]}}
     <<: *request_for_404_with_cc
+
+    proxy-request:
+      expect: absent
 
     # This should be served out of cache, therefore the origin server should
     # not see this.

--- a/tests/gold_tests/cache/replay/negative-caching-malformed-cc.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-malformed-cc.replay.yaml
@@ -207,6 +207,9 @@ sessions:
         - [ Host, example.com ]
         - [ uuid, proper_cc_verify ]
 
+    proxy-request:
+      expect: absent
+
     # The server should not receive this request because it should be served from cache.
     server-response:
       status: 200

--- a/tests/gold_tests/cache/replay/negative-caching-no-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-no-timeout.replay.yaml
@@ -43,6 +43,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # This should not go to the server. Verify we get the cached 404 response
     # instead of this new 403 response.
     server-response:

--- a/tests/gold_tests/cache/replay/negative-caching-timeout.replay.yaml
+++ b/tests/gold_tests/cache/replay/negative-caching-timeout.replay.yaml
@@ -78,6 +78,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # 403 responses should be cached when negative caching is enabled, so this
     # should not get to the server.  But if it does, return a 404 so the test
     # knows that something went wrong.

--- a/tests/gold_tests/cache/replay/post_with_post_caching_disabled.replay.yaml
+++ b/tests/gold_tests/cache/replay/post_with_post_caching_disabled.replay.yaml
@@ -86,6 +86,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # The request should be served out of cache, so this 403 should not be
     # received.
     server-response:
@@ -177,6 +180,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # This should be served out of cache, so we do not expect for the server
     # to reply with this.
     server-response:
@@ -238,6 +244,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The server should not receive this request because ATS should reply out
     # of the cache.

--- a/tests/gold_tests/cache/replay/post_with_post_caching_enabled.replay.yaml
+++ b/tests/gold_tests/cache/replay/post_with_post_caching_enabled.replay.yaml
@@ -94,6 +94,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     # The request should not go to the server, so this 500 response should not
     # be served.
     server-response:
@@ -158,6 +161,9 @@ sessions:
       # transaction.
       delay: 500ms
 
+    proxy-request:
+      expect: absent
+
     # The request should be served out of cache, so this 403 should not be
     # received.
     server-response:
@@ -215,6 +221,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The earlier response to the POST request should be returned, not this 403.
     server-response:
@@ -334,6 +343,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # The response should be served out of cache, not via this server response.
     server-response:

--- a/tests/gold_tests/cache/replay/post_with_post_caching_override.replay.yaml
+++ b/tests/gold_tests/cache/replay/post_with_post_caching_override.replay.yaml
@@ -97,6 +97,9 @@ sessions:
         - [ Content-Length, 48 ]
         - [ uuid, 12 ]
 
+    proxy-request:
+      expect: absent
+
     # This should not go through to the server since the previous POST response
     # should have been cached. Return a non-200 response to
     # verify it is served from cache.

--- a/tests/gold_tests/cache/replay/response-cache-control-ignored.replay.yaml
+++ b/tests/gold_tests/cache/replay/response-cache-control-ignored.replay.yaml
@@ -150,6 +150,9 @@ sessions:
               - [uuid, response-cc-no-store-verify]
               - [Host, example.com]
 
+        proxy-request:
+          expect: absent
+
         server-response:
           status: 200
           reason: OK

--- a/tests/gold_tests/cache/replay/targeted-cache-control.replay.yaml
+++ b/tests/gold_tests/cache/replay/targeted-cache-control.replay.yaml
@@ -293,6 +293,9 @@ sessions:
         - [Host, default.com]
         - [uuid, default-test1-request2]
 
+    proxy-request:
+      expect: absent
+
     # Should not reach the origin.
     server-response:
       status: 404
@@ -318,6 +321,9 @@ sessions:
         - [Host, example.com]
         - [uuid, targeted-test1-request2]
 
+    proxy-request:
+      expect: absent
+
     # Should not reach the origin.
     server-response:
       status: 404
@@ -339,6 +345,9 @@ sessions:
         fields:
         - [Host, example.com]
         - [uuid, targeted-test2-request2]
+
+    proxy-request:
+      expect: absent
 
     # Should not reach the origin.
     server-response:
@@ -385,6 +394,9 @@ sessions:
         - [Host, example.com]
         - [uuid, targeted-test4-request2]
 
+    proxy-request:
+      expect: absent
+
     # Should not reach the origin.
     server-response:
       status: 404
@@ -405,6 +417,9 @@ sessions:
         fields:
         - [Host, acme.com]
         - [uuid, acme-test1-request2]
+
+    proxy-request:
+      expect: absent
 
     # The origin should not receive the request since ATS will reply out of cache.
     server-response:

--- a/tests/gold_tests/cache/replay/varied_transactions.replay.yaml
+++ b/tests/gold_tests/cache/replay/varied_transactions.replay.yaml
@@ -306,6 +306,9 @@ sessions:
       # transaction.
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -371,6 +374,9 @@ sessions:
       # Add a delay so ATS has time to finish any caching IO for the previous
       # transaction.
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     # This should be served out of the cache and not reach the origin.
     server-response:

--- a/tests/gold_tests/dns/replay/server_error.replay.yaml
+++ b/tests/gold_tests/dns/replay/server_error.replay.yaml
@@ -29,5 +29,8 @@ sessions:
         - [ X-Request, request ]
         - [ uuid, 1 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 500

--- a/tests/gold_tests/headers/replays/normalized_ae_varied_transactions.replay.yaml
+++ b/tests/gold_tests/headers/replays/normalized_ae_varied_transactions.replay.yaml
@@ -274,6 +274,9 @@ sessions:
         - [ uuid, 12 ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -297,6 +300,9 @@ sessions:
         - [ Accept-Encoding, deflate ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -319,6 +325,9 @@ sessions:
         - [ uuid, 14 ]
         - [ Accept-Encoding, "br, compress" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -378,6 +387,9 @@ sessions:
         - [ Accept-Encoding, "br, compress, gzip" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -434,6 +446,9 @@ sessions:
         - [ uuid, 22 ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -456,6 +471,9 @@ sessions:
         - [ uuid, 23 ]
         - [ Accept-Encoding, deflate ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -550,6 +568,9 @@ sessions:
         - [ Accept-Encoding, "br, compress, gzip" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -572,6 +593,9 @@ sessions:
         - [ uuid, 27 ]
         - [ Accept-Encoding, "compress, gzip" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -629,6 +653,9 @@ sessions:
         - [ uuid, 32 ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -651,6 +678,9 @@ sessions:
         - [ uuid, 33 ]
         - [ Accept-Encoding, deflate ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -779,6 +809,9 @@ sessions:
         - [ Accept-Encoding, "compress, gzip" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -802,6 +835,9 @@ sessions:
         - [ Accept-Encoding, "br;q=1.1" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -823,6 +859,9 @@ sessions:
         - [ uuid, 39 ]
         - [ Accept-Encoding, "br, gzip;q=0.8" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -880,6 +919,9 @@ sessions:
         - [ uuid, 42 ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -902,6 +944,9 @@ sessions:
         - [ uuid, 43 ]
         - [ Accept-Encoding, deflate ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -1046,6 +1091,9 @@ sessions:
         - [ Accept-Encoding, "zstd, br, compress, gzip" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1068,6 +1116,9 @@ sessions:
         - [ uuid, 48 ]
         - [ Accept-Encoding, "br, compress, gzip" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -1092,6 +1143,9 @@ sessions:
         - [ Accept-Encoding, "compress, zstd" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1114,6 +1168,9 @@ sessions:
         - [ uuid, 410 ]
         - [ Accept-Encoding, "compress, gzip" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -1171,6 +1228,9 @@ sessions:
         - [ uuid, 52 ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1193,6 +1253,9 @@ sessions:
         - [ uuid, 53 ]
         - [ Accept-Encoding, deflate ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -1454,6 +1517,9 @@ sessions:
         - [ Accept-Encoding, "compress, zstd" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1476,6 +1542,9 @@ sessions:
         - [ uuid, 511 ]
         - [ Accept-Encoding, "compress, br" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -1500,6 +1569,9 @@ sessions:
         - [ Accept-Encoding, "compress, gzip" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1522,6 +1594,9 @@ sessions:
         - [ uuid, 513 ]
         - [ Accept-Encoding, "zstd;q=1.1" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response
@@ -1546,6 +1621,9 @@ sessions:
         - [ Accept-Encoding, "br;q=1.1" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1568,6 +1646,9 @@ sessions:
         - [ Accept-Encoding, "zstd, br;q=0.8" ]
       delay: 100ms
 
+    proxy-request:
+      expect: absent
+
     server-response:
       <<: *404_response
 
@@ -1589,6 +1670,9 @@ sessions:
         - [ uuid, 516 ]
         - [ Accept-Encoding, "zstd, gzip;q=0.8" ]
       delay: 100ms
+
+    proxy-request:
+      expect: absent
 
     server-response:
       <<: *404_response

--- a/tests/gold_tests/pluginTest/escalate/escalate_failover.replay.yaml
+++ b/tests/gold_tests/pluginTest/escalate/escalate_failover.replay.yaml
@@ -31,10 +31,7 @@ sessions:
         - [ uuid, GET ]
 
     proxy-request:
-      method: "GET"
-      headers:
-        fields:
-        - [ X-Request, { value: first, as: equal } ]
+      expect: absent
 
     server-response:
       # The failover server should not receive this request since the original
@@ -57,10 +54,7 @@ sessions:
         - [ uuid, GET_chunked ]
 
     proxy-request:
-      method: "GET"
-      headers:
-        fields:
-        - [ X-Request, { value: second, as: equal } ]
+      expect: absent
 
     server-response:
       # The failover server should not receive this request since the original

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
@@ -535,6 +535,9 @@ sessions:
         - [ Host, www.example.com ]
         - [ uuid, 14 ]
 
+    proxy-request:
+      expect: absent
+
     server-response:
       status: 200
       reason: OK
@@ -590,6 +593,9 @@ sessions:
         fields:
         - [ Host, www.example.com ]
         - [ uuid, 16 ]
+
+    proxy-request:
+      expect: absent
 
     # The server-response should not be served.
     server-response:

--- a/tests/gold_tests/pluginTest/statichit/statichit.replay.yaml
+++ b/tests/gold_tests/pluginTest/statichit/statichit.replay.yaml
@@ -31,6 +31,9 @@ sessions:
         - [ Host, fqdn1 ]
         - [ uuid, 1 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 200
       headers:
@@ -54,6 +57,9 @@ sessions:
         - [ Host, fqdn1 ]
         - [ uuid, 2 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 404
       headers:
@@ -74,6 +80,9 @@ sessions:
         fields:
         - [ Host, fqdn2 ]
         - [ uuid, 3 ]
+
+    proxy-request:
+      expect: absent
 
     proxy-response:
       status: 200
@@ -98,6 +107,9 @@ sessions:
         - [ Host, fqdn3 ]
         - [ uuid, 4 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 200
       headers:
@@ -121,6 +133,9 @@ sessions:
         - [ Host, fqdn4 ]
         - [ uuid, 5 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 412
       headers:
@@ -135,6 +150,9 @@ sessions:
         fields:
         - [ Host, fqdn5 ]
         - [ uuid, 6 ]
+
+    proxy-request:
+      expect: absent
 
     proxy-response:
       status: 200
@@ -158,6 +176,9 @@ sessions:
         - [ Host, fqdn6 ]
         - [ uuid, 7 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 200
       headers:
@@ -175,6 +196,9 @@ sessions:
         fields:
         - [ Host, fqdn7 ]
         - [ uuid, 8 ]
+
+    proxy-request:
+      expect: absent
 
     proxy-response:
       status: 200
@@ -199,6 +223,9 @@ sessions:
         - [ Host, fqdn8 ]
         - [ uuid, 8 ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 200
       headers:
@@ -221,6 +248,9 @@ sessions:
         fields:
         - [ Host, fqdn9 ]
         - [ uuid, 9 ]
+
+    proxy-request:
+      expect: absent
 
     proxy-response:
       status: 200

--- a/tests/gold_tests/pluginTest/txn_box/prod/mTLS-alpha.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/mTLS-alpha.replay.yaml
@@ -14,6 +14,8 @@ sessions:
         fields:
         - [ Host, "base.ex" ]
         - [ UUID , "alpha clean" ]
+    proxy-request:
+      expect: absent
     proxy-response:
       status: 200
 
@@ -25,5 +27,7 @@ sessions:
         - [ Host, "base.ex" ]
         - [ UUID , "alpha auth" ]
         - [ Authorization , "invalid" ]
+    proxy-request:
+      expect: absent
     proxy-response:
       status: 200

--- a/tests/gold_tests/pluginTest/txn_box/prod/mTLS-bravo.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/prod/mTLS-bravo.replay.yaml
@@ -14,6 +14,8 @@ sessions:
         fields:
         - [ Host, "base.ex" ]
         - [ UUID , "bravo clean" ]
+    proxy-request:
+      expect: absent
     proxy-response:
       status: 200
 
@@ -25,6 +27,8 @@ sessions:
         - [ Host, "base.ex" ]
         - [ UUID , "bravo auth" ]
         - [ Authorization , "alpha" ]
+    proxy-request:
+      expect: absent
     proxy-response:
       status: 200
 
@@ -35,5 +39,7 @@ sessions:
         fields:
         - [ Host, "base.ex" ]
         - [ UUID , "bravo propfind" ]
+    proxy-request:
+      expect: absent
     proxy-response:
       status: 418

--- a/tests/gold_tests/redirect/replay/redirect_to_same_origin_on_cache.replay.yaml
+++ b/tests/gold_tests/redirect/replay/redirect_to_same_origin_on_cache.replay.yaml
@@ -75,6 +75,9 @@ sessions:
         - [ Content-Length, 0 ]
         - [ x-debug, x-cache ]
 
+    proxy-request:
+      expect: absent
+
     # should no request to origin server
     server-response:
       status: 503

--- a/tests/gold_tests/remap/reload_3.replay.yaml
+++ b/tests/gold_tests/remap/reload_3.replay.yaml
@@ -35,5 +35,8 @@ sessions:
         fields:
         - [ Host, charlie.ex ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 404

--- a/tests/gold_tests/remap_yaml/reload_3.replay.yaml
+++ b/tests/gold_tests/remap_yaml/reload_3.replay.yaml
@@ -35,5 +35,8 @@ sessions:
         fields:
         - [ Host, charlie.ex ]
 
+    proxy-request:
+      expect: absent
+
     proxy-response:
       status: 404

--- a/tests/gold_tests/url/uri.replay.yaml
+++ b/tests/gold_tests/url/uri.replay.yaml
@@ -153,6 +153,9 @@ sessions:
         - [ Connection, keep-alive ]
         - [ uuid, encoded_path_again ]
 
+    proxy-request:
+      expect: absent
+
     # The origin should not receive this request, but if it does, reply with a
     # non-404 response so we can detect it.
     <<: *200_ok_response
@@ -175,6 +178,9 @@ sessions:
         - [ Host, test.com ]
         - [ Connection, keep-alive ]
         - [ uuid, unencoded_path_again ]
+
+    proxy-request:
+      expect: absent
 
     # The origin should not receive this request, but if it does, reply with a
     # non-200 response so we can detect it.


### PR DESCRIPTION
Proxy Verifier v3.1.2 can now verify that ATS does not send an upstream
request to the origin. Update replay transactions that serve from cache
or otherwise respond locally to use proxy-request.expect: absent.

This makes the no-origin cases explicit across the autests and turns the
old trap server responses into a direct expectation. It also fixes one
stale comment in the HEAD/GET cache replay so the test text matches the
origin behavior.