### PR TITLE
slice: Avoid redundant prefetch re-scheduling

### DIFF
--- a/plugins/slice/Data.h
+++ b/plugins/slice/Data.h
@@ -94,6 +94,8 @@ struct Data {
 
   bool m_prefetchable{false};
 
+  int64_t m_prefetch_hwm{-1}; // highest block this request has scheduled for prefetch
+
   HdrMgr m_req_hdrmgr;  // manager for server request
   HdrMgr m_resp_hdrmgr; // manager for client response
 

--- a/plugins/slice/Data.h
+++ b/plugins/slice/Data.h
@@ -94,7 +94,7 @@ struct Data {
 
   bool m_prefetchable{false};
 
-  int m_prefetch_hwm{-1}; // highest block this request has scheduled for prefetch
+  int64_t m_prefetch_hwm{-1}; // highest block this request has scheduled for prefetch
 
   HdrMgr m_req_hdrmgr;  // manager for server request
   HdrMgr m_resp_hdrmgr; // manager for client response

--- a/plugins/slice/Data.h
+++ b/plugins/slice/Data.h
@@ -94,7 +94,7 @@ struct Data {
 
   bool m_prefetchable{false};
 
-  int64_t m_prefetch_hwm{-1}; // highest block this request has scheduled for prefetch
+  int m_prefetch_hwm{-1}; // highest block this request has scheduled for prefetch
 
   HdrMgr m_req_hdrmgr;  // manager for server request
   HdrMgr m_resp_hdrmgr; // manager for client response

--- a/plugins/slice/util.cc
+++ b/plugins/slice/util.cc
@@ -67,7 +67,14 @@ schedule_prefetch(Data *const data)
     nextblocknum = data->m_blocknum + data->m_config->m_prefetchcount;
   }
 
-  for (int i = nextblocknum; i <= data->m_blocknum + data->m_config->m_prefetchcount; i++) {
+  int const lastblocknum = data->m_blocknum + data->m_config->m_prefetchcount;
+
+  // Skip blocks already scheduled this request; re-issuing them races the inline reads.
+  if (nextblocknum <= data->m_prefetch_hwm) {
+    nextblocknum = data->m_prefetch_hwm + 1;
+  }
+
+  for (int i = nextblocknum; i <= lastblocknum; i++) {
     if (data->m_req_range.blockIsInside(data->m_config->m_blockbytes, i)) {
       if (BgBlockFetch::schedule(data, i, url)) {
         DEBUG_LOG("Background fetch requested");
@@ -75,6 +82,10 @@ schedule_prefetch(Data *const data)
         DEBUG_LOG("Background fetch not requested");
       }
     }
+  }
+
+  if (lastblocknum > data->m_prefetch_hwm) {
+    data->m_prefetch_hwm = lastblocknum;
   }
 
   TSfree(urlstr);

--- a/plugins/slice/util.cc
+++ b/plugins/slice/util.cc
@@ -61,22 +61,22 @@ schedule_prefetch(Data *const data)
   }
 
   std::string_view const url(urlstr, urllen);
-  int                    nextblocknum = data->m_blocknum + 1;
+  int64_t                nextblocknum = data->m_blocknum + 1;
 
   if (data->m_blocknum > data->m_req_range.firstBlockFor(data->m_config->m_blockbytes) + 1) {
     nextblocknum = data->m_blocknum + data->m_config->m_prefetchcount;
   }
 
-  int const lastblocknum = data->m_blocknum + data->m_config->m_prefetchcount;
+  int64_t const lastblocknum = data->m_blocknum + data->m_config->m_prefetchcount;
 
   // Skip blocks already scheduled this request; re-issuing them races the inline reads.
   if (nextblocknum <= data->m_prefetch_hwm) {
     nextblocknum = data->m_prefetch_hwm + 1;
   }
 
-  for (int i = nextblocknum; i <= lastblocknum; i++) {
+  for (int64_t i = nextblocknum; i <= lastblocknum; i++) {
     if (data->m_req_range.blockIsInside(data->m_config->m_blockbytes, i)) {
-      if (BgBlockFetch::schedule(data, i, url)) {
+      if (BgBlockFetch::schedule(data, static_cast<int>(i), url)) {
         DEBUG_LOG("Background fetch requested");
       } else {
         DEBUG_LOG("Background fetch not requested");

--- a/tests/gold_tests/pluginTest/slice/gold/slice_prefetch.gold
+++ b/tests/gold_tests/pluginTest/slice/gold/slice_prefetch.gold
@@ -20,6 +20,7 @@ bytes 0-4/18 miss
 bytes ``/18 miss
 bytes ``/18 miss
 bytes ``/18 miss
+bytes 10-14/18 hit-fresh
 bytes 15-17/18 hit-fresh
 bytes 5-16/18 miss, none
 bytes 0-6/18 hit-fresh


### PR DESCRIPTION
schedule_prefetch() ran on every server response and re-issued blocks already scheduled this request, which the in-flight dedup set does not catch. Track a per-request high-water mark so each block is prefetched at most once; update the slice_prefetch gold. Supersedes #13212.