### PR TITLE
Fix index issue with records in HostDBRecord::select_best_srv

### DIFF
--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -1601,7 +1601,6 @@ HostDBRecord::select_best_srv(char *target, InkRand *rand, ts_time now, ts_secon
 {
   ink_assert(rr_count <= 0 || static_cast<unsigned int>(rr_count) < hostdb_round_robin_max_count);
 
-  int         i      = 0;
   int         live_n = 0;
   uint32_t    weight = 0, p = INT32_MAX;
   HostDBInfo *result = nullptr;
@@ -1610,7 +1609,7 @@ HostDBRecord::select_best_srv(char *target, InkRand *rand, ts_time now, ts_secon
   HostDBInfo *live[rr.count()];
   for (auto &target : rr) {
     // skip down targets.
-    if (rr[i].is_down(now, fail_window)) {
+    if (target.is_down(now, fail_window)) {
       continue;
     }
 
@@ -1627,6 +1626,7 @@ HostDBRecord::select_best_srv(char *target, InkRand *rand, ts_time now, ts_secon
     result = this->select_next_rr(now, fail_window);
   } else {
     uint32_t xx = rand->random() % weight;
+    int      i  = 0;
     for (i = 0; i < live_n - 1 && xx >= live[i]->data.srv.srv_weight; ++i) {
       xx -= live[i]->data.srv.srv_weight;
     }

--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -1607,16 +1607,16 @@ HostDBRecord::select_best_srv(char *target, InkRand *rand, ts_time now, ts_secon
   auto        rr     = this->rr_info();
   // Array of live targets, sized by @a live_n
   HostDBInfo *live[rr.count()];
-  for (auto &target : rr) {
+  for (auto &rr_target : rr) {
     // skip down targets.
-    if (target.is_down(now, fail_window)) {
+    if (rr_target.is_down(now, fail_window)) {
       continue;
     }
 
-    if (target.data.srv.srv_priority <= p) {
-      p               = target.data.srv.srv_priority;
-      weight         += target.data.srv.srv_weight;
-      live[live_n++]  = &target;
+    if (rr_target.data.srv.srv_priority <= p) {
+      p               = rr_target.data.srv.srv_priority;
+      weight         += rr_target.data.srv.srv_weight;
+      live[live_n++]  = &rr_target;
     } else {
       break;
     }
@@ -1627,7 +1627,7 @@ HostDBRecord::select_best_srv(char *target, InkRand *rand, ts_time now, ts_secon
   } else {
     uint32_t xx = rand->random() % weight;
     int      i  = 0;
-    for (i = 0; i < live_n - 1 && xx >= live[i]->data.srv.srv_weight; ++i) {
+    for (; i < live_n - 1 && xx >= live[i]->data.srv.srv_weight; ++i) {
       xx -= live[i]->data.srv.srv_weight;
     }
 


### PR DESCRIPTION
This came up in a copilot review of a fix unrelated to this issue so I created this separate PR to address this.

It seems the loop structure at some point looped over an index, but was changed to a range based loop, neglecting to change one aspect.  But it was not noticed because the index variable is declared before the loop.

The issue is the is_down is always checked on the first target, so could skip up targets or use down targets depending.