### PR TITLE
Doc: fix cache dir sync_max_write record name

### DIFF
--- a/doc/admin-guide/files/records.yaml.en.rst
+++ b/doc/admin-guide/files/records.yaml.en.rst
@@ -2764,7 +2764,7 @@ Cache Control
    a minimum time, and the actual sync may be delayed if the disks are larger than
    how fast we allow it to write to disk (see next options).
 
-.. ts:cv:: CONFIG proxy.config.cache.dir.sync_max_writes INT 2097152
+.. ts:cv:: CONFIG proxy.config.cache.dir.sync_max_write INT 2097152
    :units: bytes
 
    How much of a stripes cache directory we will write to disk in each write cycle.


### PR DESCRIPTION
The records.yaml docs listed proxy.config.cache.dir.sync_max_writes (plural), but the actual registered record is sync_max_write (singular).

https://github.com/apache/trafficserver/blob/464c61349a3ba9d251ad8f36c884e39c912dbd28/src/records/RecordsConfig.cc#L874
