### PR TITLE
slice: Adjest AuTest for slice_prefetch

### DIFF
--- a/tests/gold_tests/pluginTest/slice/gold/slice_prefetch.gold
+++ b/tests/gold_tests/pluginTest/slice/gold/slice_prefetch.gold
@@ -20,6 +20,8 @@ bytes 0-4/18 miss
 bytes ``/18 miss
 bytes ``/18 miss
 bytes ``/18 miss
+bytes 10-14/18 hit-fresh
+bytes 15-17/18 hit-fresh
 bytes 15-17/18 hit-fresh
 bytes 5-16/18 miss, none
 bytes 0-6/18 hit-fresh


### PR DESCRIPTION
It looks like recently merged https://github.com/apache/trafficserver/pull/12949 broke `slice_prefetch` AuTest.