### PR TITLE
Guard HTTP/3 test targets with BUILD_TESTING

### DIFF
--- a/src/proxy/http3/CMakeLists.txt
+++ b/src/proxy/http3/CMakeLists.txt
@@ -47,42 +47,44 @@ target_link_libraries(
   PRIVATE ts::proxy
 )
 
-add_executable(
-  test_http3
-  test/main.cc
-  test/stub.cc
-  test/test_Http3Frame.cc
-  test/test_Http3FrameDispatcher.cc
-  Http3ProtocolEnforcer.cc
-  Http3FrameDispatcher.cc
-  Http3DebugNames.cc
-  Http3Config.cc
-  Http3Frame.cc
-  Http3SettingsHandler.cc
-)
-target_link_libraries(
-  test_http3
-  PRIVATE Catch2::Catch2WithMain
-          ts::quic
-          ts::inkevent
-          ts::records
-          ts::tsutil
-          ts::hdrs
-          ts::tscore
-)
-add_catch2_test(NAME test_http3 COMMAND test_http3)
+if(BUILD_TESTING)
+  add_executable(
+    test_http3
+    test/main.cc
+    test/stub.cc
+    test/test_Http3Frame.cc
+    test/test_Http3FrameDispatcher.cc
+    Http3ProtocolEnforcer.cc
+    Http3FrameDispatcher.cc
+    Http3DebugNames.cc
+    Http3Config.cc
+    Http3Frame.cc
+    Http3SettingsHandler.cc
+  )
+  target_link_libraries(
+    test_http3
+    PRIVATE Catch2::Catch2WithMain
+            ts::quic
+            ts::inkevent
+            ts::records
+            ts::tsutil
+            ts::hdrs
+            ts::tscore
+  )
+  add_catch2_test(NAME test_http3 COMMAND test_http3)
 
-add_executable(test_qpack test/main_qpack.cc test/test_QPACK.cc QPACK.cc)
-target_link_libraries(
-  test_qpack
-  PRIVATE Catch2::Catch2
-          ts::quic
-          ts::inkevent
-          ts::records
-          ts::tsutil
-          ts::hdrs
-          ts::tscore
-)
-add_catch2_test(NAME test_qpack COMMAND test_qpack)
+  add_executable(test_qpack test/main_qpack.cc test/test_QPACK.cc QPACK.cc)
+  target_link_libraries(
+    test_qpack
+    PRIVATE Catch2::Catch2
+            ts::quic
+            ts::inkevent
+            ts::records
+            ts::tsutil
+            ts::hdrs
+            ts::tscore
+  )
+  add_catch2_test(NAME test_qpack COMMAND test_qpack)
+endif()
 
 clang_tidy_check(http3)


### PR DESCRIPTION
Guard add_catch2_test for h3 with BUILD_TESTING. Otherwise
-DBUILD_TESTING=off fails when HTTP/3 builds are enabled.