### PR TITLE
Remove last open read cache

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/cache-volume.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/cache-volume.en.rst
@@ -130,12 +130,7 @@ a configuration with only one cache volume: :literal:`0`.
 .. ts:stat:: global proxy.process.cache.volume_0.ram_cache.misses integer
    :type: counter
 
-   Accumulates the number of misses to the LRU RAM cache for this volume.  Note that this count includes hits to the other memory caches, including the last open read and aggregation buffer caches, so it may not represent the total number of cache accesses that go to disk.
-
-.. ts:stat:: global proxy.process.cache.volume_0.last_open_read.hits integer
-   :type: counter
-
-   Accumulates the number of hits to the last open read cache for this volume.  This cache stores the most recent read operation for each open cache volume.
+   Accumulates the number of misses to the LRU RAM cache for this volume.  Note that this count includes hits to the other memory caches, including the aggregation buffer caches, so it may not represent the total number of cache accesses that go to disk.
 
 .. ts:stat:: global proxy.process.cache.volume_0.aggregation_buffer.hits integer
    :type: counter
@@ -145,7 +140,7 @@ a configuration with only one cache volume: :literal:`0`.
 .. ts:stat:: global proxy.process.cache.volume_0.all_memory_caches.misses integer
    :type: counter
 
-   Accumulates the number of misses to all memory caches (LRU RAM cache, last open read cache, and aggregation buffer) for this volume.  This represents the total number of cache accesses that go to disk for this volume.
+   Accumulates the number of misses to all memory caches (LRU RAM cache and aggregation buffer) for this volume.  This represents the total number of cache accesses that go to disk for this volume.
 
 .. ts:stat:: global proxy.process.cache.volume_0.ram_cache.total_bytes integer
    :type: gauge

--- a/doc/admin-guide/monitoring/statistics/core/cache.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/cache.en.rst
@@ -93,12 +93,7 @@ Cache
 .. ts:stat:: global proxy.process.cache.ram_cache.misses integer
    :type: counter
 
-   Accumulates the number of misses to the LRU RAM cache for all volumes.  Note that this includes hits to the other memory caches, including the last open read and aggregation buffer caches, so it may not represent the total number of cache accesses that go to disk.
-
-.. ts:stat:: global proxy.process.cache.last_open_read.hits integer
-   :type: counter
-
-   Accumulates the number of hits to the last open read cache for all volumes.  This cache stores the most recent read operation for each open cache volume.
+   Accumulates the number of misses to the LRU RAM cache for all volumes.  Note that this includes hits to the other memory caches, including the aggregation buffer caches, so it may not represent the total number of cache accesses that go to disk.
 
 .. ts:stat:: global proxy.process.cache.aggregation_buffer.hits integer
    :type: counter
@@ -108,7 +103,7 @@ Cache
 .. ts:stat:: global proxy.process.cache.all_memory_caches.misses integer
    :type: counter
 
-   Accumulates the number of misses to all memory caches (LRU RAM cache, last open read cache, and aggregation buffer) for all volumes.  This represents the total number of cache accesses that go to disk.
+   Accumulates the number of misses to all memory caches (LRU RAM cache and aggregation buffer) for all volumes.  This represents the total number of cache accesses that go to disk.
 
 .. ts:stat:: global proxy.process.cache.ram_cache.total_bytes integer
 .. ts:stat:: global proxy.process.cache.read.active integer

--- a/src/iocore/cache/CacheProcessor.cc
+++ b/src/iocore/cache/CacheProcessor.cc
@@ -1176,7 +1176,6 @@ register_cache_stats(CacheStatsBlock *rsb, const std::string &prefix)
   rsb->ram_cache_bytes_total  = ts::Metrics::Gauge::createPtr(prefix + ".ram_cache.total_bytes");
   rsb->ram_cache_bytes        = ts::Metrics::Gauge::createPtr(prefix + ".ram_cache.bytes_used");
   rsb->ram_cache_hits         = ts::Metrics::Counter::createPtr(prefix + ".ram_cache.hits");
-  rsb->last_open_read_hits    = ts::Metrics::Counter::createPtr(prefix + ".last_open_read.hits");
   rsb->agg_buffer_hits        = ts::Metrics::Counter::createPtr(prefix + ".aggregation_buffer.hits");
   rsb->ram_cache_misses       = ts::Metrics::Counter::createPtr(prefix + ".ram_cache.misses");
   rsb->all_mem_misses         = ts::Metrics::Counter::createPtr(prefix + ".all_memory_caches.misses");

--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -428,14 +428,6 @@ CacheVC::handleReadDone(int event, Event * /* e ATS_UNUSED */)
           uint64_t o = dir_offset(&dir);
           stripe->ram_cache->put(read_key, buf.get(), doc->len, http_copy_hdr, o);
         }
