### PR TITLE
Fix HTTP/2 stream (transaction) inactivity timeout

### DIFF
--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -975,7 +975,6 @@ void
 Http2Stream::send_body(bool /* call_update ATS_UNUSED */)
 {
   Http2ConnectionState &connection_state = this->get_connection_state();
-  _timeout.update_inactivity();
 
   reentrancy_count++;
 


### PR DESCRIPTION
Prior to the change, the activity of the Http2Stream was updated even if `send_a_data_frame` is failed by error like `NO_WINDOW` which breaks inactivity timeout.

It looks like when a write is success, the activity is updated by `Http2Stream::signal_write_event`, so `Http2Stream::send_body` don't need to update it.

https://github.com/apache/trafficserver/blob/83ec495a12b5e8a8795c2feb43289532b5531de7/src/proxy/http2/Http2Stream.cc#L950