### PR TITLE
add bypass header config option to maxmind_acl plugin

### DIFF
--- a/doc/admin-guide/plugins/maxmind_acl.en.rst
+++ b/doc/admin-guide/plugins/maxmind_acl.en.rst
@@ -143,3 +143,12 @@ An example configuration ::
 This is useful for internal or trusted upstream services that should not be subject to geo
 restrictions. If ``bypass`` is absent from the configuration, bypass is disabled and all
 requests are evaluated normally.
+
+.. warning::
+
+   Because the bypass skips **all** ACL checks, the configured header must be
+   unforgeable by external clients. Use an internal ``@``-prefixed header (e.g.
+   ``@GcdTaBypassGeo``) that is set by ATS itself or a trusted upstream, or
+   ensure the edge strips/overwrites the header before it reaches this plugin.
+   Configuring a normal client-supplied header allows end users to opt out of
+   geo restrictions by simply sending the header in their request.

--- a/doc/admin-guide/plugins/maxmind_acl.en.rst
+++ b/doc/admin-guide/plugins/maxmind_acl.en.rst
@@ -119,8 +119,9 @@ Bypass
 ======
 
 An optional ``bypass`` field allows a request to skip all geo checks entirely and pass through
-unmodified. If the specified request header is present, the plugin returns immediately without
-performing any country, IP, regex, or anonymous evaluation.
+unmodified. Both a header name and an expected value must be configured; when the named header
+is present in the request **and** its value matches exactly, the plugin returns immediately
+without performing any country, IP, regex, or anonymous evaluation.
 
 ``header``
    Required sub-key. The name of the HTTP request header to look for, e.g. ``@GeoBypass``.
@@ -131,8 +132,9 @@ performing any country, IP, regex, or anonymous evaluation.
    disables the bypass entirely and a warning is emitted to the ATS error log.
 
 The comparison uses the complete, raw field value of the first occurrence of the named header.
-Requests where the header appears multiple times (comma-separated or repeated lines) will not
-match, because the combined multi-value string will not equal the configured ``value``.
+Duplicate headers with the same name (repeated lines) are ignored — only the first is evaluated.
+Within that first field, the entire value must match exactly, so a comma-separated multi-value
+(e.g. ``@GeoBypass: 1, extra``) in a single header line will not match a simple configured value.
 
 An example configuration ::
 

--- a/doc/admin-guide/plugins/maxmind_acl.en.rst
+++ b/doc/admin-guide/plugins/maxmind_acl.en.rst
@@ -123,32 +123,37 @@ unmodified. If the specified request header is present, the plugin returns immed
 performing any country, IP, regex, or anonymous evaluation.
 
 ``header``
-   Required sub-key. The name of the HTTP request header to look for, e.g. ``@GcdTaBypassGeo``.
+   Required sub-key. The name of the HTTP request header to look for, e.g. ``@GeoBypass``.
 
 ``value``
-   Optional sub-key. When set, the header must also match this exact value for the bypass to
-   trigger. When omitted, the presence of the header alone is sufficient.
+   Required sub-key. The header field value must match this string exactly for the bypass to
+   trigger. Both ``header`` and ``value`` must be present and non-empty; omitting either
+   disables the bypass entirely and a warning is emitted to the ATS error log.
+
+The comparison uses the complete, raw field value of the first occurrence of the named header.
+Requests where the header appears multiple times (comma-separated or repeated lines) will not
+match, because the combined multi-value string will not equal the configured ``value``.
 
 An example configuration ::
 
    maxmind:
     database: GeoIP2-City.mmdb
     bypass:
-     header: "@GcdTaBypassGeo"
-     value: "1"   # optional — omit to bypass on header presence alone
+     header: "@GeoBypass"
+     value: "1"
     allow:
      country:
       - US
 
 This is useful for internal or trusted upstream services that should not be subject to geo
