### PR TITLE
hrw4u: Fix u4wrh set-config emitting 3-arg form with HRW type hint

### DIFF
--- a/tools/hrw4u/src/hrw_symbols.py
+++ b/tools/hrw4u/src/hrw_symbols.py
@@ -304,6 +304,9 @@ class InverseSymbolResolver(SymbolResolverBase):
             quoted_value = f'"{value}"' if not (value.startswith('"') and value.endswith('"')) else value
             qargs = [qualifier, quoted_value]
         else:
+            if name == "set-config" and len(args) == 3 and args[1].upper() in {"INT", "STRING", "FLOAT"}:
+                # strip HRW type hint; canonical HRW4U is 2-arg (type resolved via TSHttpTxnConfigFind)
+                args = [args[0], args[2]]
             qargs = [self._rewrite_inline_percents(Validator.quote_if_needed(a), section) for a in args]
 
         return f"{name}({', '.join(qargs)})" if qargs else f"{name}()"

--- a/tools/hrw4u/tests/data/ops/exceptions.txt
+++ b/tools/hrw4u/tests/data/ops/exceptions.txt
@@ -7,3 +7,8 @@ qsa.input: u4wrh
 header_value_context.input: u4wrh
 # HTTP-CNTL valid bools can not reverse back to the original input
 http_cntl_valid_bools.input: hrw4u
+# set-config with HRW type hint (INT/STRING/FLOAT) is a reverse-only form;
+# hrw4u never emits the type token.
+set-conf-type-int.input: u4wrh
+set-conf-type-string.input: u4wrh
+set-conf-type-float.input: u4wrh

--- a/tools/hrw4u/tests/data/ops/set-conf-type-float.input.txt
+++ b/tools/hrw4u/tests/data/ops/set-conf-type-float.input.txt
@@ -1,0 +1,5 @@
+REMAP {
+    if true {
+        set-config("proxy.config.http.background_fill_completed_threshold", "0.5");
+    }
+}

--- a/tools/hrw4u/tests/data/ops/set-conf-type-float.output.txt
+++ b/tools/hrw4u/tests/data/ops/set-conf-type-float.output.txt
@@ -1,0 +1,3 @@
+cond %{REMAP_PSEUDO_HOOK} [AND]
+cond %{TRUE}
+    set-config "proxy.config.http.background_fill_completed_threshold" FLOAT 0.5

--- a/tools/hrw4u/tests/data/ops/set-conf-type-int.input.txt
+++ b/tools/hrw4u/tests/data/ops/set-conf-type-int.input.txt
@@ -1,0 +1,5 @@
+REMAP {
+    if true {
+        set-config("proxy.config.http.cache.http", 0);
+    }
+}

--- a/tools/hrw4u/tests/data/ops/set-conf-type-int.output.txt
+++ b/tools/hrw4u/tests/data/ops/set-conf-type-int.output.txt
@@ -1,0 +1,3 @@
+cond %{REMAP_PSEUDO_HOOK} [AND]
+cond %{TRUE}
+    set-config "proxy.config.http.cache.http" INT 0

--- a/tools/hrw4u/tests/data/ops/set-conf-type-string.input.txt
+++ b/tools/hrw4u/tests/data/ops/set-conf-type-string.input.txt
@@ -1,0 +1,5 @@
+REMAP {
+    if true {
+        set-config("proxy.config.http.response_server_str", "my-server");
+    }
+}

--- a/tools/hrw4u/tests/data/ops/set-conf-type-string.output.txt
+++ b/tools/hrw4u/tests/data/ops/set-conf-type-string.output.txt
@@ -1,0 +1,3 @@
+cond %{REMAP_PSEUDO_HOOK} [AND]
+cond %{TRUE}
+    set-config "proxy.config.http.response_server_str" STRING "my-server"


### PR DESCRIPTION
## Summary
Some legacy header_rewrite configs spell `set-config` with an explicit HRW type
token (`INT`, `STRING`, `FLOAT`) between name and value. The native ATS parser
has no concept of that token, and HRW4U `set-config` takes exactly two
arguments. When u4wrh encounters the three-argument form, drop the type token
so the emitted HRW4U call is `set-config(name, value)`.

Adds INT, STRING, and FLOAT reverse fixtures to guard each branch of the HRW
type-hint strip.