### PR TITLE
Reduce TLS write-path overhead

### DIFF
--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -747,11 +747,9 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
   do {
     IOBufferReader *reader = buf.reader();
 
-    // Unlike the per-block original, l may span blocks so it can be coalesced below.
-    int64_t avail  = reader->read_avail();
-    int64_t wavail = towrite - total_written;
-
-    l = (wavail < avail) ? wavail : avail;
+    // towrite is already bounded by read_avail() in the caller, so this never exceeds
+    // what's queued -- avoid re-walking the block chain (O(n)) on the write hot path.
+    l = towrite - total_written;
 
     // TS-2365: If the SSL max record size is set and we have
     // more data than that, break this into smaller write

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -739,16 +739,17 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 
   Dbg(dbg_ctl_ssl, "towrite=%" PRId64, towrite);
 
-  // Per-thread scratch to coalesce fragmented blocks into one SSL_write. Reuse across
-  // connections is safe: a WANT_WRITE retry flushes SSL's own record buffer, not this.
+  // SSL_write retries (WANT_WRITE/READ) must reuse the same address; thread_local gives the
+  // coalesce path a stable one. SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER is off.
   static thread_local char gather_buf[SSL_MAX_TLS_RECORD_SIZE];
+
+  // Caller bounds towrite by read_avail(); asserting lets the loop skip an O(n) chain walk.
+  ink_assert(towrite <= buf.reader()->read_avail());
 
   ERR_clear_error();
   do {
     IOBufferReader *reader = buf.reader();
 
-    // towrite is already bounded by read_avail() in the caller, so this never exceeds
-    // what's queued -- avoid re-walking the block chain (O(n)) on the write hot path.
     l = towrite - total_written;
 
     // TS-2365: If the SSL max record size is set and we have
@@ -781,8 +782,7 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
       break;
     }
 
-    // Coalesce into the scratch buffer only when the chunk spans blocks and fits one
-    // record; otherwise write in place capped to the block.
+    // Coalesce across blocks only when it fits one record; else write in place, capped to the block.
     const char *write_block;
     int64_t     block_avail = reader->block_read_avail();
 

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -739,18 +739,19 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
 
   Dbg(dbg_ctl_ssl, "towrite=%" PRId64, towrite);
 
+  // Per-thread scratch to coalesce fragmented blocks into one SSL_write. Reuse across
+  // connections is safe: a WANT_WRITE retry flushes SSL's own record buffer, not this.
+  static thread_local char gather_buf[SSL_MAX_TLS_RECORD_SIZE];
+
   ERR_clear_error();
   do {
-    // What is remaining left in the next block?
-    l                   = buf.reader()->block_read_avail();
-    char *current_block = buf.reader()->start();
+    IOBufferReader *reader = buf.reader();
 
-    // check if to amount to write exceeds that in this buffer
+    // Unlike the per-block original, l may span blocks so it can be coalesced below.
+    int64_t avail  = reader->read_avail();
     int64_t wavail = towrite - total_written;
 
-    if (l > wavail) {
-      l = wavail;
-    }
+    l = (wavail < avail) ? wavail : avail;
 
     // TS-2365: If the SSL max record size is set and we have
     // more data than that, break this into smaller write
@@ -782,15 +783,30 @@ SSLNetVConnection::load_buffer_and_write(int64_t towrite, MIOBufferAccessor &buf
       break;
     }
 
+    // Coalesce into the scratch buffer only when the chunk spans blocks and fits one
+    // record; otherwise write in place capped to the block.
+    const char *write_block;
+    int64_t     block_avail = reader->block_read_avail();
+
+    if (block_avail < l && l <= static_cast<int64_t>(sizeof(gather_buf))) {
+      reader->memcpy(gather_buf, l, 0);
+      write_block = gather_buf;
+    } else {
+      if (l > block_avail) {
+        l = block_avail;
+      }
+      write_block = reader->start();
+    }
+
     try_to_write       = l;
     num_really_written = 0;
-    Dbg(dbg_ctl_v_ssl, "b=%p l=%" PRId64, current_block, l);
-    err = this->_ssl_write_buffer(current_block, l, num_really_written);
+    Dbg(dbg_ctl_v_ssl, "b=%p l=%" PRId64, write_block, l);
+    err = this->_ssl_write_buffer(write_block, l, num_really_written);
 
     // We wrote all that we thought we should
     if (num_really_written > 0) {
       total_written += num_really_written;
-      buf.reader()->consume(num_really_written);
+      reader->consume(num_really_written);
     }
 
     Dbg(dbg_ctl_ssl, "try_to_write=%" PRId64 " written=%" PRId64 " total_written=%" PRId64, try_to_write, num_really_written,


### PR DESCRIPTION
Coalesce a response's plaintext across IOBuffer blocks into a per-thread staging buffer and issue a single `SSL_write` per chunk (bounded to one max TLS record), instead of one `SSL_write` per block. For responses fragmented across many small blocks this cuts the number of `SSL_write` calls, TLS records, and `write()` syscalls; contiguous blocks still write in place with no copy.

Portable across OpenSSL and BoringSSL (no filter BIO), and preserves dynamic record sizing and the partial-write / `WANT_WRITE` retry path.
