### PR TITLE
10.2.x: jax_fingerprint: use ssl_multicert_config

### DIFF
--- a/tests/gold_tests/pluginTest/jax_fingerprint/jax_fingerprint.test.py
+++ b/tests/gold_tests/pluginTest/jax_fingerprint/jax_fingerprint.test.py
@@ -182,13 +182,7 @@ class JaxFingerprintTest:
         JaxFingerprintTest._ts_counter += 1
 
         self._ts.addDefaultSSLFiles()
-        self._ts.Disk.ssl_multicert_yaml.AddLines(
-            """
-ssl_multicert:
-  - dest_ip: "*"
-    ssl_cert_name: server.pem
-    ssl_key_name: server.key
-""".split("\n"))
+        self._ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
         if self._needs_tls:
             server_port = self._server.Variables.https_port
@@ -392,13 +386,7 @@ class AllMethodsTest:
         AllMethodsTest._ts_counter += 1
 
         self._ts.addDefaultSSLFiles()
-        self._ts.Disk.ssl_multicert_yaml.AddLines(
-            """
-ssl_multicert:
-  - dest_ip: "*"
-    ssl_cert_name: server.pem
-    ssl_key_name: server.key
-""".split("\n"))
+        self._ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
         server_port = self._server.Variables.https_port
 


### PR DESCRIPTION
The jax_fingerprint.test.py was cherry-picked directly from master which has the ssl_multicert.yaml change. But 10.2.x doesn't have this, so the test has to update ssl_multicert.config. This tweaks the test for the 10.2.x branch needs.