### PR TITLE
Single source of truth for Proxy Verifier metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,8 +676,11 @@ if(ENABLE_AUTEST)
   # the autest command. The original AUTEST_OPTIONS string is used in the
   # autest.sh script.
   separate_arguments(AUTEST_OPTIONS_LIST UNIX_COMMAND "${AUTEST_OPTIONS}")
-  set(PROXY_VERIFIER_VERSION "v3.1.2")
-  set(PROXY_VERIFIER_HASH "SHA1=0a60c646cbc9326abb2fbc397cb9efa8c08a807a")
+  file(READ "${CMAKE_SOURCE_DIR}/tests/proxy-verifier-version.txt" PROXY_VERIFIER_VERSION)
+  string(STRIP "${PROXY_VERIFIER_VERSION}" PROXY_VERIFIER_VERSION)
+  file(READ "${CMAKE_SOURCE_DIR}/tests/proxy-verifier-checksum.txt" PROXY_VERIFIER_SHA1)
+  string(STRIP "${PROXY_VERIFIER_SHA1}" PROXY_VERIFIER_SHA1)
+  set(PROXY_VERIFIER_HASH "SHA1=${PROXY_VERIFIER_SHA1}")
   include(proxy-verifier)
 endif()
 

--- a/tests/prepare_proxy_verifier.sh
+++ b/tests/prepare_proxy_verifier.sh
@@ -30,9 +30,11 @@ ROOT=${ROOT:-${SCRIPT_DIR}}
 
 PV_VERSION_FILE="${ROOT}/tests/proxy-verifier-version.txt"
 [ -r "${PV_VERSION_FILE}" ] || fail "\"${PV_VERSION_FILE}\" does not exist."
+PV_SUM_FILE="${ROOT}/tests/proxy-verifier-checksum.txt"
+[ -r "${PV_SUM_FILE}" ] || fail "\"${PV_SUM_FILE}\" does not exist."
 
 pv_name="proxy-verifier"
-pv_version=`cat ${ROOT}/tests/proxy-verifier-version.txt`
+read -r pv_version < "${PV_VERSION_FILE}"
 pv_top_dir="${ROOT}/tests/proxy-verifier"
 pv_unpack_dir="${pv_top_dir}/unpack/${pv_version}"
 bin_dir="${pv_unpack_dir}/bin"
@@ -40,7 +42,7 @@ pv_dir="${pv_name}-${pv_version}"
 pv_tar_filename="${pv_dir}.tar.gz"
 pv_tar="${pv_top_dir}/${pv_tar_filename}"
 pv_tar_url="https://ci.trafficserver.apache.org/bintray/${pv_tar_filename}"
-expected_sha1="e11b5867a56c5ffd496b18c901f1273e9c120a47"
+read -r expected_sha1 < "${PV_SUM_FILE}"
 pv_client="${bin_dir}/verifier-client"
 pv_server="${bin_dir}/verifier-server"
 TAR=${TAR:-tar}

--- a/tests/proxy-verifier-checksum.txt
+++ b/tests/proxy-verifier-checksum.txt
@@ -1,0 +1,1 @@
+0a60c646cbc9326abb2fbc397cb9efa8c08a807a


### PR DESCRIPTION
#13200 updated the Proxy Verifier versions and one of the checksum
references correctly, but missed the CMakeLists checksum. Currently, the
version and checksums for the Proxy Verifier release are referenced in
multiple places, making it easy to miss updating the various required
locations. This is bad.

This patch adds a checksum companion file next to the version file and
teaches all the consumers to read the shared version/checksum sources
when downloading Proxy Verifier.