-restrictions. If ``bypass`` is absent from the configuration, bypass is disabled and all
-requests are evaluated normally.
+restrictions. If ``bypass`` is absent from the configuration, or if either ``header`` or
+``value`` is missing, bypass is disabled and all requests are evaluated normally.
 
 .. warning::
 
    Because the bypass skips **all** ACL checks, the configured header must be
    unforgeable by external clients. Use an internal ``@``-prefixed header (e.g.
-   ``@GcdTaBypassGeo``) that is set by ATS itself or a trusted upstream, or
+   ``@GeoBypass``) that is set by ATS itself or a trusted upstream, or
    ensure the edge strips/overwrites the header before it reaches this plugin.
    Configuring a normal client-supplied header allows end users to opt out of
    geo restrictions by simply sending the header in their request.

--- a/doc/admin-guide/plugins/maxmind_acl.en.rst
+++ b/doc/admin-guide/plugins/maxmind_acl.en.rst
@@ -114,3 +114,32 @@ The plugin also supports optional fields from GeoGuard databases which includes:
 ``relay_proxy``
 ``proxy_over_vpn``
 ``smart_dns_proxy``
+
+Bypass
+======
+
+An optional ``bypass`` field allows a request to skip all geo checks entirely and pass through
+unmodified. If the specified request header is present, the plugin returns immediately without
+performing any country, IP, regex, or anonymous evaluation.
+
+``header``
+   Required sub-key. The name of the HTTP request header to look for, e.g. ``@GcdTaBypassGeo``.
+
+``value``
+   Optional sub-key. When set, the header must also match this exact value for the bypass to
+   trigger. When omitted, the presence of the header alone is sufficient.
+
+An example configuration ::
+
+   maxmind:
+    database: GeoIP2-City.mmdb
+    bypass:
+     header: "@GcdTaBypassGeo"
+     value: "1"   # optional — omit to bypass on header presence alone
+    allow:
+     country:
+      - US
+
+This is useful for internal or trusted upstream services that should not be subject to geo
+restrictions. If ``bypass`` is absent from the configuration, bypass is disabled and all
+requests are evaluated normally.

