### PR TITLE
Restore ssl_multicert.config for compatibility

### DIFF
--- a/doc/admin-guide/files/index.en.rst
+++ b/doc/admin-guide/files/index.en.rst
@@ -37,6 +37,7 @@ Configuration Files
    remap.yaml.en
    splitdns.config.en
    ssl_multicert.yaml.en
+   ssl_multicert.config.en
    sni.yaml.en
    storage.yaml.en
    strategies.yaml.en
@@ -83,6 +84,11 @@ Configuration Files
 :doc:`ssl_multicert.yaml.en`
    Configures |TS| to use different server certificates for SSL termination
    when listening on multiple addresses or when clients employ SNI.
+
+:doc:`ssl_multicert.config.en`
+   Legacy line-based SSL multi-certificate configuration. Loaded when
+   :file:`ssl_multicert.yaml` is absent. Use ``traffic_ctl config convert
+   ssl_multicert`` to migrate.
 
 :doc:`sni.yaml.en`
    Configures SNI based Layer 4 routing.

--- a/doc/admin-guide/files/ssl_multicert.config.en.rst
+++ b/doc/admin-guide/files/ssl_multicert.config.en.rst
@@ -15,6 +15,8 @@
   specific language governing permissions and limitations
   under the License.
 
+.. include:: ../../common.defs
+
 ====================
 ssl_multicert.config
 ====================

--- a/doc/admin-guide/files/ssl_multicert.config.en.rst
+++ b/doc/admin-guide/files/ssl_multicert.config.en.rst
@@ -15,24 +15,26 @@
   specific language governing permissions and limitations
   under the License.
 
-==================
-ssl_multicert.yaml
-==================
+====================
+ssl_multicert.config
+====================
 
-.. configfile:: ssl_multicert.yaml
+.. configfile:: ssl_multicert.config
 
-The :file:`ssl_multicert.yaml` file lets you configure Traffic
+.. note::
+
+   :file:`ssl_multicert.config` is the legacy line-based format. The
+   YAML-based :file:`ssl_multicert.yaml` is preferred. |TS| loads
+   :file:`ssl_multicert.config` only when :file:`ssl_multicert.yaml`
+   is absent. Use ``traffic_ctl config convert ssl_multicert
+   ssl_multicert.config ssl_multicert.yaml`` to migrate.
+
+The :file:`ssl_multicert.config` file lets you configure Traffic
 Server to use multiple SSL server certificates to terminate the SSL
 sessions. If you have a Traffic Server system with more than one
 IP address assigned to it, then you can assign a different SSL
 certificate to be served when a client requests a particular IP
 address or host name.
