### PR TITLE
Fix AuTest with ssl_multicert

### DIFF
--- a/tests/gold_tests/connect/h2_malformed_request_logging.test.py
+++ b/tests/gold_tests/connect/h2_malformed_request_logging.test.py
@@ -99,12 +99,6 @@ ssl_multicert:
     ssl_cert_name: server.pem
     ssl_key_name: server.key
 """.split('\n'))
-        self._ts.Disk.File(
-            os.path.join(self._ts.Variables.CONFIGDIR, 'ssl_multicert.config'),
-            id='ssl_multicert_config',
-            typename='ats:config',
-        )
-        self._ts.Disk.ssl_multicert_config.AddLine('ssl_cert_name=server.pem ssl_key_name=server.key dest_ip=*')
 
         self._ts.Disk.records_config.update(
             {

--- a/tests/gold_tests/timeout/tunnel_active_timeout.test.py
+++ b/tests/gold_tests/timeout/tunnel_active_timeout.test.py
@@ -38,8 +38,8 @@ ts.Disk.ssl_multicert_yaml.AddLines(
     f"""
 ssl_multicert:
   - dest_ip: "*"
-    ssl_cert_name= {ts.Variables.SSLDir}/server.pem
-    ssl_key_name={ts.Variables.SSLDir}/server.key
+    ssl_cert_name: server.pem
+    ssl_key_name: server.key
 """.split('\n'))
 
 ts.Disk.records_config.update(

--- a/tests/gold_tests/timeout/tunnel_active_timeout.test.py
+++ b/tests/gold_tests/timeout/tunnel_active_timeout.test.py
@@ -34,7 +34,13 @@ server.addResponse("sessionlog.json", request_header, response_header)
 
 ts.addDefaultSSLFiles()
 
-ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
+ts.Disk.ssl_multicert_yaml.AddLines(
+    f"""
+ssl_multicert:
+  - dest_ip: "*"
+    ssl_cert_name= {ts.Variables.SSLDir}/server.pem
+    ssl_key_name={ts.Variables.SSLDir}/server.key
+""".split('\n'))
 
 ts.Disk.records_config.update(
     {


### PR DESCRIPTION
Some AuTests are using `ssl_multicert.config` which is replaced by `ssl_multicert.yaml` recently.
- `h2_malformed_request_logging.test.py‎`
- `tunnel_active_timeout.test.py`