### PR TITLE
GCC 16: Regex header integer includes

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -23,10 +23,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
 #include <string_view>
 #include <string>
 #include <vector>
-#include <memory>
 
 /// @brief Match flags for regular expression evaluation.
 ///


### PR DESCRIPTION
GCC 16 no longer exposes fixed-width integer types through the current transitive include path. Include cstdint directly so Regex.h remains self-contained.