### PR TITLE
Fix undercount of cp_list_len

### DIFF
--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -1296,6 +1296,7 @@ cplist_update()
             config_vol->cachep = new_cp;
             fillExclusiveDisks(config_vol->cachep);
             cp_list.enqueue(new_cp);
+            cp_list_len++;
           } else {
             delete new_cp;
           }


### PR DESCRIPTION
When ATS enqueue a CacheVol to the list, the counter of the list have to be incremented.