### PR TITLE
Zero hdrtoken heap to fix use-of-uninitialized-value

### DIFF
--- a/src/proxy/hdrs/HdrToken.cc
+++ b/src/proxy/hdrs/HdrToken.cc
@@ -407,7 +407,7 @@ hdrtoken_init()
       heap_size                 += packed_prefix_str_len;
     }
 
-    _hdrtoken_strs_heap_f = static_cast<const char *>(ats_malloc(heap_size));
+    _hdrtoken_strs_heap_f = static_cast<const char *>(ats_calloc(1, heap_size));
     _hdrtoken_strs_heap_l = _hdrtoken_strs_heap_f + heap_size - 1;
 
     char *heap_ptr = const_cast<char *>(_hdrtoken_strs_heap_f);


### PR DESCRIPTION
The hdrtoken heap allocated in hdrtoken_init() leaves padding bytes between each token's null terminator and the next prefix slot uninitialized, since ink_strlcpy only writes strlen+1 bytes but heap_ptr advances by sstr_len (rounded up to sizeof(HdrTokenHeapPrefix)). Switch to ats_calloc so the padding bytes are zeroed.

This fixes the reported fuzzing issues
https://oss-fuzz.com/testcase-detail/4669620266270720