### PR TITLE
Per-thread FD tables via unshare(CLONE_FILES) for ET_NET threads

### DIFF
--- a/src/iocore/net/P_UnixNet.h
+++ b/src/iocore/net/P_UnixNet.h
@@ -39,9 +39,7 @@ NetHandler     *get_NetHandler(EThread *t);
 PollCont       *get_PollCont(EThread *t);
 PollDescriptor *get_PollDescriptor(EThread *t);
 
-#if defined(__linux__)
-void unshare_et_net_fd_tables();
-#endif
+void exec_thr_late_init();
 
 using NetContHandler = int (NetHandler::*)(int, void *);
 using uint32         = unsigned int;

--- a/src/iocore/net/P_UnixNet.h
+++ b/src/iocore/net/P_UnixNet.h
@@ -39,6 +39,10 @@ NetHandler     *get_NetHandler(EThread *t);
 PollCont       *get_PollCont(EThread *t);
 PollDescriptor *get_PollDescriptor(EThread *t);
 
+#if defined(__linux__)
+void unshare_et_net_fd_tables();
+#endif
+
 using NetContHandler = int (NetHandler::*)(int, void *);
 using uint32         = unsigned int;
 

--- a/src/iocore/net/UnixNet.cc
+++ b/src/iocore/net/UnixNet.cc
@@ -52,9 +52,7 @@ namespace
 DbgCtl dbg_ctl_inactivity_cop{"inactivity_cop"};
 DbgCtl dbg_ctl_inactivity_cop_check{"inactivity_cop_check"};
 DbgCtl dbg_ctl_inactivity_cop_verbose{"inactivity_cop_verbose"};
-#if defined(__linux__)
 DbgCtl dbg_ctl_iocore_net{"iocore_net"};
-#endif
 
 } // end anonymous namespace
 
@@ -208,43 +206,53 @@ initialize_thread_for_net(EThread *thread)
   thread->ep = ep;
 }
 
-#if defined(__linux__)
-// Give each ET_NET thread its own kernel FD table (files_struct) so that
-// accept4/close no longer contend on a single shared spinlock.  Every FD
-// that was open at the time of the call is copied into the new private
-// table — the underlying kernel objects (struct file) are shared, so
-// cross-thread eventfd signalling and shared cache-disk FDs keep working.
+// Late-initialization continuation for ET_NET threads.  Runs on each
+// thread after start_HttpProxyServer() has created all listen sockets
+// and all initialization FDs (eventfds, cache disks, DNS sockets, log
+// files, plugin FDs) are in place.
 //
