### PR TITLE
proxy.config.dns.search_default_domains: allow 2

### DIFF
--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -923,7 +923,7 @@ static constexpr RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.dns.retries", RECD_INT, "5", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-9]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.dns.search_default_domains", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.dns.search_default_domains", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.dns.failover_number", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/src/records/unit_tests/test_RecUtils.cc
+++ b/src/records/unit_tests/test_RecUtils.cc
@@ -24,6 +24,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "../P_RecUtils.h"
+#include "records/RecordsConfig.h"
 
 TEST_CASE("recordRangeCheck via RecordValidityCheck", "[librecords][RecUtils]")
 {
@@ -198,4 +199,17 @@ TEST_CASE("recordRangeCheck via RecordValidityCheck", "[librecords][RecUtils]")
     REQUIRE(RecordValidityCheck("9223372036854775806", RECC_INT, "[0-9223372036854775807]"));   // INT64_MAX - 1
     REQUIRE(RecordValidityCheck("-9223372036854775807", RECC_INT, "[-9223372036854775808-0]")); // INT64_MIN + 1
   }
+}
+
+TEST_CASE("search_default_domains accepts documented values", "[librecords][RecUtils]")
+{
+  const auto *record = GetRecordElementByName("proxy.config.dns.search_default_domains");
+
+  REQUIRE(record != nullptr);
+  REQUIRE(record->check == RECC_INT);
+  REQUIRE(record->regex != nullptr);
+  REQUIRE(RecordValidityCheck("0", record->check, record->regex));
+  REQUIRE(RecordValidityCheck("1", record->check, record->regex));
+  REQUIRE(RecordValidityCheck("2", record->check, record->regex));
+  REQUIRE_FALSE(RecordValidityCheck("3", record->check, record->regex));
 }


### PR DESCRIPTION
proxy.config.dns.search_default_domains is implemented for and documents
mode 2, but the record validation range rejected the value, only
allowing values 0 or 1.

This expands the record validation range to allow the user to configure
a 2 for proxy.config.dns.search_default_domains.

Fixes: #13175