### PR TITLE
Fix build: TLS log fields use m_data, not m_http_sm

### DIFF
--- a/include/proxy/logging/TransactionLogData.h
+++ b/include/proxy/logging/TransactionLogData.h
@@ -107,6 +107,11 @@ public:
   int64_t get_cache_response_body_bytes() const;
   int64_t get_cache_response_hdr_bytes() const;
 
+  // ===== TLS handshake byte counters =====
+  uint64_t get_client_tls_handshake_bytes_rx() const;
+  uint64_t get_client_tls_handshake_bytes_tx() const;
+  size_t   get_client_tls_early_data_len() const;
+
   // ===== Transaction identifiers =====
   int64_t get_sm_id() const;
   int64_t get_connection_id() const;

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -2245,12 +2245,12 @@ LogAccess::marshal_client_req_squid_len_tls(char *buf)
     int64_t val = 0;
 
     if (m_client_request) {
-      val = m_client_request->length_get() + m_http_sm->client_request_body_bytes;
+      val = m_client_request->length_get() + m_data->get_client_request_body_bytes();
     }
 
-    if (!m_http_sm->get_user_agent().get_client_tcp_reused()) {
-      uint64_t handshake_rx   = m_http_sm->get_user_agent().get_client_tls_handshake_bytes_rx();
-      size_t   early_data_len = m_http_sm->get_user_agent().get_client_tls_early_data_len();
+    if (!m_data->get_client_tcp_reused()) {
+      uint64_t handshake_rx   = m_data->get_client_tls_handshake_bytes_rx();
+      size_t   early_data_len = m_data->get_client_tls_early_data_len();
 
       if (early_data_len > 0) {
         handshake_rx -= std::min(handshake_rx, static_cast<uint64_t>(early_data_len));
@@ -2479,7 +2479,7 @@ int
 LogAccess::marshal_client_tls_handshake_bytes_rx(char *buf)
 {
   if (buf) {
-    marshal_int(buf, static_cast<int64_t>(m_http_sm->get_user_agent().get_client_tls_handshake_bytes_rx()));
+    marshal_int(buf, static_cast<int64_t>(m_data->get_client_tls_handshake_bytes_rx()));
   }
   return INK_MIN_ALIGN;
 }
@@ -2491,7 +2491,7 @@ int
 LogAccess::marshal_client_tls_handshake_bytes_tx(char *buf)
 {
   if (buf) {
-    marshal_int(buf, static_cast<int64_t>(m_http_sm->get_user_agent().get_client_tls_handshake_bytes_tx()));
+    marshal_int(buf, static_cast<int64_t>(m_data->get_client_tls_handshake_bytes_tx()));
   }
   return INK_MIN_ALIGN;
 }
@@ -2503,8 +2503,7 @@ int
 LogAccess::marshal_client_tls_handshake_bytes(char *buf)
 {
   if (buf) {
-    uint64_t total = m_http_sm->get_user_agent().get_client_tls_handshake_bytes_rx() +
-                     m_http_sm->get_user_agent().get_client_tls_handshake_bytes_tx();
+    uint64_t total = m_data->get_client_tls_handshake_bytes_rx() + m_data->get_client_tls_handshake_bytes_tx();
     marshal_int(buf, static_cast<int64_t>(total));
   }
   return INK_MIN_ALIGN;
@@ -2557,10 +2556,10 @@ int
 LogAccess::marshal_proxy_resp_squid_len_tls(char *buf)
 {
   if (buf) {
-    int64_t val = m_http_sm->client_response_hdr_bytes + m_http_sm->client_response_body_bytes;
+    int64_t val = m_data->get_client_response_hdr_bytes() + m_data->get_client_response_body_bytes();
 
-    if (!m_http_sm->get_user_agent().get_client_tcp_reused()) {
-      val += m_http_sm->get_user_agent().get_client_tls_handshake_bytes_tx();
+    if (!m_data->get_client_tcp_reused()) {
+      val += m_data->get_client_tls_handshake_bytes_tx();
     }
     marshal_int(buf, val);
   }

--- a/src/proxy/logging/TransactionLogData.cc
+++ b/src/proxy/logging/TransactionLogData.cc
@@ -738,6 +738,33 @@ TransactionLogData::get_client_tcp_reused() const
   return false;
 }
 
+uint64_t
+TransactionLogData::get_client_tls_handshake_bytes_rx() const
+{
+  if (likely(m_http_sm != nullptr)) {
+    return m_http_sm->get_user_agent().get_client_tls_handshake_bytes_rx();
+  }
+  return 0;
+}
+
+uint64_t
+TransactionLogData::get_client_tls_handshake_bytes_tx() const
+{
+  if (likely(m_http_sm != nullptr)) {
+    return m_http_sm->get_user_agent().get_client_tls_handshake_bytes_tx();
+  }
+  return 0;
+}
+
+size_t
+TransactionLogData::get_client_tls_early_data_len() const
+{
+  if (likely(m_http_sm != nullptr)) {
+    return m_http_sm->get_user_agent().get_client_tls_early_data_len();
+  }
+  return 0;
+}
+
 bool
 TransactionLogData::get_client_connection_is_ssl() const
 {


### PR DESCRIPTION
m_http_sm was removed from LogAccess by #13059 (TransactionLogData).