--- a/plugins/experimental/maxmind_acl/maxmind_acl.cc
+++ b/plugins/experimental/maxmind_acl/maxmind_acl.cc
@@ -68,6 +68,10 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     Dbg(dbg_ctl, "No ACLs configured");
   } else {
     Acl *a = static_cast<Acl *>(ih);
+    if (a->check_bypass(rh)) {
+      Dbg(dbg_ctl, "bypassing geo check due to bypass header");
+      return TSREMAP_NO_REMAP;
+    }
     if (!a->eval(rri, rh)) {
       Dbg(dbg_ctl, "denying request");
       TSHttpTxnStatusSet(rh, TS_HTTP_STATUS_FORBIDDEN, PLUGIN_NAME);

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -121,6 +121,9 @@ Acl::init(char const *filename)
   _proxy_over_vpn  = false;
   _smart_dns_proxy = false;
 
+  _bypass_header.clear();
+  _bypass_header_value.clear();
+
   if (loadallow(maxmind["allow"])) {
     Dbg(dbg_ctl, "Loaded Allow ruleset");
     status = true;
@@ -138,6 +141,8 @@ Acl::init(char const *filename)
   loadhtml(maxmind["html"]);
 
   _anonymous_blocking = loadanonymous(maxmind["anonymous"]);
+
+  loadbypass(maxmind["bypass"]);
 
   if (!status) {
     Dbg(dbg_ctl, "Failed to load any rulesets, none specified");
@@ -429,6 +434,38 @@ Acl::parseregex(const YAML::Node &regex, bool allow)
   }
 }
 
+bool
+Acl::loadbypass(const YAML::Node &bypassNode)
+{
+  if (!bypassNode) {
+    Dbg(dbg_ctl, "No bypass set");
+    return false;
+  }
+  if (bypassNode.IsNull()) {
+    Dbg(dbg_ctl, "bypass node is NULL");
+    return false;
+  }
+
+  try {
+    if (bypassNode["header"]) {
+      _bypass_header = bypassNode["header"].as<std::string>();
+      Dbg(dbg_ctl, "bypass header set to: %s", _bypass_header.c_str());
+      if (bypassNode["value"]) {
+        _bypass_header_value = bypassNode["value"].as<std::string>();
+        Dbg(dbg_ctl, "bypass value set to: %s", _bypass_header_value.c_str());
+      }
+    } else {
+      Dbg(dbg_ctl, "bypass missing 'header' key");
+      return false;
+    }
+  } catch (const YAML::Exception &e) {
+    TSError("[%s] YAML::Exception %s when parsing bypass config", PLUGIN_NAME, e.what());
+    return false;
+  }
+
+  return !_bypass_header.empty();
+}
+
 void
 Acl::loadhtml(const YAML::Node &htmlNode)
 {
@@ -501,6 +538,48 @@ Acl::loaddb(const YAML::Node &dbNode)
   db_loaded = true;
   Dbg(dbg_ctl, "Initialized MMDB with %s", dbloc.c_str());
   return true;
+}
+
+bool
+Acl::check_bypass(TSHttpTxn txnp) const
+{
+  if (_bypass_header.empty()) {
+    return false;
+  }
+
+  TSMBuffer mbuf;
+  TSMLoc    hdr_loc;
+  if (TS_SUCCESS != TSHttpTxnClientReqGet(txnp, &mbuf, &hdr_loc)) {
+    Dbg(dbg_ctl, "check_bypass: failed to get client request headers");
+    return false;
+  }
+
+  TSMLoc field_loc = TSMimeHdrFieldFind(mbuf, hdr_loc, _bypass_header.c_str(), static_cast<int>(_bypass_header.size()));
+  if (TS_NULL_MLOC == field_loc) {
+    TSHandleMLocRelease(mbuf, TS_NULL_MLOC, hdr_loc);
+    return false;
+  }
+
+  bool bypassed = false;
+  if (_bypass_header_value.empty()) {
+    // presence-only check
+    Dbg(dbg_ctl, "check_bypass: bypass header '%s' present", _bypass_header.c_str());
+    bypassed = true;
+  } else {
+    int         val_len = 0;
+    const char *val     = TSMimeHdrFieldValueStringGet(mbuf, hdr_loc, field_loc, 0, &val_len);
+    if (val != nullptr && static_cast<int>(_bypass_header_value.size()) == val_len &&
+        _bypass_header_value.compare(0, std::string::npos, val, val_len) == 0) {
+      Dbg(dbg_ctl, "check_bypass: bypass header '%s' matched value '%s'", _bypass_header.c_str(), _bypass_header_value.c_str());
+      bypassed = true;
+    } else {
+      Dbg(dbg_ctl, "check_bypass: bypass header present but value did not match");
+    }
+  }
+
+  TSHandleMLocRelease(mbuf, hdr_loc, field_loc);
+  TSHandleMLocRelease(mbuf, TS_NULL_MLOC, hdr_loc);
+  return bypassed;
 }
 
 bool

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -568,7 +568,7 @@ Acl::check_bypass(TSHttpTxn txnp) const
   int         val_len  = 0;
   const char *val      = TSMimeHdrFieldValueStringGet(mbuf, hdr_loc, field_loc, -1, &val_len);
   if (val != nullptr && 0 < val_len && std::string_view(val, val_len) == _bypass_header_value) {
-    Dbg(dbg_ctl, "check_bypass: bypass header '%s' matched value '%s'", _bypass_header.c_str(), _bypass_header_value.c_str());
+    Dbg(dbg_ctl, "check_bypass: bypass triggered");
     bypassed = true;
   } else {
     Dbg(dbg_ctl, "check_bypass: bypass header present but value did not match");

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -442,26 +442,42 @@ Acl::loadbypass(const YAML::Node &bypassNode)
     return;
   }
   if (bypassNode.IsNull()) {
-    Dbg(dbg_ctl, "bypass node is NULL");
+    TSWarning("[%s] bypass node is NULL — bypass disabled", PLUGIN_NAME);
     return;
   }
 
   try {
     if (bypassNode["header"]) {
+      const YAML::Node &headerNode = bypassNode["header"];
+      if (headerNode.IsNull() || !headerNode.IsScalar()) {
+        TSWarning("[%s] bypass 'header' is null or non-scalar — bypass disabled", PLUGIN_NAME);
+        return;
+      }
+
       if (!bypassNode["value"]) {
         TSWarning("[%s] bypass 'header' set without 'value' — bypass disabled; both are required", PLUGIN_NAME);
         return;
       }
-      _bypass_header_value = bypassNode["value"].as<std::string>();
+      const YAML::Node &valueNode = bypassNode["value"];
+      if (valueNode.IsNull() || !valueNode.IsScalar()) {
+        TSWarning("[%s] bypass 'value' is null or non-scalar — bypass disabled", PLUGIN_NAME);
+        return;
+      }
+
+      _bypass_header_value = valueNode.as<std::string>();
       if (_bypass_header_value.empty()) {
         TSWarning("[%s] bypass 'value' is empty — bypass disabled; a non-empty value is required", PLUGIN_NAME);
         return;
       }
-      _bypass_header = bypassNode["header"].as<std::string>();
+      _bypass_header = headerNode.as<std::string>();
+      if (_bypass_header.empty()) {
+        TSWarning("[%s] bypass 'header' is empty — bypass disabled; a non-empty header is required", PLUGIN_NAME);
+        return;
+      }
       Dbg(dbg_ctl, "bypass header set to: %s", _bypass_header.c_str());
       Dbg(dbg_ctl, "bypass value set to: %s", _bypass_header_value.c_str());
     } else {
-      Dbg(dbg_ctl, "bypass missing 'header' key");
+      TSWarning("[%s] bypass is set but missing 'header' key — bypass disabled", PLUGIN_NAME);
       return;
     }
   } catch (const YAML::Exception &e) {

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -567,7 +567,7 @@ Acl::check_bypass(TSHttpTxn txnp) const
     bypassed = true;
   } else {
     int         val_len = 0;
-    const char *val     = TSMimeHdrFieldValueStringGet(mbuf, hdr_loc, field_loc, 0, &val_len);
+    const char *val     = TSMimeHdrFieldValueStringGet(mbuf, hdr_loc, field_loc, -1, &val_len);
     if (val != nullptr && static_cast<int>(_bypass_header_value.size()) == val_len &&
         _bypass_header_value.compare(0, std::string::npos, val, val_len) == 0) {
       Dbg(dbg_ctl, "check_bypass: bypass header '%s' matched value '%s'", _bypass_header.c_str(), _bypass_header_value.c_str());

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -434,36 +434,40 @@ Acl::parseregex(const YAML::Node &regex, bool allow)
   }
 }
 
-bool
+void
 Acl::loadbypass(const YAML::Node &bypassNode)
 {
   if (!bypassNode) {
     Dbg(dbg_ctl, "No bypass set");
-    return false;
+    return;
   }
   if (bypassNode.IsNull()) {
     Dbg(dbg_ctl, "bypass node is NULL");
-    return false;
+    return;
   }
 
   try {
     if (bypassNode["header"]) {
+      if (!bypassNode["value"]) {
+        TSWarning("[%s] bypass 'header' set without 'value' — bypass disabled; both are required", PLUGIN_NAME);
+        return;
+      }
+      _bypass_header_value = bypassNode["value"].as<std::string>();
+      if (_bypass_header_value.empty()) {
+        TSWarning("[%s] bypass 'value' is empty — bypass disabled; a non-empty value is required", PLUGIN_NAME);
+        return;
+      }
       _bypass_header = bypassNode["header"].as<std::string>();
       Dbg(dbg_ctl, "bypass header set to: %s", _bypass_header.c_str());
-      if (bypassNode["value"]) {
-        _bypass_header_value = bypassNode["value"].as<std::string>();
-        Dbg(dbg_ctl, "bypass value set to: %s", _bypass_header_value.c_str());
-      }
+      Dbg(dbg_ctl, "bypass value set to: %s", _bypass_header_value.c_str());
     } else {
       Dbg(dbg_ctl, "bypass missing 'header' key");
-      return false;
+      return;
     }
   } catch (const YAML::Exception &e) {
     TSError("[%s] YAML::Exception %s when parsing bypass config", PLUGIN_NAME, e.what());
-    return false;
+    return;
   }
-
-  return !_bypass_header.empty();
 }
 
 void
@@ -560,21 +564,14 @@ Acl::check_bypass(TSHttpTxn txnp) const
     return false;
   }
 
-  bool bypassed = false;
-  if (_bypass_header_value.empty()) {
-    // presence-only check
-    Dbg(dbg_ctl, "check_bypass: bypass header '%s' present", _bypass_header.c_str());
+  bool        bypassed = false;
+  int         val_len  = 0;
+  const char *val      = TSMimeHdrFieldValueStringGet(mbuf, hdr_loc, field_loc, -1, &val_len);
+  if (val != nullptr && 0 < val_len && std::string_view(val, val_len) == _bypass_header_value) {
+    Dbg(dbg_ctl, "check_bypass: bypass header '%s' matched value '%s'", _bypass_header.c_str(), _bypass_header_value.c_str());
     bypassed = true;
   } else {
-    int         val_len = 0;
-    const char *val     = TSMimeHdrFieldValueStringGet(mbuf, hdr_loc, field_loc, -1, &val_len);
-    if (val != nullptr && static_cast<int>(_bypass_header_value.size()) == val_len &&
-        _bypass_header_value.compare(0, std::string::npos, val, val_len) == 0) {
-      Dbg(dbg_ctl, "check_bypass: bypass header '%s' matched value '%s'", _bypass_header.c_str(), _bypass_header_value.c_str());
-      bypassed = true;
-    } else {
-      Dbg(dbg_ctl, "check_bypass: bypass header present but value did not match");
-    }
+    Dbg(dbg_ctl, "check_bypass: bypass header present but value did not match");
   }
 
   TSHandleMLocRelease(mbuf, hdr_loc, field_loc);

--- a/plugins/experimental/maxmind_acl/mmdb.h
+++ b/plugins/experimental/maxmind_acl/mmdb.h
@@ -69,6 +69,7 @@ public:
   }
 
   bool eval(TSRemapRequestInfo *rri, TSHttpTxn txnp);
+  bool check_bypass(TSHttpTxn txnp) const;
   bool init(char const *filename);
 
   void
@@ -111,6 +112,10 @@ protected:
 
   bool _anonymous_blocking = false;
 
+  // Bypass header fields
+  std::string _bypass_header;
+  std::string _bypass_header_value;
+
   // Do we want to allow by default or not? Useful
   // for deny only rules
   bool default_allow = false;
@@ -121,6 +126,7 @@ protected:
   bool    loaddeny(const YAML::Node &denyNode);
   void    loadhtml(const YAML::Node &htmlNode);
   bool    loadanonymous(const YAML::Node &anonNode);
+  bool    loadbypass(const YAML::Node &bypassNode);
   bool    eval_country(MMDB_entry_data_s *entry_data, const std::string &url);
   bool    eval_anonymous(MMDB_entry_s *entry_data);
   void    parseregex(const YAML::Node &regex, bool allow);

--- a/plugins/experimental/maxmind_acl/mmdb.h
+++ b/plugins/experimental/maxmind_acl/mmdb.h
@@ -26,6 +26,7 @@
 #include <ts/ts.h>
 #include <ts/remap.h>
 #include <string>
+#include <string_view>
 #include <cstring>
 #include <iostream>
 #include <fstream>

--- a/plugins/experimental/maxmind_acl/mmdb.h
+++ b/plugins/experimental/maxmind_acl/mmdb.h
@@ -126,7 +126,7 @@ protected:
   bool    loaddeny(const YAML::Node &denyNode);
   void    loadhtml(const YAML::Node &htmlNode);
   bool    loadanonymous(const YAML::Node &anonNode);
-  bool    loadbypass(const YAML::Node &bypassNode);
+  void    loadbypass(const YAML::Node &bypassNode);
   bool    eval_country(MMDB_entry_data_s *entry_data, const std::string &url);
   bool    eval_anonymous(MMDB_entry_s *entry_data);
   void    parseregex(const YAML::Node &regex, bool allow);


### PR DESCRIPTION
This adds support to use an optional header/value to bypass running this plugin in the TSRemapDoRemap stage.

maxmind config yaml looks like:
```
maxmind:
 bypass:
  header: "@BypassMe"
  value: someval
```
If this option is not provided then the plugin runs as normal in enforcing mode.
Exact header and value is required.