### PR TITLE
Fix broken default.com test case in targeted-cache-control

### DIFF
--- a/tests/gold_tests/cache/replay/targeted-cache-control.replay.yaml
+++ b/tests/gold_tests/cache/replay/targeted-cache-control.replay.yaml
@@ -250,7 +250,7 @@ sessions:
         - [ ACME-Cache-Control, { value: "no-store", as: equal } ]
 
   #############################################################################
-  # Test 7: No targeted headers configured - CDN-Cache-Control should be ignored
+  # Test 7: Global targeted headers apply without conf_remap override
   #############################################################################
   - client-request:
       method: GET
@@ -291,18 +291,22 @@ sessions:
         - [Host, default.com]
         - [uuid, default-test1-request2]
 
+    proxy-request:
+      expect: absent
+
+    # Should not reach the origin.
     server-response:
       status: 404
       reason: Not Found
 
-    # Cache-Control: no-store should have prevented caching since no targeted
-    # headers are configured for this remap rule.
+    # Expect the cached 200 response because the global config sets
+    # CDN-Cache-Control as a targeted header, overriding Cache-Control: no-store.
     proxy-response:
-      status: 404
+      status: 200
       headers:
         fields:
-        - [ Cache-Control, { as: absent } ]
-        - [ CDN-Cache-Control, { as: absent } ]
+        - [ Cache-Control, { value: "no-store", as: equal } ]
+        - [ CDN-Cache-Control, { value: "max-age=30", as: equal } ]
 
   - client-request:
       # Delay to exceed Cache-Control but not CDN-Cache-Control.

--- a/tests/gold_tests/cache/replay/targeted-cache-control.replay.yaml
+++ b/tests/gold_tests/cache/replay/targeted-cache-control.replay.yaml
@@ -55,6 +55,9 @@ autest:
             args:
               - "proxy.config.http.cache.targeted_cache_control_headers=ACME-Cache-Control"
 
+      - from: "http://default.com/"
+        to: "http://backend.default.com:{SERVER_HTTP_PORT}/"
+
 
 sessions:
 - transactions:
@@ -247,6 +250,36 @@ sessions:
         - [ ACME-Cache-Control, { value: "no-store", as: equal } ]
 
   #############################################################################
+  # Test 7: No targeted headers configured - CDN-Cache-Control should be ignored
+  #############################################################################
+  - client-request:
+      method: GET
+      url: /default/test1
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, default.com]
+        - [uuid, default-test1-request1]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [Content-Type, text/plain]
+        - [Content-Length, "14"]
+        - [Cache-Control, "no-store"]
+        - [CDN-Cache-Control, "max-age=30"]
+        - [Connection, close]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ Cache-Control, { value: "no-store", as: equal } ]
+        - [ CDN-Cache-Control, { value: "max-age=30", as: equal } ]
+
+  #############################################################################
   # Now verify the correct cache behavior from above.
   #############################################################################
   - client-request:
@@ -258,21 +291,18 @@ sessions:
         - [Host, default.com]
         - [uuid, default-test1-request2]
 
-    proxy-request:
-      expect: absent
-
-    # Should not reach the origin.
     server-response:
       status: 404
       reason: Not Found
 
-    # Expect the cached 200 response due to default CDN-Cache-Control handling.
+    # Cache-Control: no-store should have prevented caching since no targeted
+    # headers are configured for this remap rule.
     proxy-response:
-      status: 200
+      status: 404
       headers:
         fields:
-        - [ Cache-Control, { value: "no-store", as: equal } ]
-        - [ CDN-Cache-Control, { value: "max-age=30", as: equal } ]
+        - [ Cache-Control, { as: absent } ]
+        - [ CDN-Cache-Control, { as: absent } ]
 
   - client-request:
       # Delay to exceed Cache-Control but not CDN-Cache-Control.


### PR DESCRIPTION
  - Fix the default.com test case in targeted-cache-control.replay.yaml that was broken by the cherry-pick of #13054                                                                  
  - The original commit on master (67b96e58bb) added a default.com remap rule, a priming request, and a verification request — but that commit was not cherry-picked to 10.2.x because
   the default targeted header change was considered a breaking change                                                                                                                
  - When #13054 was cherry-picked, it brought only the verification block without the remap rule or priming request, causing the test to always fail
  - Add the missing default.com remap rule and priming request so the test verifies that the global targeted_cache_control_headers setting applies to remap rules without a conf_remap
   override 

https://github.com/apache/trafficserver/pull/13080 failed because of the issue.