### PR TITLE
Add connect_down_policy: 4 for empty reply

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -1834,12 +1834,24 @@ Origin Server Connect Attempts
    :overridable:
 
    Controls what origin server connection failures contribute to marking a server down.
-   When set to ``2``, any connection failure during the TCP and TLS handshakes will
-   contribute to marking the server down. When set to ``1``, only TCP handshake failures
-   will contribute to marking a server down. When set to ``0``, no connection failures
-   will be used towards marking a server down. When set to ``3``, all failures covered
-   by ``2`` plus transaction inactive timeouts (server goes silent after connection is
-   established) will contribute to marking a server down.
+
+   +-------+-----------------------------------------------------------------------+
+   | Value | Behavior                                                              |
+   +=======+=======================================================================+
+   | ``0`` | No connection failures contribute to marking a server down.           |
+   +-------+-----------------------------------------------------------------------+
+   | ``1`` | TCP handshake failures (excluding TLS handshake failures) contribute  |
+   |       | to marking a server down.                                             |
+   +-------+-----------------------------------------------------------------------+
+   | ``2`` | Any connection failure during the TCP or TLS handshake contributes to |
+   |       | marking a server down.                                                |
+   +-------+-----------------------------------------------------------------------+
+   | ``3`` | All failures covered by ``2``, plus transaction inactive timeouts     |
+   |       | (server goes silent after the connection is established).             |
+   +-------+-----------------------------------------------------------------------+
+   | ``4`` | All failures covered by ``3``, plus cases where the origin closes the |
+   |       | connection before sending any response bytes.                         |
+   +-------+-----------------------------------------------------------------------+
 
 .. ts:cv:: CONFIG proxy.config.http.server_max_connections INT 0
    :reloadable:

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4667,22 +4667,32 @@ HttpSM::do_hostdb_reverse_lookup()
 bool
 HttpSM::track_connect_fail() const
 {
-  bool retval = false;
-  if (t_state.current.server->had_connect_fail()) {
-    // What does our policy say?
-    if (t_state.txn_conf->connect_down_policy == 2 ||
-        t_state.txn_conf->connect_down_policy == 3) { // Any connection error through TLS handshake
-      retval = true;
-    } else if (t_state.txn_conf->connect_down_policy == 1) { // Any connection error through TCP
-      retval = t_state.current.server->connect_result != -ENET_SSL_CONNECT_FAILED;
-    }
+  int const policy = t_state.txn_conf->connect_down_policy;
+
+  // Policy 1: any TCP-level connect error (excluding TLS handshake failures).
+  if (policy == 1 && t_state.current.server->had_connect_fail()) {
+    return t_state.current.server->connect_result != -ENET_SSL_CONNECT_FAILED;
   }
-  // Policy 3 additionally marks the server down on transaction inactive timeout,
-  // even when had_connect_fail() is false (connect_result was cleared at CONNECTION_ALIVE).
-  if (!retval && t_state.txn_conf->connect_down_policy == 3) {
-    retval = (t_state.current.server->state == HttpTransact::INACTIVE_TIMEOUT);
+
+  // Policy 2+: any connect error including TLS handshake failures.
+  if (policy >= 2 && t_state.current.server->had_connect_fail()) {
+    return true;
   }
-  return retval;
+
+  // Policy 3+: inactive timeout (connect_result was cleared at CONNECTION_ALIVE).
+  if (policy >= 3 && t_state.current.server->state == HttpTransact::INACTIVE_TIMEOUT) {
+    return true;
+  }
+
+  // Policy 4+: origin closed a fresh connection before sending any response bytes.
+  // Excludes two cases:
+  // - Reused keep-alive connection: there is a known race between ATS reusing and the origin closing it.
+  // - Multiplexed origins (HTTP/2): stream-level failure does not indicate a connection failure.
+  if (policy >= 4 && !origin_multiplexed() && server_response_hdr_bytes == 0 && server_txn->is_first_transaction()) {
+    return true;
+  }
+
+  return false;
 }
 
 void

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4688,8 +4688,15 @@ HttpSM::track_connect_fail() const
   // Excludes two cases:
   // - Reused keep-alive connection: there is a known race between ATS reusing and the origin closing it.
   // - Multiplexed origins (HTTP/2): stream-level failure does not indicate a connection failure.
-  if (policy >= 4 && !origin_multiplexed() && server_response_hdr_bytes == 0 && server_txn->is_first_transaction()) {
-    return true;
+  if (policy >= 4) {
+    bool multiplexed = false;
+    auto ssn         = server_txn->get_proxy_ssn();
+    if (ssn != nullptr) {
+      multiplexed = static_cast<PoolableSession *>(ssn)->is_multiplexing();
+    }
+    if (!multiplexed && server_txn->is_first_transaction() && server_response_hdr_bytes == 0) {
+      return true;
+    }
   }
 
   return false;

--- a/tests/gold_tests/connect_down_policy/connect_down_policy.test.py
+++ b/tests/gold_tests/connect_down_policy/connect_down_policy.test.py
@@ -111,3 +111,6 @@ ConnectDownPolicy3Test(policy=3, expect_mark_down=True).run()
 
 # Policy 2: inactive timeout should NOT mark the origin down.
 ConnectDownPolicy3Test(policy=2, expect_mark_down=False).run()
+
+# Policy 4: origin closes connection without sending any response.
+Test.ATSReplayTest(replay_file="replay/connect_down_policy_4.replay.yaml")

--- a/tests/gold_tests/connect_down_policy/gold/connect_down_policy_4_error_log.gold
+++ b/tests/gold_tests/connect_down_policy/gold/connect_down_policy_4_error_log.gold
@@ -1,0 +1,6 @@
+`` Server closed connection while reading response header. (origin backend1.example.com:``/path/)
+`` CONNECT : SUCCESS [0] connecting to 127.0.0.1:`` for host='one.example.com' url='http://backend1.example.com:``/path/' fail_count='1' marking down
+`` DNS Error: no valid server http://backend1.example.com:``/path/
+`` Server closed connection while reading response header. (origin backend2.example.com:``/path/)
+`` CONNECT : SUCCESS [0] connecting to 127.0.0.1:`` for host='two.example.com' url='http://backend2.example.com:``/path/' fail_count='1' marking down
+`` DNS Error: no valid server http://backend2.example.com:``/path/

--- a/tests/gold_tests/connect_down_policy/replay/connect_down_policy_4.replay.yaml
+++ b/tests/gold_tests/connect_down_policy/replay/connect_down_policy_4.replay.yaml
@@ -1,0 +1,129 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# This replay file assumes that caching is disabled.
+#
+
+meta:
+  version: "1.0"
+
+# Configuration section for autest integration
+autest:
+  description: 'Verify connect down policy 4 - origin closes connection without sending a response'
+
+  dns:
+    name: 'dns-dp-4'
+    records:
+      backend1.example.com: ["127.0.0.1"]
+      backend2.example.com: ["127.0.0.1"]
+
+  server:
+    name: 'server-dp-4'
+
+  client:
+    name: 'client-dp-4'
+
+  ats:
+    name: 'ts-dp-4'
+    process_config:
+      enable_cache: false
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'http|hostdb'
+      proxy.config.http.connect.down.policy: 4
+      proxy.config.http.connect_attempts_rr_retries: 0
+      proxy.config.http.connect_attempts_max_retries: 0
+      proxy.config.http.connect_attempts_max_retries_down_server: 0
+      proxy.config.http.connect_attempts_timeout: 1
+      proxy.config.http.down_server.cache_time: 5
+
+    remap_config:
+      - from: "http://one.example.com/"
+        to: "http://backend1.example.com:{SERVER_HTTP_PORT}/"
+      - from: "http://two.example.com/"
+        to: "http://backend2.example.com:{SERVER_HTTP_PORT}/"
+
+    log_validation:
+      error_log:
+        gold_file: "gold/connect_down_policy_4_error_log.gold"
+
+sessions:
+- transactions:
+  # on_connect: refuse - Server accepts TCP connection but immediately closes it without sending any HTTP response
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, one.example.com]
+        - [uuid, 1]
+
+    server-response:
+      on_connect: refuse
+
+    proxy-response:
+      status: 502
+
+  # Verify the origin is marked down after the close.
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, one.example.com]
+        - [uuid, 10]
+
+    proxy-request:
+      expect: absent
+
+    proxy-response:
+      status: 500
+
+  # on_connect: reset - Server accepts TCP connection but immediately reset it without sending any HTTP response
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, two.example.com]
+        - [uuid, 2]
+
+    server-response:
+      on_connect: reset
+
+    proxy-response:
+      status: 502
+
+  # Verify the origin is marked down after the reset.
+  - client-request:
+      method: GET
+      url: /path/
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, two.example.com]
+        - [uuid, 20]
+
+    proxy-request:
+      expect: absent
+
+    proxy-response:
+      status: 500

