### PR TITLE
Remove cache alternate vector detach

### DIFF
--- a/src/iocore/cache/CacheHttp.cc
+++ b/src/iocore/cache/CacheHttp.cc
@@ -67,27 +67,6 @@ CacheHTTPInfoVector::insert(CacheHTTPInfo *info, int index)
   -------------------------------------------------------------------------*/
 
 void
-CacheHTTPInfoVector::detach(int idx, CacheHTTPInfo *r)
-{
-  int i;
-
-  ink_assert(idx >= 0);
-  ink_assert(idx < xcount);
-
-  r->copy_shallow(&data[idx].alternate);
-  data[idx].alternate.destroy();
-
-  for (i = idx; i < (xcount - 1); i++) {
-    data[i] = data[i + i];
-  }
-
-  xcount -= 1;
-}
-
-/*-------------------------------------------------------------------------
-  -------------------------------------------------------------------------*/
-
-void
 CacheHTTPInfoVector::remove(int idx, bool destroy)
 {
   if (destroy) {

--- a/src/iocore/cache/P_CacheHttp.h
+++ b/src/iocore/cache/P_CacheHttp.h
@@ -50,7 +50,6 @@ struct CacheHTTPInfoVector {
   }
   int            insert(CacheHTTPInfo *info, int id = -1);
   CacheHTTPInfo *get(int idx);
-  void           detach(int idx, CacheHTTPInfo *r);
   void           remove(int idx, bool destroy);
   void           clear(bool destroy = true);
   void


### PR DESCRIPTION
Cache alternate detach is a private helper with no current callers, and
its compaction loop contains a latent out-of-bounds read if the helper is
ever used. Keeping the dead path around preserves a future cache metadata
hazard without providing any current behavior.

This removes the unused helper and its declaration instead of repairing
the unreachable implementation. Existing alternate removal continues to
use the live remove path.