### PR TITLE
Update H3 dependency build scripts

### DIFF
--- a/tools/build_boringssl_h3_tools.sh
+++ b/tools/build_boringssl_h3_tools.sh
@@ -38,6 +38,13 @@ echo "Building boringssl H3 dependencies in ${WORKDIR}. Installation will be don
 CFLAGS=${CFLAGS:-"-O3 -g"}
 CXXFLAGS=${CXXFLAGS:-"-O3 -g"}
 BORINGSSL_PATH="${BASE}/boringssl"
+GO_VERSION=${GO_VERSION:-"1.26.2"}
+BORINGSSL_COMMIT=${BORINGSSL_COMMIT:-"c3ffc3300a9450cf8e396c7880be7c6cadc16a4a"}
+QUICHE_TAG=${QUICHE_TAG:-"0.28.0"}
+CURL_TAG=${CURL_TAG:-"curl-8_20_0"}
+NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
+NGTCP2_TAG=${NGTCP2_TAG:-"v1.22.1"}
+NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.69.0"}
 
 if [ -e /etc/redhat-release ]; then
     MAKE="gmake"
@@ -112,11 +119,9 @@ else
     OS="linux"
 fi
 
-go_version=1.26.2
-BORINGSSL_COMMIT=${BORINGSSL_COMMIT:-"c3ffc3300a9450cf8e396c7880be7c6cadc16a4a"}
-wget https://go.dev/dl/go${go_version}.${OS}-${ARCH}.tar.gz
-rm -rf ${BASE}/go && tar -C ${BASE} -xf go${go_version}.${OS}-${ARCH}.tar.gz
-rm go${go_version}.${OS}-${ARCH}.tar.gz
+wget https://go.dev/dl/go${GO_VERSION}.${OS}-${ARCH}.tar.gz
+rm -rf ${BASE}/go && tar -C ${BASE} -xf go${GO_VERSION}.${OS}-${ARCH}.tar.gz
+rm go${GO_VERSION}.${OS}-${ARCH}.tar.gz
 
 GO_BINARY_PATH=${BASE}/go/bin/go
 if [ ! -d boringssl ]; then
@@ -137,17 +142,31 @@ if [ $retVal -eq 1 ]; then
 fi
 set -e
 
+# Check compiler flags before passing them to CMake. GCC errors on some
+# Clang-only -Wno-error flags, including -Wno-error=character-conversion.
+compiler_supports_flag() {
+  local compiler=$1
+  local flag=$2
+
+  echo '' | "${compiler}" "${flag}" -x c++ -c -o /dev/null - >/dev/null 2>&1
+}
+
 # Note: -Wdangling-pointer=0
 #   We may have some issues with latest GCC compilers, so disabling -Wdangling-pointer=
 # Note: -UBORINGSSL_HAVE_LIBUNWIND
 #   Disable related libunwind test builds, there are some version number issues
 #   with this pkg in Ubuntu 20.04, so disable this to make sure it builds.
+BSSL_CXX_FLAGS="-Wno-error=ignored-attributes -UBORINGSSL_HAVE_LIBUNWIND"
+if compiler_supports_flag c++ -Wno-error=character-conversion; then
+  BSSL_CXX_FLAGS="-Wno-error=character-conversion ${BSSL_CXX_FLAGS}"
+fi
+
 cmake \
   -B build-shared \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \
   -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS='-Wno-error=character-conversion -Wno-error=ignored-attributes -UBORINGSSL_HAVE_LIBUNWIND' \
+  -DCMAKE_CXX_FLAGS="${BSSL_CXX_FLAGS}" \
   -DCMAKE_C_FLAGS=${BSSL_C_FLAGS} \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
   -DBUILD_TESTING=0 \
@@ -159,7 +178,7 @@ cmake \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \
   -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_FLAGS='-Wno-error=character-conversion -Wno-error=ignored-attributes -UBORINGSSL_HAVE_LIBUNWIND' \
