### PR TITLE
Restore a shortcut in hot loop in _mime_hdr_field_list_search_by_string

### DIFF
--- a/include/tsutil/StringCompare.h
+++ b/include/tsutil/StringCompare.h
@@ -1,0 +1,49 @@
+/** @file
+
+  Helper for std::string_view comparison
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#pragma once
+
+#include <strings.h>
+#include <string_view>
+
+namespace ts
+{
+/**
+  Returns true iff @a lhs and @a rhs compare equal, ignoring case.
+
+  Prefer this over libswoc's @c strcasecmp(std::string_view, std::string_view) when you only need
+  an equality check: this short-circuits on length mismatch, whereas the libswoc version must keep
+  comparing bytes to produce a correct ordering result even when the lengths differ.
+
+  For case-sensitive comparison, use @c std::string_view::operator==.
+ */
+inline bool
+iequals(const std::string_view &lhs, const std::string_view &rhs)
+{
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+
+  return ::strncasecmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+}
+} // namespace ts

--- a/include/tsutil/StringCompare.h
+++ b/include/tsutil/StringCompare.h
@@ -38,7 +38,7 @@ namespace ts
   For case-sensitive comparison, use @c std::string_view::operator==.
  */
 inline bool
-iequals(const std::string_view &lhs, const std::string_view &rhs)
+iequals(std::string_view lhs, std::string_view rhs) noexcept
 {
   if (lhs.size() != rhs.size()) {
     return false;

--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -1160,7 +1160,7 @@ _mime_hdr_field_list_search_by_string(MIMEHdrImpl *mh, std::string_view field_na
 
     too_far_field = &(fblock->m_field_slots[fblock->m_freetop]);
     while (field < too_far_field) {
-      if (field->is_live() &&
+      if (field->is_live() && field->m_len_name == field_name.length() &&
           strcasecmp(std::string_view{field->m_ptr_name, static_cast<std::string_view::size_type>(field->m_len_name)},
                      field_name) == 0) {
         return field;

--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -24,6 +24,9 @@
 #include "tscore/ink_defs.h"
 #include "tscore/ink_platform.h"
 #include "tscore/ink_memory.h"
+
+#include "tsutil/StringCompare.h"
+
 #include <cassert>
 #include <cctype>
 #include <cstdio>
@@ -1160,9 +1163,9 @@ _mime_hdr_field_list_search_by_string(MIMEHdrImpl *mh, std::string_view field_na
 
     too_far_field = &(fblock->m_field_slots[fblock->m_freetop]);
     while (field < too_far_field) {
-      if (field->is_live() && field->m_len_name == field_name.length() &&
-          strcasecmp(std::string_view{field->m_ptr_name, static_cast<std::string_view::size_type>(field->m_len_name)},
-                     field_name) == 0) {
+      if (field->is_live() &&
+          ts::iequals(std::string_view{field->m_ptr_name, static_cast<std::string_view::size_type>(field->m_len_name)},
+                      field_name)) {
         return field;
       }
       ++field;

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -25,6 +25,7 @@
 #include "proxy/http/HttpConfig.h"
 #include "tscore/ink_hrtime.h"
 #include "tsutil/Metrics.h"
+#include "tsutil/StringCompare.h"
 #include "tsutil/ts_bw_format.h"
 #include "proxy/ProxyTransaction.h"
 #include "proxy/http/HttpSM.h"
@@ -791,7 +792,7 @@ HttpSM::state_read_client_request_header(int event, void *data)
         (t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_POST ||
          t_state.hdr_info.client_request.method_get_wksidx() == HTTP_WKSIDX_PUT)) {
       auto expect{t_state.hdr_info.client_request.value_get(static_cast<std::string_view>(MIME_FIELD_EXPECT))};
-      if (strcasecmp(expect, static_cast<std::string_view>(HTTP_VALUE_100_CONTINUE)) == 0) {
+      if (ts::iequals(expect, static_cast<std::string_view>(HTTP_VALUE_100_CONTINUE))) {
         // When receive an "Expect: 100-continue" request from client, ATS sends a "100 Continue" response to client
         // immediately, before receive the real response from original server.
         if (t_state.http_config_param->send_100_continue_response) {

--- a/src/proxy/http/HttpTransactHeaders.cc
+++ b/src/proxy/http/HttpTransactHeaders.cc
@@ -40,6 +40,7 @@
 
 #include "iocore/utils/Machine.h"
 #include "tsutil/DbgCtl.h"
+#include "tsutil/StringCompare.h"
 
 using namespace std::literals;
 
@@ -898,7 +899,7 @@ HttpTransactHeaders::remove_100_continue_headers(HttpTransact::State *s, HTTPHdr
 {
   auto expect{s->hdr_info.client_request.value_get(static_cast<std::string_view>(MIME_FIELD_EXPECT))};
 
-  if (strcasecmp(expect, static_cast<std::string_view>(HTTP_VALUE_100_CONTINUE)) == 0) {
+  if (ts::iequals(expect, static_cast<std::string_view>(HTTP_VALUE_100_CONTINUE))) {
     outgoing->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPECT));
   }
 }


### PR DESCRIPTION
@c-taylor noticed the 10.2.x branch has regression of throughput performance. It looks like several changes made it but the first big drop is introduced by `3b0f0b760387af0c4f6fdd40c4bc98f14dbf0c4d`. The shortcut in the hot loop seems important.

Below is comparison of 1 URL against 1 ET_NET thread performance.

commit | req/sec | note
-- | -- | --
086847590c | 14683.37 | (parent of 3b0f0b7603)
3b0f0b7603 | 11024.33 |  
3b0f0b7603 + this patch | 13535.39 |
  