-// This must be scheduled AFTER start_HttpProxyServer() so that all
-// initialization FDs (eventfds, cache disks, DNS sockets, log files,
-// listen sockets, plugin FDs) are already in place.
+// On Linux, when accept is performed directly on ET_NET threads
+// (accept_threads == 0), this calls unshare(CLONE_FILES) to give each
+// thread its own private kernel FD table, eliminating spinlock
+// contention on accept4/close.  The underlying kernel objects
+// (struct file) are shared, so cross-thread eventfd signalling and
+// shared cache-disk FDs keep working.
+//
+// This is NOT safe with dedicated accept threads (accept_threads > 0)
+// because accepted sockets are created on the accept thread and handed
+// off to ET_NET by FD number — after unshare those FDs would not exist
+// in the ET_NET thread's private table.
 
 namespace
 {
-struct UnshareFilesCont : public Continuation {
+struct ExecThrLateCont : public Continuation {
   int
   mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   {
-    if (unshare(CLONE_FILES) < 0) {
+#if defined(__linux__)
+    int accept_threads = RecGetRecordInt("proxy.config.accept_threads").value_or(0);
+    if (accept_threads > 0) {
+      Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: skipping unshare (accept_threads=%d)", this_ethread()->id, accept_threads);
+    } else if (unshare(CLONE_FILES) < 0) {
       Warning("ET_NET thread %d: unshare(CLONE_FILES) failed: %s", this_ethread()->id, strerror(errno));
     } else {
       Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: FD table unshared", this_ethread()->id);
     }
+#endif
     delete this;
     return EVENT_DONE;
   }
 
-  UnshareFilesCont() : Continuation(nullptr) { SET_HANDLER(&UnshareFilesCont::mainEvent); }
+  ExecThrLateCont() : Continuation(nullptr) { SET_HANDLER(&ExecThrLateCont::mainEvent); }
 };
 } // end anonymous namespace
 
 void
-unshare_et_net_fd_tables()
+exec_thr_late_init()
 {
   int n = eventProcessor.thread_group[ET_NET]._count;
   for (int i = 0; i < n; i++) {
-    eventProcessor.thread_group[ET_NET]._thread[i]->schedule_imm(new UnshareFilesCont());
+    eventProcessor.thread_group[ET_NET]._thread[i]->schedule_imm(new ExecThrLateCont());
   }
-  Note("Scheduled unshare(CLONE_FILES) on %d ET_NET threads", n);
+  Note("Scheduled exec_thr_late_init() on %d ET_NET threads", n);
 }
-#endif

--- a/src/iocore/net/UnixNet.cc
+++ b/src/iocore/net/UnixNet.cc
@@ -27,6 +27,10 @@
 #include "iocore/net/AsyncSignalEventIO.h"
 #include "tscore/ink_hrtime.h"
 
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
 #if TS_USE_LINUX_IO_URING
 #include "iocore/io_uring/IO_URING.h"
 #endif
@@ -48,6 +52,9 @@ namespace
 DbgCtl dbg_ctl_inactivity_cop{"inactivity_cop"};
 DbgCtl dbg_ctl_inactivity_cop_check{"inactivity_cop_check"};
 DbgCtl dbg_ctl_inactivity_cop_verbose{"inactivity_cop_verbose"};
+#if defined(__linux__)
+DbgCtl dbg_ctl_iocore_net{"iocore_net"};
+#endif
 
 } // end anonymous namespace
 
@@ -200,3 +207,44 @@ initialize_thread_for_net(EThread *thread)
 #endif
   thread->ep = ep;
 }
+
+#if defined(__linux__)
+// Give each ET_NET thread its own kernel FD table (files_struct) so that
+// accept4/close no longer contend on a single shared spinlock.  Every FD
+// that was open at the time of the call is copied into the new private
+// table — the underlying kernel objects (struct file) are shared, so
+// cross-thread eventfd signalling and shared cache-disk FDs keep working.
+//
+// This must be scheduled AFTER start_HttpProxyServer() so that all
+// initialization FDs (eventfds, cache disks, DNS sockets, log files,
+// listen sockets, plugin FDs) are already in place.
+
+namespace
+{
+struct UnshareFilesCont : public Continuation {
+  int
+  mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
+  {
+    if (unshare(CLONE_FILES) < 0) {
+      Warning("ET_NET thread %d: unshare(CLONE_FILES) failed: %s", this_ethread()->id, strerror(errno));
+    } else {
+      Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: FD table unshared", this_ethread()->id);
+    }
+    delete this;
+    return EVENT_DONE;
+  }
+
+  UnshareFilesCont() : Continuation(nullptr) { SET_HANDLER(&UnshareFilesCont::mainEvent); }
+};
+} // end anonymous namespace
+
+void
+unshare_et_net_fd_tables()
+{
+  int n = eventProcessor.thread_group[ET_NET]._count;
+  for (int i = 0; i < n; i++) {
+    eventProcessor.thread_group[ET_NET]._thread[i]->schedule_imm(new UnshareFilesCont());
+  }
+  Note("Scheduled unshare(CLONE_FILES) on %d ET_NET threads", n);
+}
+#endif

--- a/src/iocore/net/UnixNet.cc
+++ b/src/iocore/net/UnixNet.cc
@@ -207,21 +207,19 @@ initialize_thread_for_net(EThread *thread)
 }
 
 // Late-initialization continuation for ET_NET threads.  Runs on each
-// thread after start_HttpProxyServer() has created all listen sockets
-// and all initialization FDs (eventfds, cache disks, DNS sockets, log
-// files, plugin FDs) are in place.
+// thread after all initialization FDs (eventfds, cache disks, DNS
+// sockets, log files, plugin FDs) are in place but BEFORE
+// start_HttpProxyServer() schedules accept_per_thread.
 //
