### PR TITLE
Update AGENTS.md and clarify SECURITY.md plugin scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,11 @@ MIOBuffer *buffer = (MIOBuffer*)malloc(sizeof(MIOBuffer));
 - `src/proxy/http/remap/RemapConfig.cc` - URL remapping logic
 - `include/ts/ts.h` - Plugin API
 
+## Security
+
+See [SECURITY.md](SECURITY.md) for the project's security policy, threat model,
+scope, and vulnerability reporting process.
+
 ## Resources
 
 - Official docs: https://trafficserver.apache.org/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,11 @@ Administrative users are always considered to be trusted. Reports for vulnerabil
 
 Security-sensitive information may be logged with modified logging configurations, particularly if debug logging is enabled.
 
-Experimental features and plugins are known unstable and not supposed to be used on production. We do not consider
-vulnerabilities in those as security issues. You may report vulnerabilities in those publicly on our public lists or GitHub. However, please
+Experimental features are known unstable and not supposed to be used on production. We do not consider
+vulnerabilities in those as security issues. This explicitly includes HTTP/3 and QUIC support, which remain
+experimental. You may report vulnerabilities in those publicly on our public lists or GitHub. However, please
 contact us privately, if you believe the vulnerabilities you find are serious, or if you are not sure whether you should report the
 vulnerabilities publicly.
+
+Plugins shipped with Traffic Server, including those under `plugins/experimental/`, are in scope for security
+reporting. Please report vulnerabilities in those through the private security mailing list following the process above.


### PR DESCRIPTION
## Summary

- AGENTS.md: add a Security section pointing at SECURITY.md so the policy is discoverable for coding agents.
- SECURITY.md: clarify that shipped plugins, including those under `plugins/experimental/`, are in scope for security reporting. Narrow the experimental carve-out to experimental features and name HTTP/3 / QUIC explicitly.

## Test plan

- [x] Documentation only; no code or test changes required.