### PR TITLE
Fix cache_read_vc assertion crash in redirect flow

### DIFF
--- a/src/proxy/http/HttpCacheSM.cc
+++ b/src/proxy/http/HttpCacheSM.cc
@@ -70,13 +70,24 @@ HttpCacheAction::cancel(Continuation *c)
 // HttpCacheSM
 //
 /**
-  Reset captive_action and counters for another cache operations.
-  - e.g. following redirect starts over from cache lookup
+  Reset state for another cache operation (e.g., following a redirect).
+
+  This closes any existing cache read VC, cancels pending retry events,
+  and resets the captive action. Without this cleanup, a stale cache_read_vc
+  from a previous successful read could remain set when the new cache
+  operation completes, causing an assertion failure if redirect_in_process
+  has been cleared by that time.
  */
 void
 HttpCacheSM::reset()
 {
   captive_action.reset();
+  close_read();
+
+  if (_read_retry_event != nullptr) {
+    _read_retry_event->cancel();
+    _read_retry_event = nullptr;
+  }
 }
 
 void


### PR DESCRIPTION
This builds on top of #12182

This fixes a crash seen in docs where the assertion at 
HttpCacheSM.cc:137 fails:

```
  ink_assert((cache_read_vc == nullptr) ||
             master_sm->t_state.redirect_info.redirect_in_process)
```

The crash occurs when a redirect cache lookup completes after
redirect_in_process has been cleared, but cache_read_vc from the
original request is still set. The root cause is that reset() only
resets captive_action but does not close the existing cache_read_vc
or cancel any pending retry events.

This patch adds the missing cleanup to reset(): it now closes any
existing cache read VC and cancels pending retry events before
starting a new cache operation. This ensures stale state from a
previous cache operation cannot interfere with the new one.