+  -DCMAKE_CXX_FLAGS="${BSSL_CXX_FLAGS}" \
   -DCMAKE_C_FLAGS="${BSSL_C_FLAGS}" \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
   -DBUILD_TESTING=0 \
@@ -180,14 +199,16 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone  https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.28.0
+git checkout ${QUICHE_TAG}
 QUICHE_BSSL_PATH=${BORINGSSL_LIB_PATH} QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
 sudo mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 sudo mkdir -p ${QUICHE_BASE}/include
 sudo cp target/release/libquiche.a ${QUICHE_BASE}/lib/
-[ -f target/release/libquiche.so ] && sudo cp target/release/libquiche.so ${QUICHE_BASE}/lib/
-# Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
-sudo ln -sf ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
+if [ -f target/release/libquiche.so ]; then
+  sudo cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+  # Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+  sudo ln -sf ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
+fi
 sudo cp quiche/include/quiche.h ${QUICHE_BASE}/include/
 sudo cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
 sudo chmod -R a+rX ${BASE}
@@ -197,7 +218,7 @@ LDFLAGS=${LDFLAGS:-"-Wl,-rpath,${BORINGSSL_LIB_PATH}"}
 
 # Then nghttp3
 echo "Building nghttp3..."
-[ ! -d nghttp3 ] && git clone --depth 1 -b v1.15.0 https://github.com/ngtcp2/nghttp3.git
+[ ! -d nghttp3 ] && git clone --depth 1 -b ${NGHTTP3_TAG} https://github.com/ngtcp2/nghttp3.git
 cd nghttp3
 git submodule update --init
 autoreconf -if
@@ -215,8 +236,9 @@ cd ..
 
 # Now ngtcp2
 echo "Building ngtcp2..."
-[ ! -d ngtcp2 ] && git clone --depth 1 -b v1.22.1 https://github.com/ngtcp2/ngtcp2.git
+[ ! -d ngtcp2 ] && git clone --depth 1 -b ${NGTCP2_TAG} https://github.com/ngtcp2/ngtcp2.git
 cd ngtcp2
+git submodule update --init
 autoreconf -if
 ./configure \
   --prefix=${BASE} \
@@ -235,7 +257,7 @@ cd ..
 
 # Then nghttp2, with support for H3
 echo "Building nghttp2 ..."
-[ ! -d nghttp2 ] && git clone --depth 1 -b v1.69.0 https://github.com/nghttp2/nghttp2.git
+[ ! -d nghttp2 ] && git clone --depth 1 -b ${NGHTTP2_TAG} https://github.com/nghttp2/nghttp2.git
 cd nghttp2
 git submodule update --init
 autoreconf -if
@@ -265,17 +287,19 @@ cd ..
 
 # Then curl
 echo "Building curl ..."
-[ ! -d curl ] && git clone --depth 1 -b curl-8_20_0 https://github.com/curl/curl.git
+[ ! -d curl ] && git clone --depth 1 -b ${CURL_TAG} https://github.com/curl/curl.git
 cd curl
 # On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
 # The second runs fine.
 autoreconf -fi || autoreconf -fi
+# Keep discovery on PKG_CONFIG_PATH so curl finds ngtcp2 and its BoringSSL crypto backend together.
+PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${BORINGSSL_LIB_PATH}/pkgconfig \
 ./configure \
   --prefix=${BASE} \
   --with-openssl="${BORINGSSL_PATH}" \
-  --with-nghttp2=${BASE} \
-  --with-nghttp3=${BASE} \
-  --with-ngtcp2=${BASE} \
+  --with-nghttp2 \
+  --with-nghttp3 \
+  --with-ngtcp2 \
   LDFLAGS="${LDFLAGS} -L${BORINGSSL_LIB_PATH} -Wl,-rpath,${BORINGSSL_LIB_PATH}" \
   CFLAGS="${CFLAGS}" \
   CXXFLAGS="${CXXFLAGS}"

--- a/tools/build_h3_tools.sh
+++ b/tools/build_h3_tools.sh
@@ -20,9 +20,10 @@
 #  limitations under the License.
 
 
