### PR TITLE
Add autest for empty POST framing: 411 response

### DIFF
--- a/tests/gold_tests/post/post-no-cl.test.py
+++ b/tests/gold_tests/post/post-no-cl.test.py
@@ -1,0 +1,25 @@
+'''
+Verify that POST requests without a body are accepted.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify that POST request without a Content-Length or Transfer-Encoding header is
+rejected with a 411.
+'''
+
+Test.ATSReplayTest(replay_file='replay/post-no-cl.replay.yaml')

--- a/tests/gold_tests/post/replay/post-no-cl.replay.yaml
+++ b/tests/gold_tests/post/replay/post-no-cl.replay.yaml
@@ -1,0 +1,60 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+autest:
+  description: 'Verify ATS rejects unspecified length POST requests with a 411.'
+
+  dns:
+    name: 'dns'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+    process_config:
+      enable_cache: false
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'http|http_trans'
+
+    remap_config:
+      - from: "http://example.com/"
+        to: "http://backend.example.com:{SERVER_HTTP_PORT}/"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "POST"
+      version: "1.1"
+      url: /no-cl
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, post-no-cl ]
+
+    proxy-request:
+      expect: absent
+
+    proxy-response:
+      status: 411


### PR DESCRIPTION
Add a replay-based autest for a POST request that omits both
Content-Length and Transfer-Encoding. This captures the current
411 response in ATS and gives us a focused reproducer for issue
12960.

411 is in compliance with the RFC:

https://datatracker.ietf.org/doc/html/rfc9112#section-6.3

  A server MAY reject a request that contains a message body but not a
  Content-Length by responding with 411 (Length Required).

Fixes: #12960