### PR TITLE
slice: fix stpcpy off-by-one for header value extraction

### DIFF
--- a/plugins/slice/HttpHeader.cc
+++ b/plugins/slice/HttpHeader.cc
@@ -168,33 +168,35 @@ HttpHeader::removeKey(char const *const keystr, int const keylen)
 bool
 HttpHeader::valueForKey(char const *const keystr, int const keylen, char *const valstr, int *const vallen, int const index) const
 {
-  if (!isValid()) {
+  if (nullptr == valstr || nullptr == vallen) {
+    return false;
+  }
+  if (!isValid() || index < -1) {
     *vallen = 0;
     return false;
   }
 
   bool status = false;
 
+  int const valcap = *vallen;
+  *vallen          = 0;
+  valstr[0]        = 0;
+
   TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen);
 
   if (nullptr != locfield) {
     int               getlen = 0;
     char const *const getstr = TSMimeHdrFieldValueStringGet(m_buffer, m_lochdr, locfield, index, &getlen);
-
-    int const valcap = *vallen;
-    if (nullptr != getstr && 0 < getlen && getlen < (valcap - 1)) {
+    if (nullptr != getstr && 0 < getlen && getlen < valcap) {
       char *const endp = stpncpy(valstr, getstr, getlen);
-
-      *vallen = endp - valstr;
-      status  = (*vallen < valcap);
-
-      if (status) {
-        *endp = '\0';
+      int const   len  = endp - valstr;
+      if (len < valcap) {
+        *endp   = '\0';
+        *vallen = len;
+        status  = true;
       }
     }
     TSHandleMLocRelease(m_buffer, m_lochdr, locfield);
-  } else {
-    *vallen = 0;
   }
 
   return status;

--- a/plugins/slice/HttpHeader.cc
+++ b/plugins/slice/HttpHeader.cc
@@ -180,8 +180,10 @@ HttpHeader::valueForKey(char const *const keystr, int const keylen, char *const 
 
   int const valcap = *vallen;
   *vallen          = 0;
-  valstr[0]        = 0;
-
+  if (valcap <= 0) {
+    return false;
+  }
+  valstr[0]             = '\0';
   TSMLoc const locfield = TSMimeHdrFieldFind(m_buffer, m_lochdr, keystr, keylen);
 
   if (nullptr != locfield) {

--- a/plugins/slice/HttpHeader.h
+++ b/plugins/slice/HttpHeader.h
@@ -114,7 +114,9 @@ struct HttpHeader {
   // returns false if header invalid or something went wrong with removal.
   bool removeKey(char const *const key, int const keylen);
 
-  // retrieves header value as a char*
+  // retrieves header value as a null terminated char* in valstr.
+  // caller must ensure the valstr buffer has sufficient capacity.
+  // null termination only guaranteed on success.
   bool valueForKey(char const *const keystr, int const keylen,
                    char *const valstr,    // <-- return string value
                    int *const  vallen,    // <-- pass in capacity, returns len of string


### PR DESCRIPTION
The off by one wastes a single character, it doesn't overrun.