### PR TITLE
Fix compilation under `LOOP_CHECK_MODE`

### DIFF
--- a/src/iocore/cache/CacheDir.cc
+++ b/src/iocore/cache/CacheDir.cc
@@ -308,7 +308,7 @@ dir_clean_bucket(Dir *b, int s, StripeSM *stripe)
 #ifdef LOOP_CHECK_MODE
     loop_count++;
     if (loop_count > DIR_LOOP_THRESHOLD) {
-      if (vol->directory.bucket_loop_fix(b, s))
+      if (stripe->directory.bucket_loop_fix(b, s))
         return;
     }
 #endif

--- a/src/iocore/cache/unit_tests/test_CacheDir.cc
+++ b/src/iocore/cache/unit_tests/test_CacheDir.cc
@@ -169,58 +169,58 @@ public:
 #ifdef LOOP_CHECK_MODE
       // probe in bucket with loop
       rand_CacheKey(&key);
-      s1 = key.slice32(0) % vol->segments;
-      b1 = key.slice32(1) % vol->buckets;
-      dir_corrupt_bucket(dir_bucket(b1, vol->directory.get_segment(s1)), s1, vol);
-      stripe->directory.insert(&key, vol, &dir);
+      s1 = key.slice32(0) % stripe->directory.segments;
+      b1 = key.slice32(1) % stripe->directory.buckets;
+      dir_corrupt_bucket(dir_bucket(b1, stripe->directory.get_segment(s1)), s1, stripe);
+      stripe->directory.insert(&key, stripe, &dir);
       Dir *last_collision = 0;
-      vol->directory.probe(&key, vol, &dir, &last_collision);
+      stripe->directory.probe(&key, stripe, &dir, &last_collision);
 
       rand_CacheKey(&key);
-      s1 = key.slice32(0) % vol->segments;
-      b1 = key.slice32(1) % vol->buckets;
-      dir_corrupt_bucket(dir_bucket(b1, vol->directory.get_segment(s1)), s1, vol);
+      s1 = key.slice32(0) % stripe->directory.segments;
+      b1 = key.slice32(1) % stripe->directory.buckets;
+      dir_corrupt_bucket(dir_bucket(b1, stripe->directory.get_segment(s1)), s1, stripe);
 
       last_collision = 0;
-      vol->directory.probe(&key, vol, &dir, &last_collision);
+      stripe->directory.probe(&key, stripe, &dir, &last_collision);
 
       // overwrite in bucket with loop
       rand_CacheKey(&key);
-      s1 = key.slice32(0) % vol->segments;
-      b1 = key.slice32(1) % vol->buckets;
+      s1 = key.slice32(0) % stripe->directory.segments;
+      b1 = key.slice32(1) % stripe->directory.buckets;
       CacheKey key1;
       key1.b[1] = 127;
       dir1      = dir;
       dir_set_offset(&dir1, 23);
-      stripe->directory.insert(&key1, vol, &dir1);
-      stripe->directory.insert(&key, vol, &dir);
+      stripe->directory.insert(&key1, stripe, &dir1);
+      stripe->directory.insert(&key, stripe, &dir);
       key1.b[1] = 80;
-      stripe->directory.insert(&key1, vol, &dir1);
-      dir_corrupt_bucket(dir_bucket(b1, vol->directory.get_segment(s1)), s1, vol);
-      vol->directory.overwrite(&key, vol, &dir, &dir, 1);
+      stripe->directory.insert(&key1, stripe, &dir1);
+      dir_corrupt_bucket(dir_bucket(b1, stripe->directory.get_segment(s1)), s1, stripe);
+      stripe->directory.overwrite(&key, stripe, &dir, &dir, 1);
 
       rand_CacheKey(&key);
-      s1       = key.slice32(0) % vol->segments;
-      b1       = key.slice32(1) % vol->buckets;
+      s1       = key.slice32(0) % stripe->directory.segments;
+      b1       = key.slice32(1) % stripe->directory.buckets;
       key.b[1] = 23;
-      stripe->directory.insert(&key, vol, &dir1);
-      dir_corrupt_bucket(dir_bucket(b1, vol->directory.get_segment(s1)), s1, vol);
-      vol->directory.overwrite(&key, vol, &dir, &dir, 0);
+      stripe->directory.insert(&key, stripe, &dir1);
+      dir_corrupt_bucket(dir_bucket(b1, stripe->directory.get_segment(s1)), s1, stripe);
+      stripe->directory.overwrite(&key, stripe, &dir, &dir, 0);
 
       rand_CacheKey(&key);
-      s1        = key.slice32(0) % vol->segments;
-      Dir *seg1 = vol->directory.get_segment(s1);
+      s1        = key.slice32(0) % stripe->directory.segments;
+      Dir *seg1 = stripe->directory.get_segment(s1);
       // freelist_length in freelist with loop
-      dir_corrupt_bucket(dir_from_offset(vol->header->freelist[s], seg1), s1, vol);
-      vol->directory.freelist_length(s1);
+      dir_corrupt_bucket(dir_from_offset(stripe->directory.header->freelist[s], seg1), s1, stripe);
+      stripe->directory.freelist_length(s1);
 
       rand_CacheKey(&key);
-      s1 = key.slice32(0) % vol->segments;
-      b1 = key.slice32(1) % vol->buckets;
+      s1 = key.slice32(0) % stripe->directory.segments;
+      b1 = key.slice32(1) % stripe->directory.buckets;
       // bucket_length in bucket with loop
-      dir_corrupt_bucket(dir_bucket(b1, vol->directory.get_segment(s1)), s1, vol);
-      vol->directory.bucket_length(dir_bucket(b1, vol->directory.get_segment(s1)), s1, vol);
-      CHECK(vol->directory.check());
+      dir_corrupt_bucket(dir_bucket(b1, stripe->directory.get_segment(s1)), s1, stripe);
+      stripe->directory.bucket_length(dir_bucket(b1, stripe->directory.get_segment(s1)), s1);
+      CHECK(stripe->directory.check());
 #else
       // test corruption detection
       rand_CacheKey(&key);


### PR DESCRIPTION
In earlier work, `vol` was renamed to `stripe` throughout the cache. A few occurences of `vol` were missed because they are conditionally compiled. This patch renames `vol` to `stripe` within code switched by the `LOOP_CHECK_MODE` definition.

I compiled with `LOOP_CHECK_MODE`, confirmed the compilation failure in `master`, and confirmed the fix. I also ran the CacheDir tests, which passed. It would have been better to run some AuTests as well for this patch, but I don't have a way to run them on my setup yet.