-// On Linux, when accept is performed directly on ET_NET threads
-// (accept_threads == 0), this calls unshare(CLONE_FILES) to give each
-// thread its own private kernel FD table, eliminating spinlock
-// contention on accept4/close.  The underlying kernel objects
-// (struct file) are shared, so cross-thread eventfd signalling and
-// shared cache-disk FDs keep working.
+// On Linux, when per-thread listen is enabled (exec_thread.listen=1,
+// SO_REUSEPORT), this calls unshare(CLONE_FILES) to give each thread
+// its own private kernel FD table, eliminating spinlock contention on
+// accept4/close.  The subsequent do_listen() in accept_per_thread
+// creates the per-thread listen socket directly in the private table.
 //
-// This is NOT safe with dedicated accept threads (accept_threads > 0)
-// because accepted sockets are created on the accept thread and handed
-// off to ET_NET by FD number — after unshare those FDs would not exist
-// in the ET_NET thread's private table.
+// The underlying kernel objects (struct file) are shared, so
+// cross-thread eventfd signalling and shared cache-disk FDs keep
+// working.
 
 namespace
 {
@@ -230,13 +228,13 @@ struct ExecThrLateCont : public Continuation {
   mainEvent(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
   {
 #if defined(__linux__)
-    int accept_threads = RecGetRecordInt("proxy.config.accept_threads").value_or(0);
-    if (accept_threads > 0) {
-      Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: skipping unshare (accept_threads=%d)", this_ethread()->id, accept_threads);
-    } else if (unshare(CLONE_FILES) < 0) {
-      Warning("ET_NET thread %d: unshare(CLONE_FILES) failed: %s", this_ethread()->id, strerror(errno));
-    } else {
-      Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: FD table unshared", this_ethread()->id);
+    int listen_per_thread = RecGetRecordInt("proxy.config.exec_thread.listen").value_or(0);
+    if (listen_per_thread == 1) {
+      if (unshare(CLONE_FILES) < 0) {
+        Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: unshare(CLONE_FILES) failed: %s", this_ethread()->id, strerror(errno));
+      } else {
+        Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: FD table unshared", this_ethread()->id);
+      }
     }
 #endif
     delete this;
@@ -254,5 +252,5 @@ exec_thr_late_init()
   for (int i = 0; i < n; i++) {
     eventProcessor.thread_group[ET_NET]._thread[i]->schedule_imm(new ExecThrLateCont());
   }
-  Note("Scheduled exec_thr_late_init() on %d ET_NET threads", n);
+  Dbg(dbg_ctl_iocore_net, "Scheduled exec_thr_late_init() on %d ET_NET threads", n);
 }

--- a/src/iocore/net/UnixNet.cc
+++ b/src/iocore/net/UnixNet.cc
@@ -212,14 +212,19 @@ initialize_thread_for_net(EThread *thread)
 // start_HttpProxyServer() schedules accept_per_thread.
 //
 // On Linux, when per-thread listen is enabled (exec_thread.listen=1,
-// SO_REUSEPORT), this calls unshare(CLONE_FILES) to give each thread
-// its own private kernel FD table, eliminating spinlock contention on
-// accept4/close.  The subsequent do_listen() in accept_per_thread
-// creates the per-thread listen socket directly in the private table.
+// SO_REUSEPORT) and server session sharing uses per-thread pools,
+// this calls unshare(CLONE_FILES) to give each thread its own private
+// kernel FD table, eliminating spinlock contention on accept4/close.
+// The subsequent do_listen() in accept_per_thread creates the
+// per-thread listen socket directly in the private table.
 //
 // The underlying kernel objects (struct file) are shared, so
 // cross-thread eventfd signalling and shared cache-disk FDs keep
 // working.
+//
+// NOT safe with global/hybrid session sharing pools because
+// migrateToCurrentThread() transfers socket FDs by number — after
+// unshare those FDs do not exist in the target thread's private table.
 
 namespace
 {
@@ -230,7 +235,10 @@ struct ExecThrLateCont : public Continuation {
 #if defined(__linux__)
     int listen_per_thread = RecGetRecordInt("proxy.config.exec_thread.listen").value_or(0);
     if (listen_per_thread == 1) {
-      if (unshare(CLONE_FILES) < 0) {
+      auto pool = RecGetRecordStringAlloc("proxy.config.http.server_session_sharing.pool");
+      if (pool && *pool != "thread") {
+        Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: skipping unshare (session pool=%s)", this_ethread()->id, pool->c_str());
+      } else if (unshare(CLONE_FILES) < 0) {
         Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: unshare(CLONE_FILES) failed: %s", this_ethread()->id, strerror(errno));
       } else {
         Dbg(dbg_ctl_iocore_net, "ET_NET thread %d: FD table unshared", this_ethread()->id);

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -898,9 +898,7 @@ CB_After_Cache_Init()
     // call accept on the ports now that the cache is initialized.
     Note("Enabling listen, cache initialization finished");
     start_HttpProxyServer();
-#if defined(__linux__)
-    unshare_et_net_fd_tables();
-#endif
+    exec_thr_late_init(); // Must be last call before emit_fully_initialized_message()
     emit_fully_initialized_message();
   }
 
@@ -2461,9 +2459,7 @@ main(int /* argc ATS_UNUSED */, const char **argv)
         // In either case we should not delay to accept the ports.
         Dbg(dbg_ctl_http_listen, "Not delaying listen");
         start_HttpProxyServer(); // PORTS_READY_HOOK called from in here
-#if defined(__linux__)
-        unshare_et_net_fd_tables();
-#endif
+        exec_thr_late_init();    // Must be last call before emit_fully_initialized_message()
         emit_fully_initialized_message();
       }
     }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -898,6 +898,9 @@ CB_After_Cache_Init()
     // call accept on the ports now that the cache is initialized.
     Note("Enabling listen, cache initialization finished");
     start_HttpProxyServer();
+#if defined(__linux__)
+    unshare_et_net_fd_tables();
+#endif
     emit_fully_initialized_message();
   }
 
@@ -2458,6 +2461,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
         // In either case we should not delay to accept the ports.
         Dbg(dbg_ctl_http_listen, "Not delaying listen");
         start_HttpProxyServer(); // PORTS_READY_HOOK called from in here
+#if defined(__linux__)
+        unshare_et_net_fd_tables();
+#endif
         emit_fully_initialized_message();
       }
     }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -897,8 +897,8 @@ CB_After_Cache_Init()
     // delayed the call to start_HttpProxyServer until we got here. We must
     // call accept on the ports now that the cache is initialized.
     Note("Enabling listen, cache initialization finished");
+    exec_thr_late_init(); // Must be called before start_HttpProxyServer
     start_HttpProxyServer();
-    exec_thr_late_init(); // Must be last call before emit_fully_initialized_message()
     emit_fully_initialized_message();
   }
 
@@ -2458,8 +2458,8 @@ main(int /* argc ATS_UNUSED */, const char **argv)
         //
         // In either case we should not delay to accept the ports.
         Dbg(dbg_ctl_http_listen, "Not delaying listen");
+        exec_thr_late_init();    // Must be called before start_HttpProxyServer
         start_HttpProxyServer(); // PORTS_READY_HOOK called from in here
-        exec_thr_late_init();    // Must be last call before emit_fully_initialized_message()
         emit_fully_initialized_message();
       }
     }


### PR DESCRIPTION
Eliminate kernel spinlock contention on the shared files_struct by giving each ET_NET thread its own private FD table after all initialization FDs are in place. This removes the accept4/close contention visible as ~58% CPU in native_queued_spin_lock_slowpath at high thread counts.

This change is incompatible with MacOS and FreeBSD: The only equivalent solution there seems to be migrating to multi process. (This should be discussed as a long term goal)

Scheduled after start_HttpProxyServer() to ensure all persistent FDs (eventfds, cache disks, DNS sockets, log files, listen sockets, plugin FDs) are copied into each threads private table. Linux-only; non-fatal on failure (falls back to shared table).

I was also able to cause intermittent socket failures before applying this change.