### PR TITLE
compress; Fixes a regression in protocol parser

### DIFF
--- a/plugins/compress/configuration.cc
+++ b/plugins/compress/configuration.cc
@@ -194,7 +194,7 @@ isCommaOrSpace(int ch)
 }
 
 void
-HostConfiguration::add_compression_algorithms(swoc::TextView line)
+HostConfiguration::add_compression_algorithms(swoc::TextView &line)
 {
   compression_algorithms_ = ALGORITHM_DEFAULT; // remove the default gzip.
   for (;;) {
@@ -228,7 +228,7 @@ HostConfiguration::add_compression_algorithms(swoc::TextView line)
 }
 
 void
-HostConfiguration::add_compressible_status_codes(swoc::TextView line)
+HostConfiguration::add_compressible_status_codes(swoc::TextView &line)
 {
   compressible_status_codes_.clear();
 

--- a/plugins/compress/configuration.h
+++ b/plugins/compress/configuration.h
@@ -195,11 +195,11 @@ public:
   void               update_defaults();
   void               add_allow(swoc::TextView allow);
   void               add_compressible_content_type(swoc::TextView content_type);
-  void               add_compressible_status_codes(swoc::TextView status_codes);
+  void               add_compressible_status_codes(swoc::TextView &status_codes);
   [[nodiscard]] bool is_url_allowed(const char *url, int url_len);
   [[nodiscard]] bool is_content_type_compressible(const char *content_type, int content_type_length);
   [[nodiscard]] bool is_status_code_compressible(const TSHttpStatus status_code) const;
-  void               add_compression_algorithms(swoc::TextView algorithms);
+  void               add_compression_algorithms(swoc::TextView &algorithms);
   [[nodiscard]] int  compression_algorithms();
   void               set_range_request(swoc::TextView token);
 

--- a/tests/gold_tests/pluginTest/compress/compress.gold
+++ b/tests/gold_tests/pluginTest/compress/compress.gold
@@ -174,8 +174,8 @@
 > Accept-Encoding: gzip, deflate, sdch, br, zstd
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
-< Content-Encoding: zstd
 < Vary: Accept-Encoding
+< Content-Encoding: zstd
 < Content-Length: 64
 ===
 > GET http://ae-4/obj4 HTTP/1.1
@@ -209,8 +209,8 @@
 > Accept-Encoding: zstd
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
-< Content-Encoding: zstd
 < Vary: Accept-Encoding
+< Content-Encoding: zstd
 < Content-Length: 64
 ===
 > GET http://ae-5/obj5 HTTP/1.1
@@ -218,8 +218,8 @@
 > Accept-Encoding: gzip, deflate, sdch, br, zstd
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
-< Content-Encoding: zstd
 < Vary: Accept-Encoding
+< Content-Encoding: zstd
 < Content-Length: 64
 ===
 > GET http://ae-5/obj5 HTTP/1.1
@@ -253,8 +253,8 @@
 > Accept-Encoding: zstd
 < HTTP/1.1 200 OK
 < Content-Type: text/javascript
-< Content-Encoding: zstd
 < Vary: Accept-Encoding
+< Content-Encoding: zstd
 < Content-Length: 64
 ===
 > GET http://ae-0/obj0 HTTP/1.1

--- a/tests/gold_tests/pluginTest/compress/compress_userver.gold
+++ b/tests/gold_tests/pluginTest/compress/compress_userver.gold
@@ -36,7 +36,7 @@
 0/gzip;q=-0.1
 0/aaa, gzip;q=0.666, bbb
 0/ br ; q=0.666, bbb
-0/aaa, gzip;q=0.666 ,
+0/aaa, gzip;q=0.666 , 
 3/gzip
 vary-no-accept-encoding
 0/compress, identity


### PR DESCRIPTION
This is a regression I think, in 10.2, where we get warnings like

...(Parse)> (compress) WARNING: failed to interpret "br,gzip" at line 2