-
-.. note::
-
-   For backward compatibility, |TS| falls back to loading the legacy
-   :file:`ssl_multicert.config` when :file:`ssl_multicert.yaml` is
-   absent. See :doc:`ssl_multicert.config.en` for the legacy format.
 
 At configuration time, certificates are parsed to extract the
 certificate subject and all the DNS `subject alternative names
@@ -42,17 +44,17 @@ found in the certificate. Wildcard names are supported, but only
 of the form `*.domain.com`, ie. where `*` is the leftmost domain
 component.
 
-Changes to :file:`ssl_multicert.yaml` can be applied to a running
+Changes to :file:`ssl_multicert.config` can be applied to a running
 Traffic Server using :option:`traffic_ctl config reload`.
 
 Format
 ======
 
-The :file:`ssl_multicert.yaml` file uses YAML format with a top-level
-``ssl_multicert`` key containing a sequence of certificate entries.
-Each entry is a mapping with the following keys:
+Each :file:`ssl_multicert.config` line consists of a sequence of
+`key=value` fields that specify how Traffic Server should use a
+particular SSL certificate.
 
-ssl_cert_name: FILENAME[,FILENAME ...]
+ssl_cert_name=FILENAME[,FILENAME ...]
   The name of the file containing the TLS certificate. *FILENAME*
   is located relative to the directory specified by the
   :ts:cv:`proxy.config.ssl.server.cert.path` configuration variable.
@@ -74,10 +76,9 @@ ssl_cert_name: FILENAME[,FILENAME ...]
   You can also configure multiple leaf certificates in a same chain
   with OpenSSL 1.0.1.
 
-  This is the only field that is required to be present (unless
-  ``action`` is set to ``tunnel``).
+  This is the only field that is required to be present.
 
-dest_ip: ADDRESS (optional)
+dest_ip=ADDRESS (optional)
   The IP (v4 or v6) address that the certificate should be presented
   on. This is now only used as a fallback in the case that the TLS
   ServerNameIndication extension is not supported. If *ADDRESS* is
@@ -88,19 +89,19 @@ dest_ip: ADDRESS (optional)
   IPv6 addresses must be enclosed by square brackets if they have
   a port, eg, [::1]:80. Care should be taken to make each ADDRESS unique.
 
-ssl_key_name: FILENAME (optional)
+ssl_key_name=FILENAME (optional)
   The name of the file containing the private key for this certificate.
   If the key is contained in the certificate file, this field can
   be omitted, otherwise *FILENAME* is resolved relative to the
   :ts:cv:`proxy.config.ssl.server.private_key.path` configuration variable.
 
-ssl_ca_name: FILENAME (optional)
+ssl_ca_name=FILENAME (optional)
   If the certificate is issued by an authority that is not in the
   system CA bundle, additional certificates may be needed to validate
   the certificate chain. *FILENAME* is resolved relative to the
   :ts:cv:`proxy.config.ssl.CA.cert.path` configuration variable.
 
-ssl_ocsp_name: FILENAME (optional)
+ssl_ocsp_name=FILENAME (optional)
   The name of the file containing the prefetched OCSP stapling response
   for this certificate. This field can be omitted to let trafficserver
   fetch OCSP responses dynamically. Otherwise, when included, the administrator is
@@ -108,16 +109,16 @@ ssl_ocsp_name: FILENAME (optional)
   relative to the :ts:cv:`proxy.config.ssl.ocsp.response.path`
   configuration variable.
 
-ssl_ticket_enabled: 1|0 (optional)
+ssl_ticket_enabled=1|0 (optional)
   Enable RFC 5077 stateless TLS session tickets. To support this,
   OpenSSL should be upgraded to version 0.9.8f or higher. This
   option must be set to `0` to disable session ticket support.
 
-ssl_ticket_number: INTEGER (optional)
+ssl_ticket_number=INTEGER (optional)
   Specifies the number of TLSv1.3 session tickets that are issued.
   This defaults to 2 (the OpenSSL default)
 
-ssl_key_dialog: builtin|"exec:/path/to/program [args]" (optional)
+ssl_key_dialog=builtin|"exec:/path/to/program [args]" (optional)
   Method used to provide a pass phrase for encrypted private keys.  If the
   pass phrase is incorrect, SSL negotiation for this dest_ip will fail for
   clients who attempt to connect.
@@ -134,10 +135,6 @@ ssl_key_dialog: builtin|"exec:/path/to/program [args]" (optional)
       are supported by single quoting (').  The intent is that this
       program runs a security check to ensure that the system is not
       compromised by an attacker before providing the pass phrase.
-
-action: tunnel (optional)
-  If set to ``tunnel``, Traffic Server will not participate in the
-  TLS handshake and will blind tunnel the connection instead.
 
 Certificate Selection
 =====================
@@ -174,27 +171,19 @@ are terminated with the ``default.pem`` certificate.
 Since the private key is included in the certificate files, no
 private key name is specified.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: server.pem
-        dest_ip: "111.11.11.1"
-
-      - ssl_cert_name: server1.pem
-        dest_ip: "11.1.1.1"
-
-      - ssl_cert_name: default.pem
-        dest_ip: "*"
+    dest_ip=111.11.11.1 ssl_cert_name=server.pem
+    dest_ip=11.1.1.1 ssl_cert_name=server1.pem
+    dest_ip=* ssl_cert_name=default.pem
 
 The following example configures Traffic Server to use the ECDSA
 certificate chain ``ecdsa.pem`` or RSA certificate chain ``rsa.pem``
 for all requests.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: ecdsa.pem,rsa.pem
-        dest_ip: "*"
+    dest_ip=* ssl_cert_name=ecdsa.pem,rsa.pem
 
 The following example configures Traffic Server to use the ECDSA
 certificate chain ``ecdsa.pem`` or RSA certificate chain ``rsa.pem``
@@ -202,46 +191,35 @@ for all requests, the public key and private key are in separate PEM files.
 Note that the number of files in ssl_key_name must match the files in ssl_cert_name,
 and they should be presented in the same order.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: ecdsa_pub.pem,rsa_pub.pem
-        ssl_key_name: ecdsa_private.pem,rsa_private.pem
-        dest_ip: "*"
+    dest_ip=* ssl_cert_name=ecdsa_pub.pem,rsa_pub.pem ssl_key_name=ecdsa_private.pem,rsa_private.pem
 
 The following example configures Traffic Server to use the SSL
 certificate ``server.pem`` and the private key ``serverKey.pem``
 for all requests to port 8443 on IP address 111.11.11.1. The
 ``general.pem`` certificate is used for server name matches.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: server.pem,general.pem
-        ssl_key_name: serverKey.pem
-        dest_ip: "111.11.11.1:8443"
+     dest_ip=111.11.11.1:8443 ssl_cert_name=server.pem ssl_key_name=serverKey.pem ssl_cert_name=general.pem
 
 The following example configures Traffic Server to use the SSL
 certificate ``server.pem`` for all requests to the IP address
-111.11.11.1. Session tickets are enabled.
+111.11.11.1. Session tickets are enabled with a persistent ticket
+key.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: server.pem
-        dest_ip: "111.11.11.1"
-        ssl_ticket_enabled: 1
+    dest_ip=111.11.11.1 ssl_cert_name=server.pem ssl_ticket_enabled=1 ticket_key_name=ticket.key
 
 The following example configures Traffic Server to use the SSL
 certificate ``server.pem`` and disable session tickets for all
 requests to the IP address 111.11.11.1.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: server.pem
-        dest_ip: "111.11.11.1"
-        ssl_ticket_enabled: 0
+    dest_ip=111.11.11.1 ssl_cert_name=server.pem ssl_ticket_enabled=0
 
 The following examples configure Traffic Server to use the SSL
 certificate ``server.pem`` which includes an encrypted private key.
@@ -250,27 +228,7 @@ parameter (foo) in the first example, and with two parameters (foo)
 and (ba r) in the second example, the program (mypass) will return the
 pass phrase to decrypt the keys.
 
-.. code-block:: yaml
+::
 
-    ssl_multicert:
-      - ssl_cert_name: server1.pem
-        ssl_key_dialog: "exec:/usr/bin/mypass foo"
-
-      - ssl_cert_name: server2.pem
-        ssl_key_dialog: "exec:/usr/bin/mypass foo 'ba r'"
-
-Migration from ssl_multicert.config
-===================================
-
-The ``traffic_ctl`` command can be used to convert pre-11.x ``ssl_multicert.config``
-files to the new YAML format:
-
-.. code-block:: bash
-
-    traffic_ctl config convert ssl_multicert ssl_multicert.config ssl_multicert.yaml
-
-To output to stdout instead of a file, use ``-`` as the output path:
-
-.. code-block:: bash
-
-    traffic_ctl config convert ssl_multicert ssl_multicert.config -
+    ssl_cert_name=server1.pem ssl_key_dialog="exec:/usr/bin/mypass foo"
+    ssl_cert_name=server2.pem ssl_key_dialog="exec:/usr/bin/mypass foo 'ba r'"

--- a/doc/admin-guide/files/ssl_multicert.config.en.rst
+++ b/doc/admin-guide/files/ssl_multicert.config.en.rst
@@ -67,15 +67,15 @@ ssl_cert_name=FILENAME[,FILENAME ...]
   When running with OpenSSL 1.0.2 or later, this directive can be
   used to configure the intermediate CA chain on a per-certificate
   basis.  Multiple chain files are separated by comma character.
-  For example, it is possible able to configure a ECDSA certificate
-  chain and a RSA certificate chain and serve them simultaneously,
+  For example, it is possible to configure an ECDSA certificate
+  chain and an RSA certificate chain and serve them simultaneously,
   allowing OpenSSL to determine which certificate would be used
   when the TLS session cipher suites are negotiated.  Note that the
   leaf certs in `FILENAME1` and `FILENAME2` must have the same
-  subjects and alternate names. The first certificate is used to
+  subjects and alternate names. The first certificate is used
   to match the client's SNI request.
 
-  You can also configure multiple leaf certificates in a same chain
+  You can also configure multiple leaf certificates in the same chain
   with OpenSSL 1.0.1.
 
   This is the only field that is required to be present.

--- a/doc/admin-guide/files/ssl_multicert.yaml.en.rst
+++ b/doc/admin-guide/files/ssl_multicert.yaml.en.rst
@@ -15,6 +15,8 @@
   specific language governing permissions and limitations
   under the License.
 
+.. include:: ../../common.defs
+
 ==================
 ssl_multicert.yaml
 ==================

--- a/include/tscore/Filenames.h
+++ b/include/tscore/Filenames.h
@@ -40,10 +40,12 @@ namespace filename
   constexpr const char *PARENT        = "parent.config";
   constexpr const char *REMAP         = "remap.config";
   constexpr const char *REMAP_YAML    = "remap.yaml";
-  constexpr const char *SSL_MULTICERT = "ssl_multicert.yaml";
-  constexpr const char *SPLITDNS      = "splitdns.config";
-  constexpr const char *SNI           = "sni.yaml";
-  constexpr const char *JSONRPC       = "jsonrpc.yaml";
+
+  constexpr const char *SSL_MULTICERT_YAML = "ssl_multicert.yaml";
+
+  constexpr const char *SPLITDNS = "splitdns.config";
+  constexpr const char *SNI      = "sni.yaml";
+  constexpr const char *JSONRPC  = "jsonrpc.yaml";
 
   ///////////////////////////////////////////////////////////////////
   // Various other file names

--- a/include/tscore/Filenames.h
+++ b/include/tscore/Filenames.h
@@ -42,6 +42,7 @@ namespace filename
   constexpr const char *REMAP_YAML    = "remap.yaml";
 
   constexpr const char *SSL_MULTICERT_YAML = "ssl_multicert.yaml";
+  constexpr const char *SSL_MULTICERT      = "ssl_multicert.config"; //< deprecated by SSL_MULTICERT_YAML
 
   constexpr const char *SPLITDNS = "splitdns.config";
   constexpr const char *SNI      = "sni.yaml";

--- a/src/iocore/net/P_SSLConfig.h
+++ b/src/iocore/net/P_SSLConfig.h
@@ -42,6 +42,14 @@
 struct SSLCertLookup;
 struct ssl_ticket_key_block;
 
+// Resolved SSL multicert config file, including any legacy fallback state.
+struct SSLMulticertFile {
+  std::string path;
+  std::string parent_filename;         // basename for FileManager parent lookup
+  bool        legacy_fallback = false; // yaml absent, fell back to ssl_multicert.config
+  bool        both_present    = false; // record on default, both yaml and legacy exist
+};
+
 /////////////////////////////////////////////////////////////
 //
 // struct SSLConfigParams
@@ -162,6 +170,8 @@ struct SSLConfigParams : public ConfigInfo {
   void SSLConfigInit(swoc::IPRangeSet *global);
   void SetServerPolicy(const char *);
   void SetServerPolicyProperties(const char *);
+
+  static SSLMulticertFile resolveMulticertConfig();
 
 private:
   // c_str() of string passed to in-progess call to updateCTX().

--- a/src/iocore/net/SSLClientCoordinator.cc
+++ b/src/iocore/net/SSLClientCoordinator.cc
@@ -71,7 +71,7 @@ SSLClientCoordinator::startup()
                                                                       "proxy.config.ssl.server.multicert.filename",
                                                                       ts::filename::SSL_MULTICERT_YAML, false);
 
-  // Also register the legacy ssl_multicert.config so the backward-compatibility fallback
+  // Also register the legacy ssl_multicert.config so the backward-compatibility fallback remains monitored for reloads.
   FileManager::instance().addFile(ts::filename::SSL_MULTICERT, "proxy.config.ssl.server.multicert.filename", false, false);
 
   // Sub-module initialization (order matters: SSLConfig before SNIConfig)

--- a/src/iocore/net/SSLClientCoordinator.cc
+++ b/src/iocore/net/SSLClientCoordinator.cc
@@ -66,8 +66,9 @@ SSLClientCoordinator::startup()
     "ssl_client_coordinator", "sni", "proxy.config.ssl.servername.filename", ts::filename::SNI, false);
 
   // Track ssl_multicert.config — same pattern.
-  config::ConfigRegistry::Get_Instance().add_file_and_node_dependency(
-    "ssl_client_coordinator", "ssl_multicert", "proxy.config.ssl.server.multicert.filename", ts::filename::SSL_MULTICERT, false);
+  config::ConfigRegistry::Get_Instance().add_file_and_node_dependency("ssl_client_coordinator", "ssl_multicert",
+                                                                      "proxy.config.ssl.server.multicert.filename",
+                                                                      ts::filename::SSL_MULTICERT_YAML, false);
 
   // Sub-module initialization (order matters: SSLConfig before SNIConfig)
   SSLConfig::startup();

--- a/src/iocore/net/SSLClientCoordinator.cc
+++ b/src/iocore/net/SSLClientCoordinator.cc
@@ -25,6 +25,7 @@
 #include "P_SSLConfig.h"
 #include "iocore/net/SSLSNIConfig.h"
 #include "mgmt/config/ConfigRegistry.h"
+#include "mgmt/config/FileManager.h"
 #include "tscore/Filenames.h"
 #if TS_USE_QUIC == 1
 #include "iocore/net/QUICMultiCertConfigLoader.h"
@@ -65,10 +66,13 @@ SSLClientCoordinator::startup()
   config::ConfigRegistry::Get_Instance().add_file_and_node_dependency(
     "ssl_client_coordinator", "sni", "proxy.config.ssl.servername.filename", ts::filename::SNI, false);
 
-  // Track ssl_multicert.config — same pattern.
+  // Track ssl_multicert.yaml — same pattern.
   config::ConfigRegistry::Get_Instance().add_file_and_node_dependency("ssl_client_coordinator", "ssl_multicert",
                                                                       "proxy.config.ssl.server.multicert.filename",
                                                                       ts::filename::SSL_MULTICERT_YAML, false);
+
+  // Also register the legacy ssl_multicert.config so the backward-compatibility fallback
+  FileManager::instance().addFile(ts::filename::SSL_MULTICERT, "proxy.config.ssl.server.multicert.filename", false, false);
 
   // Sub-module initialization (order matters: SSLConfig before SNIConfig)
   SSLConfig::startup();

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -258,6 +258,38 @@ SSLConfigParams::SetServerPolicy(const char *verify_server)
   }
 }
 
+SSLMulticertFile
+SSLConfigParams::resolveMulticertConfig()
+{
+  SSLMulticertFile result;
+
+  char rec_buf[PATH_NAME_MAX] = {};
+  RecGetRecordString("proxy.config.ssl.server.multicert.filename", rec_buf, PATH_NAME_MAX);
+  const bool record_default = (rec_buf[0] == '\0' || strcmp(rec_buf, ts::filename::SSL_MULTICERT_YAML) == 0);
+
+  ats_scoped_str yaml_path(RecConfigReadConfigPath(nullptr, ts::filename::SSL_MULTICERT_YAML));
+  ats_scoped_str legacy_path(RecConfigReadConfigPath(nullptr, ts::filename::SSL_MULTICERT));
+
+  const bool yaml_exists   = yaml_path && swoc::file::exists(swoc::file::path(yaml_path.get()));
+  const bool legacy_exists = legacy_path && swoc::file::exists(swoc::file::path(legacy_path.get()));
+
+  if (record_default && !yaml_exists && legacy_exists) {
+    result.legacy_fallback = true;
+    result.parent_filename = ts::filename::SSL_MULTICERT;
+    if (legacy_path) {
+      result.path = legacy_path.get();
+    }
+  } else {
+    result.both_present    = record_default && yaml_exists && legacy_exists;
+    result.parent_filename = record_default ? ts::filename::SSL_MULTICERT_YAML : rec_buf;
+    if (ats_scoped_str p(RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename")); p) {
+      result.path = p.get();
+    }
+  }
+
+  return result;
+}
+
 void
 SSLConfigParams::initialize(ConfigContext ctx)
 {
@@ -440,35 +472,19 @@ SSLConfigParams::initialize(ConfigContext ctx)
     set_paths_helper(serverCertRelativePath, nullptr, &serverCertPathOnly, nullptr);
   }
 
-  // Resolve the multicert config path. Prefer the configured path; if the
-  // user is on the default (ssl_multicert.yaml) and it is absent while a
-  // legacy ssl_multicert.config exists alongside, fall back to the legacy
-  // file for backward compatibility.
   {
-    char rec_buf[PATH_NAME_MAX] = {};
-    RecGetRecordString("proxy.config.ssl.server.multicert.filename", rec_buf, PATH_NAME_MAX);
-    const bool record_default = (rec_buf[0] == '\0' || strcmp(rec_buf, ts::filename::SSL_MULTICERT_YAML) == 0);
-
-    ats_scoped_str yaml_path(RecConfigReadConfigPath(nullptr, ts::filename::SSL_MULTICERT_YAML));
-    ats_scoped_str legacy_path(RecConfigReadConfigPath(nullptr, ts::filename::SSL_MULTICERT));
-
-    const bool yaml_exists   = yaml_path && swoc::file::exists(swoc::file::path(yaml_path.get()));
-    const bool legacy_exists = legacy_path && swoc::file::exists(swoc::file::path(legacy_path.get()));
-
-    if (record_default && !yaml_exists && legacy_exists) {
+    auto multicert = resolveMulticertConfig();
+    if (multicert.legacy_fallback) {
       Note("%s not found, falling back to %s", ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT);
-      configFilePath = ats_strdup(legacy_path.get());
-    } else {
-      configFilePath = ats_stringdup(RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"));
-      if (record_default && yaml_exists && legacy_exists) {
-        Note("%s exists alongside %s; the legacy file is ignored. "
-             "To resolve, either: (a) migrate %s to %s (e.g. 'traffic_ctl config convert ssl_multicert') and remove %s, "
-             "or (b) remove %s to fall back to %s.",
-             ts::filename::SSL_MULTICERT, ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT,
-             ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT, ts::filename::SSL_MULTICERT_YAML,
-             ts::filename::SSL_MULTICERT);
-      }
+    } else if (multicert.both_present) {
+      Note("%s exists alongside %s; the legacy file is ignored. "
+           "To resolve, either: (a) migrate %s to %s (e.g. 'traffic_ctl config convert ssl_multicert') and remove %s, "
+           "or (b) remove %s to fall back to %s.",
+           ts::filename::SSL_MULTICERT, ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT,
+           ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT, ts::filename::SSL_MULTICERT_YAML,
+           ts::filename::SSL_MULTICERT);
     }
+    configFilePath = multicert.path.empty() ? nullptr : ats_strdup(multicert.path.c_str());
   }
   configExitOnLoadError = RecGetRecordInt("proxy.config.ssl.server.multicert.exit_on_load_fail").value_or(0);
   configLoadConcurrency = RecGetRecordInt("proxy.config.ssl.server.multicert.concurrency").value_or(1);

--- a/src/iocore/net/SSLConfig.cc
+++ b/src/iocore/net/SSLConfig.cc
@@ -39,12 +39,15 @@
 #include "iocore/net/SSLDiags.h"
 #include "iocore/net/TLSEarlyDataSupport.h"
 #include "iocore/net/YamlSNIConfig.h"
+#include "tscore/Filenames.h"
 #include "tscore/ink_config.h"
 #include "tscore/Layout.h"
 #include "records/RecHttp.h"
 #include "records/RecCore.h"
 #include "mgmt/config/ConfigContextDiags.h"
 #include "mgmt/config/ConfigRegistry.h"
+
+#include "swoc/swoc_file.h"
 
 #include <openssl/pem.h>
 #include <algorithm>
@@ -437,7 +440,36 @@ SSLConfigParams::initialize(ConfigContext ctx)
     set_paths_helper(serverCertRelativePath, nullptr, &serverCertPathOnly, nullptr);
   }
 
-  configFilePath        = ats_stringdup(RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"));
+  // Resolve the multicert config path. Prefer the configured path; if the
+  // user is on the default (ssl_multicert.yaml) and it is absent while a
+  // legacy ssl_multicert.config exists alongside, fall back to the legacy
+  // file for backward compatibility.
+  {
+    char rec_buf[PATH_NAME_MAX] = {};
+    RecGetRecordString("proxy.config.ssl.server.multicert.filename", rec_buf, PATH_NAME_MAX);
+    const bool record_default = (rec_buf[0] == '\0' || strcmp(rec_buf, ts::filename::SSL_MULTICERT_YAML) == 0);
+
+    ats_scoped_str yaml_path(RecConfigReadConfigPath(nullptr, ts::filename::SSL_MULTICERT_YAML));
+    ats_scoped_str legacy_path(RecConfigReadConfigPath(nullptr, ts::filename::SSL_MULTICERT));
+
+    const bool yaml_exists   = yaml_path && swoc::file::exists(swoc::file::path(yaml_path.get()));
+    const bool legacy_exists = legacy_path && swoc::file::exists(swoc::file::path(legacy_path.get()));
+
+    if (record_default && !yaml_exists && legacy_exists) {
+      Note("%s not found, falling back to %s", ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT);
+      configFilePath = ats_strdup(legacy_path.get());
+    } else {
+      configFilePath = ats_stringdup(RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"));
+      if (record_default && yaml_exists && legacy_exists) {
+        Note("%s exists alongside %s; the legacy file is ignored. "
+             "To resolve, either: (a) migrate %s to %s (e.g. 'traffic_ctl config convert ssl_multicert') and remove %s, "
+             "or (b) remove %s to fall back to %s.",
+             ts::filename::SSL_MULTICERT, ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT,
+             ts::filename::SSL_MULTICERT_YAML, ts::filename::SSL_MULTICERT, ts::filename::SSL_MULTICERT_YAML,
+             ts::filename::SSL_MULTICERT);
+      }
+    }
+  }
   configExitOnLoadError = RecGetRecordInt("proxy.config.ssl.server.multicert.exit_on_load_fail").value_or(0);
   configLoadConcurrency = RecGetRecordInt("proxy.config.ssl.server.multicert.concurrency").value_or(1);
   if (configLoadConcurrency == 0) {

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1822,18 +1822,18 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup, bool firstLoad)
 {
   const SSLConfigParams *params = this->_params;
 
-  Note("(%s) %s loading ...", this->_debug_tag(), ts::filename::SSL_MULTICERT_YAML);
+  // Guard against nullptr configFilePath which can happen if records aren't initialized.
+  if (params->configFilePath == nullptr) {
+    return swoc::Errata(ERRATA_WARN, "No SSL certificate configuration file path configured");
+  }
+
+  Note("(%s) %s loading ...", this->_debug_tag(), params->configFilePath);
 
   // Optionally elevate/allow file access to read root-only
   // certificates. The destructor will drop privilege for us.
   uint32_t elevate_setting = 0;
   elevate_setting          = RecGetRecordInt("proxy.config.ssl.cert.load_elevated").value_or(0);
   ElevateAccess elevate_access(elevate_setting ? ElevateAccess::FILE_PRIVILEGE : 0);
-
-  // Guard against nullptr configFilePath which can happen if records aren't initialized.
-  if (params->configFilePath == nullptr) {
-    return swoc::Errata(ERRATA_WARN, "No SSL certificate configuration file path configured");
-  }
 
   config::SSLMultiCertParser                       parser;
   config::ConfigResult<config::SSLMultiCertConfig> parse_result = parser.parse(params->configFilePath);

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1822,7 +1822,7 @@ SSLMultiCertConfigLoader::load(SSLCertLookup *lookup, bool firstLoad)
 {
   const SSLConfigParams *params = this->_params;
 
-  Note("(%s) %s loading ...", this->_debug_tag(), ts::filename::SSL_MULTICERT);
+  Note("(%s) %s loading ...", this->_debug_tag(), ts::filename::SSL_MULTICERT_YAML);
 
   // Optionally elevate/allow file access to read root-only
   // certificates. The destructor will drop privilege for us.

--- a/src/records/RecordsConfig.cc
+++ b/src/records/RecordsConfig.cc
@@ -1177,7 +1177,7 @@ static constexpr RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.cert_chain.filename", RECD_STRING, nullptr, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
-  {RECT_CONFIG, "proxy.config.ssl.server.multicert.filename", RECD_STRING, ts::filename::SSL_MULTICERT, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
+  {RECT_CONFIG, "proxy.config.ssl.server.multicert.filename", RECD_STRING, ts::filename::SSL_MULTICERT_YAML, RECU_RESTART_TS, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
   {RECT_CONFIG, "proxy.config.ssl.server.multicert.exit_on_load_fail", RECD_INT, "1", RECU_RESTART_TS, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
   ,

--- a/src/traffic_ctl/SSLMultiCertCommand.cc
+++ b/src/traffic_ctl/SSLMultiCertCommand.cc
@@ -26,12 +26,15 @@
 #include "tscore/Layout.h"
 #include "tscore/Filenames.h"
 
+#include "swoc/swoc_file.h"
+
 #include <iostream>
 
 namespace
 {
 
-/// Get the default ssl_multicert.yaml file path.
+/// Get the active ssl_multicert file path. Prefers ssl_multicert.yaml; falls
+/// back to legacy ssl_multicert.config when only that exists.
 std::string
 get_default_ssl_multicert_path()
 {
@@ -41,7 +44,13 @@ get_default_ssl_multicert_path()
   } else {
     sysconfdir = Layout::get()->sysconfdir;
   }
-  return Layout::get()->relative_to(sysconfdir, ts::filename::SSL_MULTICERT_YAML);
+  std::string yaml_path   = Layout::get()->relative_to(sysconfdir, ts::filename::SSL_MULTICERT_YAML);
+  std::string legacy_path = Layout::get()->relative_to(sysconfdir, ts::filename::SSL_MULTICERT);
+
+  if (!swoc::file::exists(swoc::file::path(yaml_path)) && swoc::file::exists(swoc::file::path(legacy_path))) {
+    return legacy_path;
+  }
+  return yaml_path;
 }
 
 } // namespace

--- a/src/traffic_ctl/SSLMultiCertCommand.cc
+++ b/src/traffic_ctl/SSLMultiCertCommand.cc
@@ -41,7 +41,7 @@ get_default_ssl_multicert_path()
   } else {
     sysconfdir = Layout::get()->sysconfdir;
   }
-  return Layout::get()->relative_to(sysconfdir, ts::filename::SSL_MULTICERT);
+  return Layout::get()->relative_to(sysconfdir, ts::filename::SSL_MULTICERT_YAML);
 }
 
 } // namespace

--- a/src/traffic_layout/info.cc
+++ b/src/traffic_layout/info.cc
@@ -175,7 +175,7 @@ produce_layout(bool json)
   print_var(ts::filename::RECORDS, RecConfigReadConfigPath(nullptr, ts::filename::RECORDS), json);
   print_var(ts::filename::REMAP, RecConfigReadConfigPath("proxy.config.url_remap.filename"), json);
   print_var(ts::filename::PLUGIN, RecConfigReadConfigPath(nullptr, ts::filename::PLUGIN), json);
-  print_var(ts::filename::SSL_MULTICERT, RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"), json);
+  print_var(ts::filename::SSL_MULTICERT_YAML, RecConfigReadConfigPath("proxy.config.ssl.server.multicert.filename"), json);
   print_var(ts::filename::STORAGE, RecConfigReadConfigPath(nullptr, ts::filename::STORAGE), json);
   print_var(ts::filename::HOSTING, RecConfigReadConfigPath("proxy.config.cache.hosting_filename"), json);
   print_var(ts::filename::IP_ALLOW, RecConfigReadConfigPath("proxy.config.cache.ip_allow.filename"), json, true);

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2536,22 +2536,8 @@ init_ssl_ctx_callback(void *ctx, bool server)
 void
 load_ssl_file_callback(const char *ssl_file)
 {
-  // Parent lookup must match the actually-loaded multicert file, not just the
-  // YAML default name — when legacy fallback is in effect, configFilePath ends
-  // in ssl_multicert.config and the YAML-keyed parent binding would miss.
-  const char              *parent = ts::filename::SSL_MULTICERT_YAML;
-  SSLConfig::scoped_config params;
-
-  if (params && params->configFilePath != nullptr) {
-    std::string_view fp{params->configFilePath};
-
-    if (auto slash = fp.find_last_of('/'); slash != std::string_view::npos) {
-      parent = params->configFilePath + slash + 1;
-    } else {
-      parent = params->configFilePath;
-    }
-  }
-  FileManager::instance().configFileChild(parent, ssl_file);
+  auto multicert = SSLConfigParams::resolveMulticertConfig();
+  FileManager::instance().configFileChild(multicert.parent_filename.c_str(), ssl_file);
 }
 
 void

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2536,7 +2536,7 @@ init_ssl_ctx_callback(void *ctx, bool server)
 void
 load_ssl_file_callback(const char *ssl_file)
 {
-  FileManager::instance().configFileChild(ts::filename::SSL_MULTICERT, ssl_file);
+  FileManager::instance().configFileChild(ts::filename::SSL_MULTICERT_YAML, ssl_file);
 }
 
 void

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2536,7 +2536,22 @@ init_ssl_ctx_callback(void *ctx, bool server)
 void
 load_ssl_file_callback(const char *ssl_file)
 {
-  FileManager::instance().configFileChild(ts::filename::SSL_MULTICERT_YAML, ssl_file);
+  // Parent lookup must match the actually-loaded multicert file, not just the
+  // YAML default name — when legacy fallback is in effect, configFilePath ends
+  // in ssl_multicert.config and the YAML-keyed parent binding would miss.
+  const char              *parent = ts::filename::SSL_MULTICERT_YAML;
+  SSLConfig::scoped_config params;
+
+  if (params && params->configFilePath != nullptr) {
+    std::string_view fp{params->configFilePath};
+
+    if (auto slash = fp.find_last_of('/'); slash != std::string_view::npos) {
+      parent = params->configFilePath + slash + 1;
+    } else {
+      parent = params->configFilePath;
+    }
+  }
+  FileManager::instance().configFileChild(parent, ssl_file);
 }
 
 void

--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -60,7 +60,8 @@ def MakeATSProcess(
         dump_runroot=True,
         enable_proxy_protocol=False,
         enable_proxy_protocol_cp_src=False,
-        disable_log_checks=False):
+        disable_log_checks=False,
+        use_legacy_ssl_multicert=False):
     """Create a traffic server process.
 
     :param block_for_debug: if True, causes traffic_server to run with the
@@ -68,6 +69,9 @@ def MakeATSProcess(
     triggered by running traffic_server under a debugger. In the debugger,
     `set cmd_block = 0`, set any desired break points, then `c` to continue
     to let the test proceed.
+    :param use_legacy_ssl_multicert: if True, skip the default
+    ssl_multicert.yaml setup so the test can stage a legacy
+    ssl_multicert.config file and exercise the runtime fallback path.
     """
     #####################################
     # common locations
@@ -309,7 +313,8 @@ def MakeATSProcess(
 
     fname = "ssl_multicert.yaml"
     tmpname = os.path.join(config_dir, fname)
-    p.Disk.File(tmpname, id=make_id(fname), typename="ats:config")
+    if not use_legacy_ssl_multicert:
+        p.Disk.File(tmpname, id=make_id(fname), typename="ats:config")
 
     fname = "sni.yaml"
     tmpname = os.path.join(config_dir, fname)

--- a/tests/gold_tests/config/etc/ssl_multicert.config
+++ b/tests/gold_tests/config/etc/ssl_multicert.config
@@ -1,0 +1,1 @@
+dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key

--- a/tests/gold_tests/config/replay/ssl_multicert_legacy_fallback.replay.yaml
+++ b/tests/gold_tests/config/replay/ssl_multicert_legacy_fallback.replay.yaml
@@ -1,0 +1,46 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+sessions:
+
+- protocol:
+    stack: https
+    tls:
+      sni: example.com
+  transactions:
+
+  - client-request:
+      method: GET
+      url: /
+      version: '1.1'
+      headers:
+        fields:
+        - [Host, example.com]
+        - [uuid, ssl-multicert-fallback]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [Content-Length, "0"]
+        - [X-Response, fallback-ok]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/config/ssl_multicert_legacy_fallback.test.py
+++ b/tests/gold_tests/config/ssl_multicert_legacy_fallback.test.py
@@ -1,3 +1,6 @@
+'''
+Verify the legacy ssl_multicert.config fallback path.
+'''
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -15,157 +18,193 @@
 #  limitations under the License.
 
 import os
+from enum import Enum
 
 Test.Summary = '''
 Verify Apache Traffic Server falls back to legacy ssl_multicert.config
 when ssl_multicert.yaml is absent.
 '''
 
-sni_domain = 'example.com'
+SNI_DOMAIN = 'example.com'
+REPLAY_FILE = 'replay/ssl_multicert_legacy_fallback.replay.yaml'
 
-ts = Test.MakeATSProcess("ts", enable_tls=True, use_legacy_ssl_multicert=True)
-server = Test.MakeOriginServer("server")
-request_header = {"headers": f"GET / HTTP/1.1\r\nHost: {sni_domain}\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-server.addResponse("sessionlog.json", request_header, response_header)
 
-ts.Disk.records_config.update(
-    {
-        'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
-        'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
-    })
-
-ts.addDefaultSSLFiles()
-
-ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.Port}')
-
-# Stage a legacy ssl_multicert.config (line-based) instead of ssl_multicert.yaml.
-legacy_path = os.path.join(ts.Variables.CONFIGDIR, 'ssl_multicert.config')
-ts.Disk.File(legacy_path, id='ssl_multicert_config', typename='ats:config')
-ts.Disk.ssl_multicert_config.AddLines([
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
-])
-
-# The fallback Note should appear in diags.log.
-ts.Disk.diags_log.Content += Testers.ContainsExpression(
-    r'ssl_multicert\.yaml not found, falling back to ssl_multicert\.config',
-    'ssl_multicert.yaml fallback Note should be logged when only the legacy file is present')
-
-tr = Test.AddTestRun(f"Connect using cert loaded from legacy ssl_multicert.config (SNI={sni_domain})")
-tr.Processes.Default.StartBefore(Test.Processes.ts)
-tr.Processes.Default.StartBefore(server)
-tr.StillRunningAfter = ts
-tr.StillRunningAfter = server
-tr.MakeCurlCommand(
-    f"-q -s -v -k --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' "
-    f"https://{sni_domain}:{ts.Variables.ssl_port}",
-    ts=ts)
-tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
-tr.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
-
-##########################################################################
-# When ssl_multicert.yaml exists alongside legacy ssl_multicert.config,
-# yaml wins and a Note about the legacy file being ignored is logged.
-ts2 = Test.MakeATSProcess("ts2", enable_tls=True)
-server2 = Test.MakeOriginServer("server2")
-server2.addResponse("sessionlog.json", request_header, response_header)
-
-ts2.Disk.records_config.update(
-    {
-        'proxy.config.ssl.server.cert.path': f'{ts2.Variables.SSLDir}',
-        'proxy.config.ssl.server.private_key.path': f'{ts2.Variables.SSLDir}',
-    })
-ts2.addDefaultSSLFiles()
-ts2.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server2.Variables.Port}')
-
-ts2.Disk.ssl_multicert_yaml.AddLines(
+class _BaseSslMulticertTest:
     """
+    Common scaffolding: a single ATS instance + verifier origin server.
+    Subclasses override _setupTS to stage the scenario-specific config.
+    """
+
+    _client_counter = 0
+
+    class State(Enum):
+        INIT = 0
+        RUNNING = 1
+
+    def __init__(self, ts_name, server_name):
+        self.state = self.State.INIT
+        self.ts_name = ts_name
+        self.server_name = server_name
+        self._setupServer()
+        self._setupTS()
+
+    def _setupServer(self):
+        self.server = Test.MakeVerifierServerProcess(self.server_name, REPLAY_FILE)
+
+    def _setupTS(self):
+        raise NotImplementedError
+
+    def _baseRecordsConfig(self):
+        return {
+            'proxy.config.ssl.server.cert.path': f'{self.ts.Variables.SSLDir}',
+            'proxy.config.ssl.server.private_key.path': f'{self.ts.Variables.SSLDir}',
+        }
+
+    def _checkProcessBefore(self, tr):
+        if self.state == self.State.RUNNING:
+            tr.StillRunningBefore = self.ts
+            tr.StillRunningBefore = self.server
+        else:
+            tr.Processes.Default.StartBefore(self.ts)
+            tr.Processes.Default.StartBefore(self.server)
+            self.state = self.State.RUNNING
+
+    def _checkProcessAfter(self, tr):
+        assert (self.state == self.State.RUNNING)
+        tr.StillRunningAfter = self.ts
+        tr.StillRunningAfter = self.server
+
+    def _addReplayRun(self, description):
+        tr = Test.AddTestRun(description)
+        self._checkProcessBefore(tr)
+        client_name = f'client-{_BaseSslMulticertTest._client_counter}'
+        _BaseSslMulticertTest._client_counter += 1
+        tr.AddVerifierClientProcess(client_name, REPLAY_FILE, https_ports=[self.ts.Variables.ssl_port])
+        self._checkProcessAfter(tr)
+
+    def _addRegistryRun(self, description, expected_files):
+        """
+        traffic_ctl config registry should list the SSL multicert files
+        registered by the SSL client coordinator at startup.
+        """
+        tr = Test.AddTestRun(description)
+        self._checkProcessBefore(tr)
+        tr.Processes.Default.Env = self.ts.Env
+        tr.Processes.Default.Command = 'traffic_ctl config registry'
+        tr.Processes.Default.ReturnCode = 0
+        for fname in expected_files:
+            tr.Processes.Default.Streams.stdout += Testers.ContainsExpression(
+                fname.replace('.', r'\.'), f'{fname} should appear in the file registry')
+        self._checkProcessAfter(tr)
+
+
+class LegacySslMulticertOnlyTest(_BaseSslMulticertTest):
+    """
+    Only legacy ssl_multicert.config is staged; ATS should fall back to it
+    and load TLS certs successfully.
+    """
+
+    def __init__(self):
+        super().__init__("ts", "server")
+
+    def _setupTS(self):
+        self.ts = Test.MakeATSProcess(self.ts_name, enable_tls=True, use_legacy_ssl_multicert=True)
+        self.ts.Disk.records_config.update(self._baseRecordsConfig())
+        self.ts.addDefaultSSLFiles()
+        self.ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{self.server.Variables.http_port}')
+
+        self.ts.Setup.CopyAs(os.path.join(Test.TestDirectory, 'etc', 'ssl_multicert.config'), self.ts.Variables.CONFIGDIR)
+
+        self.ts.Disk.diags_log.Content += Testers.ContainsExpression(
+            r'ssl_multicert\.yaml not found, falling back to ssl_multicert\.config',
+            'ssl_multicert.yaml fallback Note should be logged when only the legacy file is present')
+
+    def run(self):
+        self._addReplayRun(f"Connect using cert loaded from legacy ssl_multicert.config (SNI={SNI_DOMAIN})")
+        self._addRegistryRun(
+            "Verify config registry lists ssl_multicert.yaml and legacy ssl_multicert.config",
+            ['ssl_multicert.yaml', 'ssl_multicert.config'])
+
+
+class CoexistSslMulticertTest(_BaseSslMulticertTest):
+    """
+    Both ssl_multicert.yaml and ssl_multicert.config exist; YAML wins and a
+    Note about the legacy file being ignored is logged.
+    """
+
+    def __init__(self):
+        super().__init__("ts2", "server2")
+
+    def _setupTS(self):
+        self.ts = Test.MakeATSProcess(self.ts_name, enable_tls=True)
+        self.ts.Disk.records_config.update(self._baseRecordsConfig())
+        self.ts.addDefaultSSLFiles()
+        self.ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{self.server.Variables.http_port}')
+
+        self.ts.Disk.ssl_multicert_yaml.AddLines(
+            """
 ssl_multicert:
   - dest_ip: "*"
     ssl_cert_name: server.pem
     ssl_key_name: server.key
 """.split("\n"))
 
-# Stage a stray legacy file so we exercise the "both present" warning path.
-legacy2_path = os.path.join(ts2.Variables.CONFIGDIR, 'ssl_multicert.config')
-ts2.Disk.File(legacy2_path, id='ssl_multicert_config_extra', typename='ats:config')
-ts2.Disk.ssl_multicert_config_extra.AddLines([
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
-])
+        self.ts.Setup.CopyAs(os.path.join(Test.TestDirectory, 'etc', 'ssl_multicert.config'), self.ts.Variables.CONFIGDIR)
 
-ts2.Disk.diags_log.Content += Testers.ContainsExpression(
-    r'ssl_multicert\.config exists alongside ssl_multicert\.yaml; the legacy file is ignored',
-    'Note about ignored legacy ssl_multicert.config should be logged when both files are present')
+        self.ts.Disk.diags_log.Content += Testers.ContainsExpression(
+            r'ssl_multicert\.config exists alongside ssl_multicert\.yaml; the legacy file is ignored',
+            'Note about ignored legacy ssl_multicert.config should be logged when both files are present')
 
-tr2 = Test.AddTestRun(f"yaml wins when both files exist (SNI={sni_domain})")
-tr2.Processes.Default.StartBefore(ts2)
-tr2.Processes.Default.StartBefore(server2)
-tr2.StillRunningAfter = ts2
-tr2.StillRunningAfter = server2
-tr2.MakeCurlCommand(
-    f"-q -s -v -k --resolve '{sni_domain}:{ts2.Variables.ssl_port}:127.0.0.1' "
-    f"https://{sni_domain}:{ts2.Variables.ssl_port}",
-    ts=ts2)
-tr2.Processes.Default.ReturnCode = 0
-tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
-tr2.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
+    def run(self):
+        self._addReplayRun(f"yaml wins when both files exist (SNI={SNI_DOMAIN})")
+        self._addRegistryRun(
+            "Verify config registry lists both ssl_multicert.yaml and ssl_multicert.config",
+            ['ssl_multicert.yaml', 'ssl_multicert.config'])
 
-##########################################################################
-# When the admin has customized proxy.config.ssl.server.multicert.filename
-# to something other than the default ssl_multicert.yaml, the legacy
-# fallback must NOT engage even if ssl_multicert.config exists.
-ts3 = Test.MakeATSProcess("ts3", enable_tls=True, use_legacy_ssl_multicert=True)
-server3 = Test.MakeOriginServer("server3")
-server3.addResponse("sessionlog.json", request_header, response_header)
 
-ts3.Disk.records_config.update(
-    {
-        'proxy.config.ssl.server.cert.path': f'{ts3.Variables.SSLDir}',
-        'proxy.config.ssl.server.private_key.path': f'{ts3.Variables.SSLDir}',
-        'proxy.config.ssl.server.multicert.filename': 'custom_multicert.yaml',
-    })
-
-ts3.addDefaultSSLFiles()
-ts3.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server3.Variables.Port}')
-
-# Stage the custom-named YAML so ATS has something valid to load.
-custom_path = os.path.join(ts3.Variables.CONFIGDIR, 'custom_multicert.yaml')
-ts3.Disk.File(custom_path, id='ssl_multicert_yaml_custom', typename='ats:config')
-ts3.Disk.ssl_multicert_yaml_custom.AddLines(
+class CustomFilenameSslMulticertTest(_BaseSslMulticertTest):
     """
+    proxy.config.ssl.server.multicert.filename is set to a non-default value.
+    The legacy fallback must NOT engage even if ssl_multicert.config exists.
+    """
+
+    def __init__(self):
+        super().__init__("ts3", "server3")
+
+    def _setupTS(self):
+        self.ts = Test.MakeATSProcess(self.ts_name, enable_tls=True, use_legacy_ssl_multicert=True)
+        records = self._baseRecordsConfig()
+        records['proxy.config.ssl.server.multicert.filename'] = 'custom_multicert.yaml'
+        self.ts.Disk.records_config.update(records)
+        self.ts.addDefaultSSLFiles()
+        self.ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{self.server.Variables.http_port}')
+
+        custom_path = os.path.join(self.ts.Variables.CONFIGDIR, 'custom_multicert.yaml')
+        self.ts.Disk.File(custom_path, id='ssl_multicert_yaml_custom', typename='ats:config')
+        self.ts.Disk.ssl_multicert_yaml_custom.AddLines(
+            """
 ssl_multicert:
   - dest_ip: "*"
     ssl_cert_name: server.pem
     ssl_key_name: server.key
 """.split("\n"))
 
-# Also stage a legacy ssl_multicert.config that would normally trigger fallback —
-# but must be ignored here because the record was customized.
-legacy3_path = os.path.join(ts3.Variables.CONFIGDIR, 'ssl_multicert.config')
-ts3.Disk.File(legacy3_path, id='ssl_multicert_config_custom', typename='ats:config')
-ts3.Disk.ssl_multicert_config_custom.AddLines([
-    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
-])
+        self.ts.Setup.CopyAs(os.path.join(Test.TestDirectory, 'etc', 'ssl_multicert.config'), self.ts.Variables.CONFIGDIR)
 
-# Neither the fallback Note nor the "both present" Note should appear, because the
-# record value is not the default.
-ts3.Disk.diags_log.Content += Testers.ExcludesExpression(
-    r'ssl_multicert\.yaml not found, falling back to ssl_multicert\.config',
-    'Fallback Note must NOT appear when record is at a non-default filename')
-ts3.Disk.diags_log.Content += Testers.ExcludesExpression(
-    r'ssl_multicert\.config exists alongside ssl_multicert\.yaml; the legacy file is ignored',
-    '"Both present" Note must NOT appear when record is at a non-default filename')
+        self.ts.Disk.diags_log.Content += Testers.ExcludesExpression(
+            r'ssl_multicert\.yaml not found, falling back to ssl_multicert\.config',
+            'Fallback Note must NOT appear when record is at a non-default filename')
+        self.ts.Disk.diags_log.Content += Testers.ExcludesExpression(
+            r'ssl_multicert\.config exists alongside ssl_multicert\.yaml; the legacy file is ignored',
+            '"Both present" Note must NOT appear when record is at a non-default filename')
 
-tr3 = Test.AddTestRun(f"Custom record value disables legacy fallback (SNI={sni_domain})")
-tr3.Processes.Default.StartBefore(ts3)
-tr3.Processes.Default.StartBefore(server3)
-tr3.StillRunningAfter = ts3
-tr3.StillRunningAfter = server3
-tr3.MakeCurlCommand(
-    f"-q -s -v -k --resolve '{sni_domain}:{ts3.Variables.ssl_port}:127.0.0.1' "
-    f"https://{sni_domain}:{ts3.Variables.ssl_port}",
-    ts=ts3)
-tr3.Processes.Default.ReturnCode = 0
-tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
-tr3.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
+    def run(self):
+        self._addReplayRun(f"Custom record value disables legacy fallback (SNI={SNI_DOMAIN})")
+        self._addRegistryRun(
+            "Verify config registry lists custom_multicert.yaml and legacy ssl_multicert.config",
+            ['custom_multicert.yaml', 'ssl_multicert.config'])
+
+
+LegacySslMulticertOnlyTest().run()
+CoexistSslMulticertTest().run()
+CustomFilenameSslMulticertTest().run()

--- a/tests/gold_tests/config/ssl_multicert_legacy_fallback.test.py
+++ b/tests/gold_tests/config/ssl_multicert_legacy_fallback.test.py
@@ -1,0 +1,171 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Verify Apache Traffic Server falls back to legacy ssl_multicert.config
+when ssl_multicert.yaml is absent.
+'''
+
+sni_domain = 'example.com'
+
+ts = Test.MakeATSProcess("ts", enable_tls=True, use_legacy_ssl_multicert=True)
+server = Test.MakeOriginServer("server")
+request_header = {"headers": f"GET / HTTP/1.1\r\nHost: {sni_domain}\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionlog.json", request_header, response_header)
+
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': f'{ts.Variables.SSLDir}',
+        'proxy.config.ssl.server.private_key.path': f'{ts.Variables.SSLDir}',
+    })
+
+ts.addDefaultSSLFiles()
+
+ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.Port}')
+
+# Stage a legacy ssl_multicert.config (line-based) instead of ssl_multicert.yaml.
+legacy_path = os.path.join(ts.Variables.CONFIGDIR, 'ssl_multicert.config')
+ts.Disk.File(legacy_path, id='ssl_multicert_config', typename='ats:config')
+ts.Disk.ssl_multicert_config.AddLines([
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
+])
+
+# The fallback Note should appear in diags.log.
+ts.Disk.diags_log.Content += Testers.ContainsExpression(
+    r'ssl_multicert\.yaml not found, falling back to ssl_multicert\.config',
+    'ssl_multicert.yaml fallback Note should be logged when only the legacy file is present')
+
+tr = Test.AddTestRun(f"Connect using cert loaded from legacy ssl_multicert.config (SNI={sni_domain})")
+tr.Processes.Default.StartBefore(Test.Processes.ts)
+tr.Processes.Default.StartBefore(server)
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+tr.MakeCurlCommand(
+    f"-q -s -v -k --resolve '{sni_domain}:{ts.Variables.ssl_port}:127.0.0.1' "
+    f"https://{sni_domain}:{ts.Variables.ssl_port}",
+    ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
+tr.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
+
+##########################################################################
+# When ssl_multicert.yaml exists alongside legacy ssl_multicert.config,
+# yaml wins and a Note about the legacy file being ignored is logged.
+ts2 = Test.MakeATSProcess("ts2", enable_tls=True)
+server2 = Test.MakeOriginServer("server2")
+server2.addResponse("sessionlog.json", request_header, response_header)
+
+ts2.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': f'{ts2.Variables.SSLDir}',
+        'proxy.config.ssl.server.private_key.path': f'{ts2.Variables.SSLDir}',
+    })
+ts2.addDefaultSSLFiles()
+ts2.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server2.Variables.Port}')
+
+ts2.Disk.ssl_multicert_yaml.AddLines(
+    """
+ssl_multicert:
+  - dest_ip: "*"
+    ssl_cert_name: server.pem
+    ssl_key_name: server.key
+""".split("\n"))
+
+# Stage a stray legacy file so we exercise the "both present" warning path.
+legacy2_path = os.path.join(ts2.Variables.CONFIGDIR, 'ssl_multicert.config')
+ts2.Disk.File(legacy2_path, id='ssl_multicert_config_extra', typename='ats:config')
+ts2.Disk.ssl_multicert_config_extra.AddLines([
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
+])
+
+ts2.Disk.diags_log.Content += Testers.ContainsExpression(
+    r'ssl_multicert\.config exists alongside ssl_multicert\.yaml; the legacy file is ignored',
+    'Note about ignored legacy ssl_multicert.config should be logged when both files are present')
+
+tr2 = Test.AddTestRun(f"yaml wins when both files exist (SNI={sni_domain})")
+tr2.Processes.Default.StartBefore(ts2)
+tr2.Processes.Default.StartBefore(server2)
+tr2.StillRunningAfter = ts2
+tr2.StillRunningAfter = server2
+tr2.MakeCurlCommand(
+    f"-q -s -v -k --resolve '{sni_domain}:{ts2.Variables.ssl_port}:127.0.0.1' "
+    f"https://{sni_domain}:{ts2.Variables.ssl_port}",
+    ts=ts2)
+tr2.Processes.Default.ReturnCode = 0
+tr2.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
+tr2.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
+
+##########################################################################
+# When the admin has customized proxy.config.ssl.server.multicert.filename
+# to something other than the default ssl_multicert.yaml, the legacy
+# fallback must NOT engage even if ssl_multicert.config exists.
+ts3 = Test.MakeATSProcess("ts3", enable_tls=True, use_legacy_ssl_multicert=True)
+server3 = Test.MakeOriginServer("server3")
+server3.addResponse("sessionlog.json", request_header, response_header)
+
+ts3.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': f'{ts3.Variables.SSLDir}',
+        'proxy.config.ssl.server.private_key.path': f'{ts3.Variables.SSLDir}',
+        'proxy.config.ssl.server.multicert.filename': 'custom_multicert.yaml',
+    })
+
+ts3.addDefaultSSLFiles()
+ts3.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server3.Variables.Port}')
+
+# Stage the custom-named YAML so ATS has something valid to load.
+custom_path = os.path.join(ts3.Variables.CONFIGDIR, 'custom_multicert.yaml')
+ts3.Disk.File(custom_path, id='ssl_multicert_yaml_custom', typename='ats:config')
+ts3.Disk.ssl_multicert_yaml_custom.AddLines(
+    """
+ssl_multicert:
+  - dest_ip: "*"
+    ssl_cert_name: server.pem
+    ssl_key_name: server.key
+""".split("\n"))
+
+# Also stage a legacy ssl_multicert.config that would normally trigger fallback —
+# but must be ignored here because the record was customized.
+legacy3_path = os.path.join(ts3.Variables.CONFIGDIR, 'ssl_multicert.config')
+ts3.Disk.File(legacy3_path, id='ssl_multicert_config_custom', typename='ats:config')
+ts3.Disk.ssl_multicert_config_custom.AddLines([
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key',
+])
+
+# Neither the fallback Note nor the "both present" Note should appear, because the
+# record value is not the default.
+ts3.Disk.diags_log.Content += Testers.ExcludesExpression(
+    r'ssl_multicert\.yaml not found, falling back to ssl_multicert\.config',
+    'Fallback Note must NOT appear when record is at a non-default filename')
+ts3.Disk.diags_log.Content += Testers.ExcludesExpression(
+    r'ssl_multicert\.config exists alongside ssl_multicert\.yaml; the legacy file is ignored',
+    '"Both present" Note must NOT appear when record is at a non-default filename')
+
+tr3 = Test.AddTestRun(f"Custom record value disables legacy fallback (SNI={sni_domain})")
+tr3.Processes.Default.StartBefore(ts3)
+tr3.Processes.Default.StartBefore(server3)
+tr3.StillRunningAfter = ts3
+tr3.StillRunningAfter = server3
+tr3.MakeCurlCommand(
+    f"-q -s -v -k --resolve '{sni_domain}:{ts3.Variables.ssl_port}:127.0.0.1' "
+    f"https://{sni_domain}:{ts3.Variables.ssl_port}",
+    ts=ts3)
+tr3.Processes.Default.ReturnCode = 0
+tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
+tr3.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")


### PR DESCRIPTION
https://github.com/apache/trafficserver/pull/12755 replaced `ssl_multicert.config` with `ssl_multicert.yaml`. This restores `ssl_multicert.config` support for compatibility. Following #13191.