--- a/tests/gold_tests/connect_down_policy/replay/connect_down_policy_4.replay.yaml
+++ b/tests/gold_tests/connect_down_policy/replay/connect_down_policy_4.replay.yaml
@@ -26,19 +26,19 @@ autest:
   description: 'Verify connect down policy 4 - origin closes connection without sending a response'
 
   dns:
-    name: 'dns-dp-4'
+    name: 'dns-policy-4'
     records:
       backend1.example.com: ["127.0.0.1"]
       backend2.example.com: ["127.0.0.1"]
 
   server:
-    name: 'server-dp-4'
+    name: 'server-policy-4'
 
   client:
-    name: 'client-dp-4'
+    name: 'client-policy-4'
 
   ats:
-    name: 'ts-dp-4'
+    name: 'ts-policy-4'
     process_config:
       enable_cache: false
 
@@ -93,6 +93,9 @@ sessions:
     proxy-request:
       expect: absent
 
+    server-response:
+      status: 200
+
     proxy-response:
       status: 500
 
@@ -124,6 +127,9 @@ sessions:
 
     proxy-request:
       expect: absent
+
+    server-response:
+      status: 200
 
     proxy-response:
       status: 500


### PR DESCRIPTION
# Problem                                                   
                                                                                                                                                                                                                                                           
When an origin server accepts a TCP/TLS connection but closes it without sending any HTTP response, ATS does not mark the origin as down — even after exhausting all retry attempts. This can cause ATS to keep hammering a misbehaving origin on every request.                                                                                                                                                                                                                                                

# Fix 

- Add a new policy, `4`, all failures covered by policy 3, plus the case where `server_response_hdr_bytes == 0` at the end of a transaction — i.e. the origin closed or reset the connection after the TCP handshake without sending any HTTP response.
- The `HttpSM::track_connect_fail()` function was also refactored for clarity. 
- AuTest uses new `on_connect: refuse|reset` feature (thank you, @bneradt )

## notes

Two cases are explicitly excluded:

- Reused keep-alive connections: there is a known race between ATS reusing a keep-alive connection and the origin closing it, described by @moonchen on #12437. Considering this case, the policy 4 is only applied for the first transaction.
- Multiplexed origins ( HTTP/2 ): per-stream error observation (e.g. RST_STREAM) does not indicate the underlying connection is unhealthy.