-# The whole idea is to end up with two set of tools, a borinssgl toolset and an
-# openssl one. The first one can be used to build ATS+Boringssl+quiche(borinssl) while the
-# later one will give the base to build ATS on top of openssl/quictls+quiche(openssl/quictls).
+# The whole idea is to end up with two sets of tools, a boringssl toolset and an
+# openssl one. The first one can be used to build ATS+Boringssl+quiche(boringssl)
+# while the latter one will give the base to build ATS on top of
+# OpenSSL+quiche(OpenSSL).
 
 
 SCRIPT_PATH=$(dirname $0)
@@ -33,7 +34,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# then openssl/quictls.
+# then OpenSSL.
 BASE=${BASE:-"/opt"}/h3-tools-openssl ${SCRIPT_PATH}/build_openssl_h3_tools.sh
 if [ $? -ne 0 ]; then
     echo "build_openssl_h3_tools script Failed."

--- a/tools/build_openssl_h3_tools.sh
+++ b/tools/build_openssl_h3_tools.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 #  Simple script to build OpenSSL and various tools with H3 and QUIC support
-#  including quiche+openssl-quictls.
+#  including quiche+OpenSSL.
 #  This probably needs to be modified based on platform.
 #
 #  Licensed to the Apache Software Foundation (ASF) under one
@@ -27,17 +27,22 @@ readonly WORKDIR
 
 cd "${WORKDIR}"
 
-# Update this as the draft we support updates.
-OPENSSL_BRANCH=${OPENSSL_BRANCH:-"openssl-3.1.7+quic"}
+# OPENSSL_BRANCH is kept for compatibility with older local invocations.
+OPENSSL_TAG=${OPENSSL_TAG:-${OPENSSL_BRANCH:-"openssl-3.5.6"}}
+QUICHE_TAG=${QUICHE_TAG:-"0.28.0"}
+CURL_TAG=${CURL_TAG:-"curl-8_20_0"}
+NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
+NGTCP2_TAG=${NGTCP2_TAG:-"v1.22.1"}
+NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.69.0"}
 
 # Set these, if desired, to change these to your preferred installation
 # directory
 BASE=${BASE:-"/opt/h3-tools-openssl"}
 OPENSSL_BASE=${OPENSSL_BASE:-"${BASE}/openssl-quic"}
-OPENSSL_PREFIX=${OPENSSL_PREFIX:-"${OPENSSL_BASE}-${OPENSSL_BRANCH}"}
+OPENSSL_PREFIX=${OPENSSL_PREFIX:-"${OPENSSL_BASE}-${OPENSSL_TAG}"}
 MAKE="make"
 
-echo "Building openssl/quictls H3 dependencies in ${WORKDIR}. Installation will be done in ${BASE}"
+echo "Building OpenSSL H3 dependencies in ${WORKDIR}. Installation will be done in ${BASE}"
 
 CFLAGS=${CFLAGS:-"-O3 -g"}
 CXXFLAGS=${CXXFLAGS:-"-O3 -g"}
@@ -90,9 +95,9 @@ else
 fi
 
 echo "Building OpenSSL with QUIC support"
-[ ! -d openssl-quic ] && git clone -b ${OPENSSL_BRANCH} --depth 1 https://github.com/quictls/openssl.git openssl-quic
-cd openssl-quic
-./config enable-tls1_3 --prefix=${OPENSSL_PREFIX}
+[ ! -d openssl ] && git clone -b ${OPENSSL_TAG} --depth 1 https://github.com/openssl/openssl.git openssl
+cd openssl
+./config enable-tls1_3 --prefix=${OPENSSL_PREFIX} --libdir=lib
 ${MAKE} -j ${num_threads}
 sudo ${MAKE} install_sw
 sudo chmod -R a+rX ${BASE}
@@ -103,7 +108,7 @@ sudo ln -sf ${OPENSSL_PREFIX} ${OPENSSL_BASE}
 sudo chmod -R a+rX ${BASE}
 cd ..
 