-        if (!doc_len) {
-          // keep a pointer to it. In case the state machine decides to
-          // update this document, we don't have to read it back in memory
-          // again
-          stripe->first_fragment_key    = *read_key;
-          stripe->first_fragment_offset = dir_offset(&dir);
-          stripe->first_fragment_data   = buf;
-        }
       } // end VIO::READ check
       // If it could be compressed, unmarshal after
       if (http_copy_hdr && doc->doc_type == CACHE_FRAG_TYPE_HTTP && doc->hlen && okay) {
@@ -473,17 +465,7 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     return EVENT_RETURN;
   }
 
-  // 2. check last open read cache
-  if (load_from_last_open_read_call()) {
-    Dbg(dbg_ctl_cache_ram, "last open read hit");
-    f.doc_from_ram_cache = true;
-    io.aio_result        = io.aiocb.aio_nbytes;
-
-    POP_HANDLER;
-    return EVENT_RETURN;
-  }
-
-  // 3. check aggregation buffer
+  // 2. check aggregation buffer
   if (load_from_aggregation_buffer()) {
     Dbg(dbg_ctl_cache_ram, "aggregation buffer hit");
     f.doc_from_ram_cache = true;
@@ -493,7 +475,7 @@ CacheVC::handleRead(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
     return EVENT_RETURN;
   }
 
-  // 4. read from Disk (AIO) due to all memory cache miss
+  // 3. read from Disk (AIO) due to all memory cache miss
   Dbg(dbg_ctl_cache_ram, "all memory cache miss");
 
   ts::Metrics::Counter::increment(cache_rsb.all_mem_misses);
@@ -527,18 +509,6 @@ CacheVC::load_from_ram_cache()
   int     ram_hit_state = this->stripe->ram_cache->get(read_key, &this->buf, static_cast<uint64_t>(o));
   f.compressed_in_ram   = (ram_hit_state > RAM_HIT_COMPRESS_NONE) ? 1 : 0;
   return ram_hit_state >= RAM_HIT_COMPRESS_NONE;
-}
-
-bool
-CacheVC::load_from_last_open_read_call()
-{
-  if (*this->read_key == this->stripe->first_fragment_key && dir_offset(&this->dir) == this->stripe->first_fragment_offset) {
-    this->buf = this->stripe->first_fragment_data;
-    ts::Metrics::Counter::increment(cache_rsb.last_open_read_hits);
-    ts::Metrics::Counter::increment(stripe->cache_vol->vol_rsb.last_open_read_hits);
-    return true;
-  }
-  return false;
 }
 
 bool

--- a/src/iocore/cache/CacheVC.h
+++ b/src/iocore/cache/CacheVC.h
@@ -133,7 +133,6 @@ struct CacheVC : public CacheVConnection {
   int  handleReadDone(int event, Event *e);
   int  handleRead(int event, Event *e);
   bool load_from_ram_cache();
-  bool load_from_last_open_read_call();
   bool load_from_aggregation_buffer();
   int  do_read_call(CacheKey *akey);
   int  handleWrite(int event, Event *e);

--- a/src/iocore/cache/P_CacheStats.h
+++ b/src/iocore/cache/P_CacheStats.h
@@ -45,7 +45,6 @@ struct CacheStatsBlock {
   ts::Metrics::Gauge::AtomicType   *direntries_total       = nullptr;
   ts::Metrics::Gauge::AtomicType   *direntries_used        = nullptr;
   ts::Metrics::Counter::AtomicType *ram_cache_hits         = nullptr;
-  ts::Metrics::Counter::AtomicType *last_open_read_hits    = nullptr;
   ts::Metrics::Counter::AtomicType *agg_buffer_hits        = nullptr;
   ts::Metrics::Counter::AtomicType *ram_cache_misses       = nullptr;
   ts::Metrics::Counter::AtomicType *all_mem_misses         = nullptr;

--- a/src/iocore/cache/StripeSM.h
+++ b/src/iocore/cache/StripeSM.h
@@ -144,10 +144,6 @@ public:
   CacheSync *waiting_dir_sync     = nullptr;
   bool       writing_end_marker   = false;
 
-  CacheKey          first_fragment_key;
-  int64_t           first_fragment_offset = 0;
-  Ptr<IOBufferData> first_fragment_data;
-
   void cancel_trigger();
 
   int recover_data();


### PR DESCRIPTION
It was discussed in #13061 that the one disk read rarely saved with the last open read cache is probably fine on today's SSDs. Removing the optimization simplifies the cache. 

 Fixes #13095