### PR TITLE
Fix use-after-free in ParsedConfigCache for short config strings

### DIFF
--- a/include/proxy/http/HttpConfig.h
+++ b/include/proxy/http/HttpConfig.h
@@ -933,6 +933,12 @@ public:
     std::variant<std::monostate, HostResData, HttpStatusCodeList, HttpForwarded::OptionBitSet, MgmtByte,
                  TargetedCacheControlHeaders>
       parsed{};
+
+    ParsedValue()                               = default;
+    ParsedValue(const ParsedValue &)            = delete;
+    ParsedValue &operator=(const ParsedValue &) = delete;
+    ParsedValue(ParsedValue &&)                 = delete;
+    ParsedValue &operator=(ParsedValue &&)      = delete;
   };
 
   /** Return the parsed value for the configuration.
@@ -958,7 +964,7 @@ private:
   static ParsedConfigCache &instance();
 
   const ParsedValue &lookup_impl(TSOverridableConfigKey key, std::string_view value);
-  ParsedValue        parse(TSOverridableConfigKey key, std::string_view value);
+  void               parse_into(ParsedValue &result, TSOverridableConfigKey key, std::string_view value);
 
   // Custom hash for the cache key.
   struct CacheKeyHash {

--- a/src/proxy/http/HttpConfig.cc
+++ b/src/proxy/http/HttpConfig.cc
@@ -786,15 +786,14 @@ ParsedConfigCache::lookup_impl(TSOverridableConfigKey key, std::string_view valu
   }
 
   // Parse and insert.
-  auto [inserted_it, success] = _cache.emplace(cache_key, parse(key, value));
+  auto [inserted_it, success] = _cache.try_emplace(cache_key);
+  parse_into(inserted_it->second, key, value);
   return inserted_it->second;
 }
 
-ParsedConfigCache::ParsedValue
-ParsedConfigCache::parse(TSOverridableConfigKey key, std::string_view value)
+void
+ParsedConfigCache::parse_into(ParsedValue &result, TSOverridableConfigKey key, std::string_view value)
 {
-  ParsedValue result{};
-
   // Store the string value - the parsed structures may reference this.
   result.conf_value_storage = std::string(value);
 
@@ -843,8 +842,6 @@ ParsedConfigCache::parse(TSOverridableConfigKey key, std::string_view value)
     // No special parsing needed for this config.
     break;
   }
-
-  return result;
 }
 
 /** Template for creating conversions and initialization for @c std::chrono based configuration variables.


### PR DESCRIPTION
- Fix use-after-free in ParsedConfigCache when config values are short enough for std::string SSO (Small String Optimization)
- ParsedValue::parse() returned by value, and emplace moved it into the map — relocating the SSO inline buffer while string_views in TargetedCacheControlHeaders::headers[] still pointed to the old address
- Make ParsedValue non-movable and use try_emplace + parse_into() so parsing happens directly in the map node
- Also fixes the same class of bug for HostResData::conf_value and HttpStatusCodeList::conf_value pointers

Reproducer: configure conf_remap with a short targeted header value like ACME-Cache-Control (18 chars, within libc++ SSO threshold of 22). The string_views in the per-transaction override become dangling, causing incorrect cache behavior.

The SSO threshold varies by standard library — libc++ (macOS/clang): 22 bytes, libstdc++ (GCC/Linux): 15 bytes. A value like ACME-Cache-Control (18 chars) triggers SSO on libc++ but uses heap allocation on libstdc++, where the buffer pointer survives the move. This is why the bug may reproduce on macOS but not on Linux CI with GCC.