### PR TITLE
header_rewrite: Fix IPv6 CIDR masking for non-aligned prefixes

### DIFF
--- a/plugins/header_rewrite/cidr.h
+++ b/plugins/header_rewrite/cidr.h
@@ -1,0 +1,54 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+// CIDR masking helpers for %{CIDR:...}, kept header-only for unit testing.
+#pragma once
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <cstdint>
+#include <cstring>
+
+// /0 yields a 0 mask, avoiding the undefined `<< 32`.
+inline in_addr_t
+cidr_v4_mask(int prefix)
+{
+  return prefix ? htonl(UINT32_MAX << (32 - prefix)) : 0;
+}
+
+// Trailing bytes to clear, plus a high-bit mask for the partial byte (0xff if aligned).
+inline void
+cidr_v6_params(int prefix, int &zero_bytes, unsigned char &mask)
+{
+  int const rem_bits = prefix % 8;
+
+  zero_bytes = (128 - prefix) / 8;
+  mask       = rem_bits ? static_cast<unsigned char>(0xff << (8 - rem_bits)) : 0xff;
+}
+
+// Clear the trailing zero_bytes, then keep the high bits of the byte above them.
+inline void
+cidr_apply_v6(in6_addr &addr, int zero_bytes, unsigned char mask)
+{
+  if (zero_bytes > 0) {
+    memset(&addr.s6_addr[16 - zero_bytes], 0, zero_bytes);
+  }
+  if (mask != 0xff) {
+    addr.s6_addr[16 - zero_bytes - 1] &= mask;
+  }
+}

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -35,6 +35,7 @@
 #include "ts/ts.h"
 
 #include "conditions.h"
+#include "cidr.h"
 #include "lulu.h"
 
 static const sockaddr *getClientAddr(TSHttpTxn txnp, int txn_private_slot);
