### PR TITLE
regex_map_yaml.test.py: address escape warnings

### DIFF
--- a/tests/gold_tests/remap_yaml/regex_map_yaml.test.py
+++ b/tests/gold_tests/remap_yaml/regex_map_yaml.test.py
@@ -41,7 +41,7 @@ ts.Disk.records_config.update(
     })
 
 ts.Disk.remap_yaml.AddLines(
-    f'''
+    rf'''
 remap:
   - type: regex_map
     from:


### PR DESCRIPTION
Newer Python versions warn when the regex_map_yaml test compiles a
non-raw f-string containing regex escapes. The same string also turns
\b into a backspace before writing remap.yaml, which makes the regex in
the generated config less faithful to the source.

Here's the warning we were seeing:

```
Running Test regex_map_yaml:/home/jenkins/workspace/GitHub-sec-master/autest-child/src/tests/gold_tests/remap_yaml/regex_map_yaml.test.py:60: SyntaxWarning: invalid escape sequence '\.'
  tr.Processes.Default.ReturnCode = 0
/home/jenkins/workspace/GitHub-sec-master/autest-child/src/tests/gold_tests/remap_yaml/regex_map_yaml.test.py:59: SyntaxWarning: invalid escape sequence '\.'
  tr.MakeCurlCommand('-H"Host: zero.one.two.three.com" http://127.0.0.1:{0}/ --verbose'.format(ts.Variables.port), ts=ts)
. Passed
```

This makes the YAML config block in the test a raw f-string so regex
backslashes remain literal while the port interpolation still works.