### PR TITLE
Limit regex remap substitutions

### DIFF
--- a/src/proxy/http/remap/RemapConfig.cc
+++ b/src/proxy/http/remap/RemapConfig.cc
@@ -1047,6 +1047,11 @@ process_regex_mapping_config(const char *from_host_lower, url_mapping *new_mappi
         Warning("Substitution id [%c] has no corresponding capture pattern in regex [%s]", to_host[i + 1], from_host_lower);
         goto lFail;
       }
+      if (reg_map->n_substitutions >= UrlRewrite::MAX_REGEX_SUBS) {
+        Warning("too many substitution markers in regex remap target [%.*s], saw %d markers, max %d", to_host_len, to_host.data(),
+                reg_map->n_substitutions + 1, UrlRewrite::MAX_REGEX_SUBS);
+        goto lFail;
+      }
       reg_map->substitution_markers[reg_map->n_substitutions] = i;
       reg_map->substitution_ids[reg_map->n_substitutions]     = substitution_id;
       ++reg_map->n_substitutions;

--- a/src/proxy/http/remap/unit-tests/test_RemapRules.cc
+++ b/src/proxy/http/remap/unit-tests/test_RemapRules.cc
@@ -37,6 +37,7 @@
 #include "tscore/BaseLogFile.h"
 #include "tsutil/PostScript.h"
 
+#include <filesystem>
 #include <fstream>
 #include <memory>
 
@@ -118,6 +119,49 @@ SCENARIO("Parsing ACL named filters", "[proxy][remap]")
         REQUIRE((bti.rules_list != nullptr && bti.rules_list->next == nullptr));
         REQUIRE((bti.rules_list != nullptr && bti.rules_list->allow_flag == true));
       }
+    }
+  }
+}
+
+std::string
+make_regex_remap_with_substitutions(int n_substitutions)
+{
+  std::string substitutions;
+
+  substitutions.reserve(n_substitutions * 2);
+  for (int i = 0; i < n_substitutions; ++i) {
+    substitutions += "$0";
+  }
+
+  return "regex_map http://([^.]+)\\.example\\.com/ http://" + substitutions + ".origin.example.com/\n";
+}
+
+SCENARIO("Parsing regex remap substitutions", "[proxy][remap]")
+{
+  GIVEN("A regex remap target with the maximum number of substitution markers")
+  {
+    std::unique_ptr<UrlRewrite> urlrw = std::make_unique<UrlRewrite>();
+
+    auto cpath = write_test_remap(make_regex_remap_with_substitutions(UrlRewrite::MAX_REGEX_SUBS), "max-regex-substitutions");
+    ts::PostScript file_cleanup([&]() -> void { std::filesystem::remove(cpath.c_str()); });
+
+    THEN("the remap parse succeeds")
+    {
+      REQUIRE(urlrw->BuildTable(cpath.c_str()) == TS_SUCCESS);
+    }
+  }
+
+  GIVEN("A regex remap target with too many substitution markers")
+  {
+    std::unique_ptr<UrlRewrite> urlrw = std::make_unique<UrlRewrite>();
+
+    auto cpath =
+      write_test_remap(make_regex_remap_with_substitutions(UrlRewrite::MAX_REGEX_SUBS + 1), "too-many-regex-substitutions");
+    ts::PostScript file_cleanup([&]() -> void { std::filesystem::remove(cpath.c_str()); });
+
+    THEN("the remap parse fails")
+    {
+      REQUIRE(urlrw->BuildTable(cpath.c_str()) != TS_SUCCESS);
     }
   }
 }


### PR DESCRIPTION
Regex remap targets could repeat valid substitution markers enough times
to exceed the fixed substitution arrays, even when every marker referred
to an allowed capture group.

This rejects targets with more substitution markers than the parser can
store and covers the boundary with remap parser unit tests.