### PR TITLE
10.1.x: proxy.config.dns.search_default_domains: allow 2

### DIFF
--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(
 )
 
 if(BUILD_TESTING)
-  add_executable(test_records unit_tests/unit_test_main.cc unit_tests/test_RecHttp.cc)
+  add_executable(test_records unit_tests/unit_test_main.cc unit_tests/test_RecHttp.cc unit_tests/test_RecUtils.cc)
   target_link_libraries(test_records PRIVATE records catch2::catch2 ts::tscore libswoc::libswoc)
   add_test(NAME test_records COMMAND test_records)
 

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -899,7 +899,7 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.dns.retries", RECD_INT, "5", RECU_RESTART_TS, RR_NULL, RECC_NULL, "[0-9]", RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.dns.search_default_domains", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  {RECT_CONFIG, "proxy.config.dns.search_default_domains", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-2]", RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.dns.failover_number", RECD_INT, "5", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,

--- a/src/records/unit_tests/test_RecUtils.cc
+++ b/src/records/unit_tests/test_RecUtils.cc
@@ -1,0 +1,40 @@
+/** @file
+
+   Catch-based tests for RecUtils.cc
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#include "catch.hpp"
+
+#include "../P_RecUtils.h"
+#include "records/RecordsConfig.h"
+
+TEST_CASE("search_default_domains accepts documented values", "[librecords][RecUtils]")
+{
+  const auto *record = GetRecordElementByName("proxy.config.dns.search_default_domains");
+
+  REQUIRE(record != nullptr);
+  REQUIRE(record->check == RECC_INT);
+  REQUIRE(record->regex != nullptr);
+  REQUIRE(RecordValidityCheck("0", record->check, record->regex));
+  REQUIRE(RecordValidityCheck("1", record->check, record->regex));
+  REQUIRE(RecordValidityCheck("2", record->check, record->regex));
+  REQUIRE_FALSE(RecordValidityCheck("3", record->check, record->regex));
+}


### PR DESCRIPTION
Backport of: #13176

---

proxy.config.dns.search_default_domains is implemented for and documents
mode 2, but the record validation range rejected the value, only
allowing values 0 or 1.

This expands the record validation range to allow the user to configure
a 2 for proxy.config.dns.search_default_domains.

Fixes: #13175
