### PR TITLE
Stabilize parallel AuTest helpers

### DIFF
--- a/tests/gold_tests/logging/ts_process_handler.py
+++ b/tests/gold_tests/logging/ts_process_handler.py
@@ -36,7 +36,10 @@ class GetPidError(Exception):
 def get_ts_process_pid(ts_identifier):
     processes = []
     for proc in psutil.process_iter(['cmdline']):
-        commandline = ' '.join(proc.info['cmdline'])
+        cmdline = proc.info.get('cmdline', [])
+        if not cmdline:
+            continue
+        commandline = ' '.join(cmdline)
         if '/traffic_server' in commandline and ts_identifier in commandline:
             return proc
     raise GetPidError("Could not find a traffic_server process")

--- a/tests/gold_tests/redirect/.gitignore
+++ b/tests/gold_tests/redirect/.gitignore
@@ -1,1 +1,2 @@
-generated_test_data/
+redirect_actions_generated_test_data/
+redirect_generated_test_data/

--- a/tests/gold_tests/redirect/redirect.test.py
+++ b/tests/gold_tests/redirect/redirect.test.py
@@ -69,7 +69,7 @@ dest_serv.addResponse("sessionfile.log", dest_request_header, dest_response_head
 
 dns.addRecords(records={"iwillredirect.test": ["127.0.0.1"]})
 
-data_dirname = 'generated_test_data'
+data_dirname = 'redirect_generated_test_data'
 data_path = os.path.join(Test.TestDirectory, data_dirname)
 os.makedirs(data_path, exist_ok=True)
 

--- a/tests/gold_tests/redirect/redirect_actions.test.py
+++ b/tests/gold_tests/redirect/redirect_actions.test.py
@@ -92,7 +92,7 @@ origin.addResponse('sessionfile.log', request_header, response_header)
 # Map scenarios to trafficserver processes.
 trafficservers = {}
 
-data_dirname = 'generated_test_data'
+data_dirname = 'redirect_actions_generated_test_data'
 data_path = os.path.join(Test.TestDirectory, data_dirname)
 os.makedirs(data_path, exist_ok=True)
 


### PR DESCRIPTION
Parallel AuTest runs can execute redirect and redirect_actions at the
same time. Both tests wrote request files into the same generated data
directory, so one test could overwrite the other's inputs and make
redirect fail with unrelated redirect_actions requests.

This gives each redirect test its own generated-data directory and
keeps those directories ignored. This also makes the SIGUSR2 helper
tolerate processes whose psutil cmdline is unavailable, so process
scanning does not crash before signaling Traffic Server.