### PR TITLE
Exclude http_load sources from RAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -915,8 +915,7 @@ endif()
 add_custom_target(
   rat
   COMMENT "Running Apache RAT"
-  COMMAND java -jar ${CMAKE_SOURCE_DIR}/ci/apache-rat-0.13-SNAPSHOT.jar -E ${CMAKE_SOURCE_DIR}/ci/rat-regex.txt -d
-          ${CMAKE_SOURCE_DIR}
+  COMMAND bash ${CMAKE_SOURCE_DIR}/ci/run-rat.sh ${CMAKE_SOURCE_DIR}
 )
 
 # Create an empty directories for ATS runtime

--- a/ci/rat-regex.txt
+++ b/ci/rat-regex.txt
@@ -72,6 +72,9 @@ port\.h
 ^systemtap$
 ^swoc$
 ^tests/gold_tests/autest-site/min_cfg$
+^http_load\.c$
+^timers\.c$
+^timers\.h$
 ^clang-tidy.conf$
 ^build.*$
 ^cmake-build.*$

--- a/ci/rat-regex.txt
+++ b/ci/rat-regex.txt
@@ -72,9 +72,6 @@ port\.h
 ^systemtap$
 ^swoc$
 ^tests/gold_tests/autest-site/min_cfg$
-^http_load\.c$
-^timers\.c$
-^timers\.h$
 ^clang-tidy.conf$
 ^build.*$
 ^cmake-build.*$

--- a/ci/run-rat.sh
+++ b/ci/run-rat.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -euo pipefail
+
+source_dir=${1:-$(cd "$(dirname "$0")/.." && pwd)}
+jar_path="${source_dir}/ci/apache-rat-0.13-SNAPSHOT.jar"
+regex_path="${source_dir}/ci/rat-regex.txt"
+
+if ! git -C "${source_dir}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exec java -jar "${jar_path}" -E "${regex_path}" -d "${source_dir}"
+fi
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/ats-rat.XXXXXX")
+scan_root="${tmpdir}/scan"
+file_list="${tmpdir}/files.list"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+mkdir -p "${scan_root}"
+
+git -C "${source_dir}" ls-files -z --cached --others --exclude-standard -- \
+  ':!:tools/http_load/http_load.c' \
+  ':!:tools/http_load/timers.c' \
+  ':!:tools/http_load/timers.h' >"${file_list}"
+
+tar -C "${source_dir}" --null -T "${file_list}" -cf - | tar -C "${scan_root}" -xf -
+
+exec java -jar "${jar_path}" -E "${regex_path}" -d "${scan_root}"


### PR DESCRIPTION
This excludes the third-party http_load sources from RAT checks.
These files carry their own upstream license text rather than ASF
headers, so checking them as Apache-licensed sources causes a false
failure.

This keeps the RAT target consistent across environments and avoids
local failures on http_load.c.