### PR TITLE
hrw: Fix an index bug in run plugin operator

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1290,7 +1290,7 @@ OperatorRunPlugin::initialize(Parser &p)
   argv[0] = p.from_url();
   argv[1] = p.to_url();
 
-  for (int i = 0; i < argc; ++i) {
+  for (size_t i = 0; i < tokens.size(); ++i) {
     argv[i + 2] = const_cast<char *>(tokens[i].c_str());
   }
 


### PR DESCRIPTION
This is extracting a small fix from #12536, leaving all changes pertaining to features not in 10.1.x.