### PR TITLE
Sync CacheDir on shutdown

### DIFF
--- a/src/iocore/cache/StripeSM.cc
+++ b/src/iocore/cache/StripeSM.cc
@@ -1323,7 +1323,7 @@ StripeSM::shutdown(EThread *shutdown_thread)
   // the process is going down, do a blocking call
   // dont release the volume's lock, there could
   // be another aggWrite in progress
-  MUTEX_TAKE_LOCK(this->mutex, shutdown_thread);
+  SCOPED_MUTEX_LOCK(lock, this->mutex, shutdown_thread);
 
   if (DISK_BAD(this->disk)) {
     Dbg(dbg_ctl_cache_dir_sync, "Dir %s: ignoring -- bad disk", this->hash_text.get());

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -85,6 +85,7 @@ extern "C" int plock(int);
 #include "../iocore/net/P_SSLUtils.h"
 #include "../iocore/dns/P_SplitDNSProcessor.h"
 #include "../iocore/hostdb/P_HostDB.h"
+#include "../iocore/cache/P_CacheDir.h"
 #include "../records/P_RecCore.h"
 #include "tscore/Layout.h"
 #include "iocore/utils/Machine.h"
@@ -285,6 +286,11 @@ struct AutoStopCont : public Continuation {
     // if the jsonrpc feature was disabled, the object will not be created.
     if (jsonrpcServer != nullptr) {
       jsonrpcServer->stop_thread();
+    }
+
+    // Flush the in-memory cache directory to disk
+    if (cacheProcessor.IsCacheEnabled() == CacheInitState::INITIALIZED) {
+      sync_cache_dir_on_shutdown();
     }
 
     // Push buffered log entries into the preproc queue before shutdown.


### PR DESCRIPTION
In the past, it's used be called by `traffic_manager`, but it's gone.