-# OpenSSL will install in /lib or lib64 depending upon the architecture.
+# OpenSSL is configured to install its libraries in lib.
 if [ -d "${OPENSSL_PREFIX}/lib" ]; then
   OPENSSL_LIB="${OPENSSL_PREFIX}/lib"
 elif [ -d "${OPENSSL_PREFIX}/lib64" ]; then
@@ -120,7 +125,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.28.0
+git checkout ${QUICHE_TAG}
 
 PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
   cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog,openssl
@@ -128,9 +133,11 @@ PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
 sudo mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 sudo mkdir -p ${QUICHE_BASE}/include
 sudo cp target/release/libquiche.a ${QUICHE_BASE}/lib/
-[ -f target/release/libquiche.so ] && sudo cp target/release/libquiche.so ${QUICHE_BASE}/lib/
-# Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
-sudo ln -sf ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
+if [ -f target/release/libquiche.so ]; then
+  sudo cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+  # Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+  sudo ln -sf ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
+fi
 sudo cp quiche/include/quiche.h ${QUICHE_BASE}/include/
 sudo cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
 sudo chmod -R a+rX ${BASE}
@@ -139,7 +146,7 @@ cd ..
 
 # Then nghttp3
 echo "Building nghttp3..."
-[ ! -d nghttp3 ] && git clone --depth 1 -b v1.15.0 https://github.com/ngtcp2/nghttp3.git
+[ ! -d nghttp3 ] && git clone --depth 1 -b ${NGHTTP3_TAG} https://github.com/ngtcp2/nghttp3.git
 cd nghttp3
 git submodule update --init
 autoreconf -if
@@ -157,11 +164,13 @@ cd ..
 
 # Now ngtcp2
 echo "Building ngtcp2..."
-[ ! -d ngtcp2 ] && git clone --depth 1 -b v1.22.1 https://github.com/ngtcp2/ngtcp2.git
+[ ! -d ngtcp2 ] && git clone --depth 1 -b ${NGTCP2_TAG} https://github.com/ngtcp2/ngtcp2.git
 cd ngtcp2
+git submodule update --init
 autoreconf -if
 ./configure \
   --prefix=${BASE} \
+  --with-openssl \
   PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
   CFLAGS="${CFLAGS}" \
   CXXFLAGS="${CXXFLAGS}" \
@@ -174,7 +183,7 @@ cd ..
 
 # Then nghttp2, with support for H3
 echo "Building nghttp2 ..."
-[ ! -d nghttp2 ] && git clone --depth 1 -b v1.69.0 https://github.com/nghttp2/nghttp2.git
+[ ! -d nghttp2 ] && git clone --depth 1 -b ${NGHTTP2_TAG} https://github.com/nghttp2/nghttp2.git
 cd nghttp2
 git submodule update --init
 autoreconf -if
@@ -202,11 +211,13 @@ cd ..
 
 # Then curl
 echo "Building curl ..."
-[ ! -d curl ] && git clone --depth 1 -b curl-8_20_0 https://github.com/curl/curl.git
+[ ! -d curl ] && git clone --depth 1 -b ${CURL_TAG} https://github.com/curl/curl.git
 cd curl
 # On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
 # The second runs fine.
 autoreconf -fi || autoreconf -fi
+# Curl 8.20 uses ngtcp2 for its OpenSSL-backed HTTP/3 transport.
+PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
 ./configure \
   --prefix=${BASE} \
   --with-ssl=${OPENSSL_PREFIX} \


### PR DESCRIPTION
The Fedora 44 staged image now uses the proxy-verifier H3 library set
and upstream OpenSSL with native QUIC. The ATS helper scripts still
constructed their OpenSSL stack from quictls and had hard-coded H3
library tags, so the controller would build a different toolchain than
the one just validated for CI.

This updates the helper defaults to OpenSSL 3.5.5, nghttp3 1.15.0,
ngtcp2 1.21.0, and nghttp2 1.68.0, while keeping the BoringSSL
revision untouched. This also makes the BoringSSL CMake warning flags
conditional for newer GCC and points curl at the native OpenSSL QUIC
configuration.