@@ -1026,8 +1027,7 @@ ConditionCidr::set_qualifier(const std::string &q)
   Dbg(pi_dbg_ctl, "\tParsing %%{CIDR:%s} qualifier", q.c_str());
   cidr = strtol(q.c_str(), &endp, 10);
   if (cidr >= 0 && cidr <= 32) {
-    _v4_mask.s_addr = UINT32_MAX >> (32 - cidr);
-    _v4_cidr        = cidr;
+    _v4_cidr = cidr;
     if (endp && (*endp == ',' || *endp == '/' || *endp == ':')) {
       cidr = strtol(endp + 1, nullptr, 10);
       if (cidr >= 0 && cidr <= 128) {
@@ -1080,12 +1080,7 @@ ConditionCidr::append_value(std::string &s, const Resources &res)
       char            resource[INET6_ADDRSTRLEN];
       struct in6_addr ipv6 = reinterpret_cast<const struct sockaddr_in6 *>(addr)->sin6_addr;
 
-      if (_v6_zero_bytes > 0) {
-        memset(&ipv6.s6_addr[16 - _v6_zero_bytes], 0, _v6_zero_bytes);
-      }
-      if (_v6_mask != 0xff) {
-        ipv6.s6_addr[16 - _v6_zero_bytes] &= _v6_mask;
-      }
+      cidr_apply_v6(ipv6, _v6_zero_bytes, _v6_mask);
       inet_ntop(AF_INET6, &ipv6, resource, INET6_ADDRSTRLEN);
       if (resource[0]) {
         s += resource;
@@ -1101,9 +1096,8 @@ ConditionCidr::append_value(std::string &s, const Resources &res)
 void
 ConditionCidr::_create_masks()
 {
-  _v4_mask.s_addr = htonl(UINT32_MAX << (32 - _v4_cidr));
-  _v6_zero_bytes  = (128 - _v6_cidr) / 8;
-  _v6_mask        = 0xff >> ((128 - _v6_cidr) % 8);
+  _v4_mask.s_addr = cidr_v4_mask(_v4_cidr);
+  cidr_v6_params(_v6_cidr, _v6_zero_bytes, _v6_mask);
 }
 
 void

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -26,8 +26,11 @@
 #include <iostream>
 #include <ostream>
 #include <sys/stat.h>
+#include <string>
+#include <utility>
 
 #include "parser.h"
+#include "cidr.h"
 
 #if TS_USE_HRW_MAXMINDDB
 #include <maxminddb.h>
@@ -728,10 +731,81 @@ test_maxmind_geo()
 }
 #endif
 
+static std::string
+cidr_mask_v6_str(const char *addr_str, int prefix)
+{
+  in6_addr addr;
+
+  inet_pton(AF_INET6, addr_str, &addr);
+
+  int           zero_bytes = 0;
+  unsigned char mask       = 0;
+
+  cidr_v6_params(prefix, zero_bytes, mask);
+  cidr_apply_v6(addr, zero_bytes, mask);
+
+  char out[INET6_ADDRSTRLEN];
+
+  inet_ntop(AF_INET6, &addr, out, sizeof(out));
+
+  return std::string(out);
+}
+
+int
+test_cidr()
+{
+  int errors = 0;
+
+  // IPv4 masks, in network byte order. /0 must be 0 (and must not shift by 32).
+  const std::pair<int, in_addr_t> v4cases[] = {
+    {0,  0                 },
+    {24, htonl(0xFFFFFF00u)},
+    {32, htonl(0xFFFFFFFFu)},
+  };
+
+  for (auto const &[prefix, expect] : v4cases) {
+    in_addr_t const got = cidr_v4_mask(prefix);
+
+    if (got != expect) {
+      std::cerr << "FAIL: cidr_v4_mask(/" << prefix << ") = " << std::hex << got << ", expected " << expect << std::dec
+                << std::endl;
+      ++errors;
+    } else {
+      std::cout << "  PASS: cidr_v4_mask(/" << prefix << ")" << std::endl;
+    }
+  }
+
+  // IPv6 masks. The source has bits set in every byte so non-byte-aligned
+  // prefixes (the actual regression) produce distinct results.
+  const char                        *src       = "2001:db8:abcd:ef13:3456:789a:bcde:f012";
+  const std::pair<int, const char *> v6cases[] = {
+    {128, "2001:db8:abcd:ef13:3456:789a:bcde:f012"},
+    {64,  "2001:db8:abcd:ef13::"                  },
+    {63,  "2001:db8:abcd:ef12::"                  },
+    {60,  "2001:db8:abcd:ef10::"                  },
+    {52,  "2001:db8:abcd:e000::"                  },
+    {48,  "2001:db8:abcd::"                       },
+    {0,   "::"                                    },
+  };
+
+  for (auto const &[prefix, expect] : v6cases) {
+    std::string const got = cidr_mask_v6_str(src, prefix);
+
+    if (got != expect) {
+      std::cerr << "FAIL: " << src << " /" << prefix << " = " << got << ", expected " << expect << std::endl;
+      ++errors;
+    } else {
+      std::cout << "  PASS: " << src << " /" << prefix << " = " << got << std::endl;
+    }
+  }
+
+  return errors;
+}
+
 int
 main()
 {
-  if (test_parsing() || test_processing() || test_tokenizer()) {
+  if (test_parsing() || test_processing() || test_tokenizer() || test_cidr()) {
     return 1;
   }
 

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
@@ -176,6 +176,13 @@ autest:
             args:
               - "rules/rule_session_vars.conf"
 
+      - from: "http://www.example.com/from_18/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/to_18/"
+        plugins:
+          - name: "header_rewrite.so"
+            args:
+              - "rules/rule_cidr.conf"
+
     log_validation:
       traffic_out:
         excludes:
@@ -1936,3 +1943,34 @@ sessions:
       headers:
         fields:
         - [ X-Session-Seen, { value: "yes", as: equal } ]
+
+# Test 67: CIDR condition - IPv4 masking of the 127.0.0.1 client address.
+# /32 keeps the full address, /24 masks the last octet, /0 collapses to
+# 0.0.0.0 (also guards the former shift-by-32 UB). The two-mask form exercises
+# the IPv6 field parsing; ',40' (empty IPv4 field) parses as a /0 IPv4 mask.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /from_18/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, 67 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Cidr-32, { value: "127.0.0.1", as: equal } ]
+        - [ X-Cidr-24, { value: "127.0.0.0", as: equal } ]
+        - [ X-Cidr-0, { value: "0.0.0.0", as: equal } ]
+        - [ X-Cidr-Two-Mask, { value: "127.0.0.0", as: equal } ]
+        - [ X-Cidr-Empty-V4, { value: "0.0.0.0", as: equal } ]

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/rule_cidr.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/rule_cidr.conf
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exercise %{CIDR:...}. The verifier client is 127.0.0.1, so only IPv4 masking
+# is observable here; IPv6 masking is covered by the unit tests.
+cond %{SEND_RESPONSE_HDR_HOOK}
+  set-header X-Cidr-32 %{CIDR:32}
+  set-header X-Cidr-24 %{CIDR:24}
+  set-header X-Cidr-0 %{CIDR:0}
+  set-header X-Cidr-Two-Mask %{CIDR:24,60}
+  set-header X-Cidr-Empty-V4 %{CIDR:,40}


### PR DESCRIPTION
ConditionCidr masked the byte that was just zeroed instead of the partial-prefix byte, and kept the low bits instead of the high bits, so any IPv6 prefix not a multiple of 8 (e.g. /60) was silently rounded up to the next byte boundary. Mask the byte above the zeroed region with a high-bit mask, and define the IPv4 /0 case, which was a shift-by-32 (undefined behavior).

The masking math now lives in a header-only, TS-API-free cidr.h so it can be unit-tested directly. Adds unit tests for IPv4 /0,/24,/32 and IPv6 /0,/48,/52,/60,/63,/64,/128, plus IPv4 CIDR cases in the header_rewrite bundle replay; the verifier client is IPv4 only, so IPv6 masking is covered by the unit test.