### PR TITLE
Fix use of uninitialized value issue from fuzzing

### DIFF
--- a/include/tscore/HashFNV.h
+++ b/include/tscore/HashFNV.h
@@ -45,7 +45,8 @@ struct ATSHash32FNV1a : ATSHash32 {
   void     clear() override;
 
 private:
-  uint32_t hval;
+  static constexpr uint32_t fnv_init = 0x811c9dc5u;
+  uint32_t                  hval{fnv_init};
 };
 
 template <typename Transform>
@@ -76,7 +77,8 @@ struct ATSHash64FNV1a : ATSHash64 {
   void     clear() override;
 
 private:
-  uint64_t hval;
+  static constexpr uint64_t fnv_init = 0xcbf29ce484222325ull;
+  uint64_t                  hval{fnv_init};
 };
 
 template <typename Transform>

--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -505,7 +505,7 @@ Http3FrameFactory::create(IOBufferReader &reader)
   ts::Http3Config::scoped_config params;
   Http3Frame                    *frame = nullptr;
 
-  uint8_t type_buf[FRAME_TYPE_MAX_BYTES];
+  uint8_t type_buf[FRAME_TYPE_MAX_BYTES]{};
   reader.memcpy(type_buf, sizeof(type_buf));
   Http3FrameType type = Http3Frame::type(type_buf, sizeof(type_buf));
 

--- a/src/tscore/HashFNV.cc
+++ b/src/tscore/HashFNV.cc
@@ -9,14 +9,8 @@
 
 #include "tscore/HashFNV.h"
 
-static const uint32_t FNV_INIT_32 = 0x811c9dc5u;
-static const uint64_t FNV_INIT_64 = 0xcbf29ce484222325ull;
-
-// FNV-1a 64bit
-ATSHash32FNV1a::ATSHash32FNV1a()
-{
-  this->clear();
-}
+// FNV-1a 32bit
+ATSHash32FNV1a::ATSHash32FNV1a() = default;
 
 void
 ATSHash32FNV1a::final()
@@ -32,14 +26,11 @@ ATSHash32FNV1a::get() const
 void
 ATSHash32FNV1a::clear()
 {
-  hval = FNV_INIT_32;
+  hval = fnv_init;
 }
 
 // FNV-1a 64bit
-ATSHash64FNV1a::ATSHash64FNV1a()
-{
-  this->clear();
-}
+ATSHash64FNV1a::ATSHash64FNV1a() = default;
 void
 ATSHash64FNV1a::final()
 {
@@ -54,5 +45,5 @@ ATSHash64FNV1a::get() const
 void
 ATSHash64FNV1a::clear()
 {
-  hval = FNV_INIT_64;
+  hval = fnv_init;
 }


### PR DESCRIPTION
This pull request refactors the FNV-1a hash implementation to simplify initialization and improve code clarity. The main changes involve moving the FNV initial constants into the class definitions as `constexpr` static members, initializing member variables directly, and simplifying constructors.

Hash algorithm improvements:

* Moved FNV initial constants (`FNV_INIT_32`, `FNV_INIT_64`) into the respective classes (`ATSHash32FNV1a`, `ATSHash64FNV1a`) as `static constexpr` members and used them to initialize `hval` directly in the class definition (`include/tscore/HashFNV.h`). [[1]](diffhunk://#diff-33a77336d448662b07ef7b2bceefa94299417b94802f37d95b4183594f56c47dL48-R49) [[2]](diffhunk://#diff-33a77336d448662b07ef7b2bceefa94299417b94802f37d95b4183594f56c47dL79-R81)
* Updated the `clear()` methods to use the new `fnv_init` static member instead of external constants (`src/tscore/HashFNV.cc`). [[1]](diffhunk://#diff-9151b9f73b3fe93f5c6f8f3aaf86436b7c226c8e538db8560cb77c06899e5dbbL35-R33) [[2]](diffhunk://#diff-9151b9f73b3fe93f5c6f8f3aaf86436b7c226c8e538db8560cb77c06899e5dbbL57-R48)
* Simplified constructors for `ATSHash32FNV1a` and `ATSHash64FNV1a` by using default constructors instead of explicitly calling `clear()` (`src/tscore/HashFNV.cc`).

Code style and safety:

* Zero-initialized the `type_buf` buffer in `Http3FrameFactory::create` for improved safety (`src/proxy/http3/Http3Frame.cc`).

This fixes the reported fuzzing issues
https://oss-fuzz.com/testcase-detail/4669620266270720
https://oss-fuzz.com/testcase-detail/4793610426449920