### PR TITLE
Reduce TLS handshake contention on SSLCertContext

### DIFF
--- a/src/iocore/net/P_SSLCertLookup.h
+++ b/src/iocore/net/P_SSLCertLookup.h
@@ -26,7 +26,7 @@
 #include "iocore/eventsystem/ConfigProcessor.h"
 #include "iocore/net/SSLTypes.h"
 #include "records/RecCore.h"
-#include "tsutil/Bravo.h"
+#include <shared_mutex>
 
 #include <set>
 #include <openssl/ssl.h>
@@ -94,8 +94,8 @@ using shared_ssl_ticket_key_block = std::shared_ptr<ssl_ticket_key_block>;
 */
 struct SSLCertContext {
 private:
-  mutable ts::bravo::shared_mutex ctx_mutex;
-  shared_SSL_CTX                  ctx;
+  mutable std::shared_mutex ctx_mutex;
+  shared_SSL_CTX            ctx;
 
 public:
   SSLCertContext() : ctx_mutex(), ctx(nullptr), opt(SSLCertContextOption::OPT_NONE), userconfig(nullptr), keyblock(nullptr) {}

--- a/src/iocore/net/P_SSLCertLookup.h
+++ b/src/iocore/net/P_SSLCertLookup.h
@@ -26,10 +26,10 @@
 #include "iocore/eventsystem/ConfigProcessor.h"
 #include "iocore/net/SSLTypes.h"
 #include "records/RecCore.h"
+#include "tsutil/Bravo.h"
 
 #include <set>
 #include <openssl/ssl.h>
-#include <mutex>
 #include <unordered_map>
 #include <utility>
 
@@ -94,8 +94,8 @@ using shared_ssl_ticket_key_block = std::shared_ptr<ssl_ticket_key_block>;
 */
 struct SSLCertContext {
 private:
-  mutable std::mutex ctx_mutex;
-  shared_SSL_CTX     ctx;
+  mutable ts::bravo::shared_mutex ctx_mutex;
+  shared_SSL_CTX                  ctx;
 
 public:
   SSLCertContext() : ctx_mutex(), ctx(nullptr), opt(SSLCertContextOption::OPT_NONE), userconfig(nullptr), keyblock(nullptr) {}

--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -238,7 +238,7 @@ SSLCertContext::SSLCertContext(SSLCertContext const &other)
   userconfig = other.userconfig;
   keyblock   = other.keyblock;
   ctx_type   = other.ctx_type;
-  ts::bravo::shared_lock lock(other.ctx_mutex);
+  std::shared_lock lock(other.ctx_mutex);
   ctx = other.ctx;
 }
 
@@ -250,7 +250,7 @@ SSLCertContext::operator=(SSLCertContext const &other)
     this->userconfig = other.userconfig;
     this->keyblock   = other.keyblock;
     this->ctx_type   = other.ctx_type;
-    ts::bravo::shared_lock lock(other.ctx_mutex);
+    std::shared_lock lock(other.ctx_mutex);
     this->ctx = other.ctx;
   }
   return *this;
@@ -259,7 +259,7 @@ SSLCertContext::operator=(SSLCertContext const &other)
 shared_SSL_CTX
 SSLCertContext::getCtx()
 {
-  ts::bravo::shared_lock lock(ctx_mutex);
+  std::shared_lock lock(ctx_mutex);
   return ctx;
 }
 

--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -33,6 +33,7 @@
 
 #include "P_SSLUtils.h"
 
+#include <mutex>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -237,7 +238,7 @@ SSLCertContext::SSLCertContext(SSLCertContext const &other)
   userconfig = other.userconfig;
   keyblock   = other.keyblock;
   ctx_type   = other.ctx_type;
-  std::lock_guard<std::mutex> lock(other.ctx_mutex);
+  ts::bravo::shared_lock lock(other.ctx_mutex);
   ctx = other.ctx;
 }
 
@@ -249,7 +250,7 @@ SSLCertContext::operator=(SSLCertContext const &other)
     this->userconfig = other.userconfig;
     this->keyblock   = other.keyblock;
     this->ctx_type   = other.ctx_type;
-    std::lock_guard<std::mutex> lock(other.ctx_mutex);
+    ts::bravo::shared_lock lock(other.ctx_mutex);
     this->ctx = other.ctx;
   }
   return *this;
@@ -258,14 +259,14 @@ SSLCertContext::operator=(SSLCertContext const &other)
 shared_SSL_CTX
 SSLCertContext::getCtx()
 {
-  std::lock_guard<std::mutex> lock(ctx_mutex);
+  ts::bravo::shared_lock lock(ctx_mutex);
   return ctx;
 }
 
 void
 SSLCertContext::setCtx(shared_SSL_CTX sc)
 {
-  std::lock_guard<std::mutex> lock(ctx_mutex);
+  std::lock_guard lock(ctx_mutex);
   ctx = std::move(sc);
 }
 


### PR DESCRIPTION
Replace std::mutex with ~ts::bravo::shared_mutex~ std::shared_mutex on SSLCertContext to allow true reader concurrency for getCtx() on the TLS handshake hot path. setCtx() (config reload only) takes an exclusive lock.

~Memory trade-off: BRAVO uses 256 cache-line-aligned reader slots (16 KB per mutex) vs 40 bytes for std::mutex or around 56 bytes for std::shared_mutex on Linux. For 256 certificates this is 4 MB (vs 10 KB / 14 KB), a modest cost relative to the SSL_CTX objects themselves but worth noting for deployments with many certs.~

Replace BRAVO with std::shared_mutex for SSLCertContext
Switch from ts::bravo::shared_mutex to std::shared_mutex. The
contention pattern (short bursts, not sustained) doesn't benefit
from BRAVO's per-thread slots, and std::shared_mutex avoids the
~16 KB per-mutex memory overhead.
