### PR TITLE
Fix data race in SSLCertContext copy & assignment

### DIFF
--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -34,6 +34,7 @@
 #include "P_SSLUtils.h"
 
 #include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -234,24 +235,24 @@ fail:
 
 SSLCertContext::SSLCertContext(SSLCertContext const &other)
 {
+  std::shared_lock lock(other.ctx_mutex);
   opt        = other.opt;
   userconfig = other.userconfig;
   keyblock   = other.keyblock;
   ctx_type   = other.ctx_type;
-  std::shared_lock lock(other.ctx_mutex);
-  ctx = other.ctx;
+  ctx        = other.ctx;
 }
 
 SSLCertContext &
 SSLCertContext::operator=(SSLCertContext const &other)
 {
   if (&other != this) {
+    std::scoped_lock lock(this->ctx_mutex, other.ctx_mutex);
     this->opt        = other.opt;
     this->userconfig = other.userconfig;
     this->keyblock   = other.keyblock;
     this->ctx_type   = other.ctx_type;
-    std::shared_lock lock(other.ctx_mutex);
-    this->ctx = other.ctx;
+    this->ctx        = other.ctx;
   }
   return *this;
 }


### PR DESCRIPTION
Resolve concurrent read/write data races by using std::scoped_lock in operator= and locking other.ctx_mutex at the start of the copy constructor.

1. Replaced the manual lock definition and sequence with std::scoped_lock

2. Pushed lock guard to beginning to avoid source mutation during read to avoid data race by threads
[ISSUE #13225](https://github.com/apache/trafficserver/issues/13225#issuecomment-4605557677)