### PR TITLE
Fix build with newer Apple clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -853,7 +853,7 @@ AS_IF([test "x${has_optimizer_flags}" = "xno"],
         ]
 )
 
-AS_IF([test "x$ac_cv_c_compiler_version" = "x17"], [NO_WARN_CAST_FUNCTION_TYPE_MISMATCH="-Wno-cast-function-type-mismatch"], [NO_WARN_CAST_FUNCTION_TYPE_MISMATCH=""])
+AS_IF([test -n "$ac_cv_c_compiler_version" && test "$ac_cv_c_compiler_version" -ge 17 2>/dev/null], [NO_WARN_CAST_FUNCTION_TYPE_MISMATCH="-Wno-cast-function-type-mismatch"], [NO_WARN_CAST_FUNCTION_TYPE_MISMATCH=""])
 AC_SUBST([NO_WARN_CAST_FUNCTION_TYPE_MISMATCH])
 
 case $host_os_def in

--- a/include/tscore/CryptoHash.h
+++ b/include/tscore/CryptoHash.h
@@ -44,7 +44,7 @@ union CryptoHash {
   uint8_t u8[CRYPTO_HASH_SIZE / sizeof(uint8_t)];
 
   /// Default constructor - init to zero.
-  CryptoHash() { memset(this, 0, sizeof(*this)); }
+  CryptoHash() { memset(static_cast<void *>(this), 0, sizeof(*this)); }
   /// Copy constructor.
   CryptoHash(CryptoHash const &that) = default;
 
@@ -53,7 +53,7 @@ union CryptoHash {
   operator=(CryptoHash const &that)
   {
     if (this != &that) {
-      memcpy(this, &that, sizeof(*this));
+      memcpy(static_cast<void *>(this), &that, sizeof(*this));
     }
     return *this;
   }

--- a/include/tscpp/util/TextView.h
+++ b/include/tscpp/util/TextView.h
@@ -1263,7 +1263,7 @@ namespace literals
    * rather bizarre to me, but there it is. Update: this depends on the version of the compiler,
    * so hopefully someday this can be removed.
    */
-  constexpr ts::TextView operator"" _tv(const char *s, size_t n) { return {s, n}; }
+  constexpr ts::TextView operator""_tv(const char *s, size_t n) { return {s, n}; }
 } // namespace literals
 
 /** Functor for STL containers that need caseless comparisons of standard string types.
@@ -1346,7 +1346,7 @@ template <> struct iterator_traits<ts::TextView> {
 //
 // I couldn't think of any better place to put this, so it's here. At least @c TextView is strongly related
 // to @c std::string_view.
-constexpr std::string_view operator"" _sv(const char *s, size_t n)
+constexpr std::string_view operator""_sv(const char *s, size_t n)
 {
   return {s, n};
 }

--- a/src/traffic_server/HostStatus.cc
+++ b/src/traffic_server/HostStatus.cc
@@ -269,7 +269,7 @@ HostStatus::setHostStatus(const std::string_view name, TSHostStatus status, cons
       host_stat = it->second;
     } else {
       host_stat = static_cast<HostStatRec *>(ats_malloc(sizeof(HostStatRec)));
-      bzero(host_stat, sizeof(HostStatRec));
+      bzero(static_cast<void *>(host_stat), sizeof(HostStatRec));
       hosts_statuses.emplace(name, host_stat);
     }
     if (reason & Reason::ACTIVE) {


### PR DESCRIPTION
Four issues from newer Apple clang (version 21):

1. TextView.h: -Wdeprecated-literal-operator flags the whitespace between `""` and the suffix identifier in user-defined literal operator declarations. Remove the space in `operator"" _tv` and `operator"" _sv`.

2. configure.ac: the version check added in PR #12834 only applied -Wno-cast-function-type-mismatch when Apple clang was exactly version 17, so the flag was silently skipped on 21+. Extend the check to match version >= 17.

3. CryptoHash.h: memset/memcpy on non-trivially-copyable union type trip -Wnontrivial-memcall. Cast `this` to `void *`.

4. HostStatus.cc: same issue with bzero on HostStatRec.