### PR TITLE
Guard txn_box stack allocations

### DIFF
--- a/plugins/experimental/txn_box/plugin/src/Modifier.cc
+++ b/plugins/experimental/txn_box/plugin/src/Modifier.cc
@@ -31,6 +31,10 @@ using swoc::Rv;
 using swoc::TextView;
 using namespace swoc::literals;
 
+// Filter inputs are tuple features; bound the temporary stack array by bytes because Feature size can change.
+static constexpr size_t MAX_FILTER_LIST_STACK_BYTES = 128 * 1024;
+static constexpr size_t MAX_FILTER_LIST_SIZE        = MAX_FILTER_LIST_STACK_BYTES / sizeof(Feature);
+
 Errata
 Modifier::define(swoc::TextView name, Modifier::Worker const &f)
 {
@@ -430,9 +434,14 @@ Mod_filter::operator()(Context &ctx, Feature &feature)
 {
   Feature zret{};
   if (feature.is_list()) {
-    auto                    src    = std::get<IndexFor(TUPLE)>(feature);
-    auto                    farray = static_cast<Feature *>(alloca(sizeof(Feature) * src.count()));
-    feature_type_for<TUPLE> dst{farray, src.count()};
+    auto src = std::get<IndexFor(TUPLE)>(feature);
+    if (src.count() > MAX_FILTER_LIST_SIZE) {
+      return {Feature{},
+              Errata(S_ERROR, "filter list too large ({} entries exceeds limit of {})", src.count(), MAX_FILTER_LIST_SIZE)};
+    }
+
+    auto                    farray  = static_cast<Feature *>(alloca(sizeof(Feature) * src.count()));
+    feature_type_for<TUPLE> dst     = {farray, src.count()};
     unsigned                dst_idx = 0;
     for (Feature f = feature; !is_nil(f); f = cdr(f)) {
       Feature item   = car(f);

--- a/plugins/experimental/txn_box/plugin/src/ts_util.cc
+++ b/plugins/experimental/txn_box/plugin/src/ts_util.cc
@@ -36,6 +36,7 @@
 #include <swoc/ArenaWriter.h>
 #include <swoc/swoc_meta.h>
 
+#include "tscore/ink_config.h"
 #include "txn_box/ts_util.h"
 
 using swoc::BufferWriter;
@@ -57,6 +58,10 @@ DbgCtl txn_box_dbg_ctl{DEBUG_TAG};
 namespace ts
 {
 namespace swoc = ::swoc; // Import to avoid global naming weirdness.
+
+// Match core Host rewrite buffers, which reserve TS_MAX_HOST_NAME_LEN bytes and reject values that fill the buffer.
+static constexpr size_t MAX_HOST_FIELD_VALUE_SIZE = TS_MAX_HOST_NAME_LEN - 1;
+
 /* ------------------------------------------------------------------------------------ */
 
 const swoc::Lexicon<TSRecordDataType> TSRecordDataTypeNames{
@@ -503,7 +508,11 @@ ts::HttpRequest::host_set(swoc::TextView const &host)
     auto     text = field.value();
     TextView host_token, port_token;
     if (swoc::IPEndpoint::tokenize(text, &host_token, &port_token)) {
-      size_t                  n = host.size() + 1 + port_token.size();
+      size_t n = host.size() + 1 + port_token.size();
+      if (n > MAX_HOST_FIELD_VALUE_SIZE) {
+        return true;
+      }
+
       swoc::FixedBufferWriter w{static_cast<char *>(alloca(n)), n};
       if (port_token.size()) {
         w.print("{}:{}", host, port_token);
@@ -532,7 +541,11 @@ ts::HttpRequest::port_set(in_port_t port)
     auto     text = field.value();
     TextView host_token, port_token;
     if (swoc::IPEndpoint::tokenize(text, &host_token, &port_token)) {
-      size_t                  n = host_token.size() + 1 + std::numeric_limits<in_port_t>::max_digits10;
+      size_t n = host_token.size() + 1 + std::numeric_limits<in_port_t>::max_digits10;
+      if (n > MAX_HOST_FIELD_VALUE_SIZE) {
+        return true;
+      }
+
       swoc::FixedBufferWriter w{static_cast<char *>(alloca(n)), n};
       w.write(host_token);
       if (port > 0) {


### PR DESCRIPTION
Large tuple features and Host field rewrites can flow through txn_box from
request-controlled input. Several paths used alloca with sizes derived from
those values, which could consume a large fraction of the ATS thread stack or
overflow it outright.

This bounds the temporary filter tuple array by a byte budget and aligns Host
field rewrite buffers with the core host-name limit. Oversized filter input now
returns an error, while oversized Host rewrites leave the existing Host field
unchanged instead of allocating a large stack buffer.