### PR TITLE
Install rustup instead of cargo to use a newer version of rustc

### DIFF
--- a/contrib/docker/ubuntu/noble/Dockerfile
+++ b/contrib/docker/ubuntu/noble/Dockerfile
@@ -33,7 +33,7 @@ RUN apt update \
     libev-dev \
     libevent-dev \
     zlib1g-dev \
-    cargo \
+    rustup \
     wget \
     git \
     libtool \
@@ -60,6 +60,8 @@ RUN apt update \
  # needed to appease nghttp2 but unused
     libssl-dev \
  && apt clean --yes
+
+RUN rustup default stable
 
 RUN mkdir -p ${BASE} && chmod a+rX ${BASE}
 


### PR DESCRIPTION
This is needed to avoid the following error while building the Cloudflare quiche library:
```
error: package `serde_with v3.18.0` cannot be built because it requires rustc 1.88 or newer, while the currently active rustc version is 1.75.0
```