### PR TITLE
authproxy: Release client request handle in StateAuthorized

### DIFF
--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -661,6 +661,8 @@ StateAuthorized(AuthRequestContext *auth, void *)
       TSHandleMLocRelease(auth->rheader.buffer, auth->rheader.header, field_loc);
       field_loc = next_field_loc;
     }
+
+    TSHandleMLocRelease(request_bufp, TS_NULL_MLOC, request_hdr);
   }
 
   // Proceed with the modified request


### PR DESCRIPTION
TSHttpTxnClientReqGet was not paired with TSHandleMLocRelease, unlike every other call site in this file. The handle is a top-level HTTP_HEADER mloc so the release is effectively a no-op today, but matching the documented API contract avoids surprises if the SDK implementation ever changes.