### PR TITLE
Fix bounds check in CacheVC::scanObject

### DIFF
--- a/src/iocore/cache/CacheVC.cc
+++ b/src/iocore/cache/CacheVC.cc
@@ -766,9 +766,17 @@ CacheVC::scanObject(int /* event ATS_UNUSED */, Event * /* e ATS_UNUSED */)
       }
       break;
     }
-    if (doc->data() - buf->data() > static_cast<int>(io.aiocb.aio_nbytes)) {
-      might_need_overlap_read = true;
-      goto Lskip;
+    {
+      size_t const doc_off = reinterpret_cast<char *>(doc) - buf->data();
+      // Bounds-check in unsigned domain: doc must lie within the
+      // buffer, with room for the Doc header, and doc->hlen must
+      // fit in the remaining bytes before doc->hdr() and
+      // HTTPInfo::unmarshal walk it.
+      if (io.aiocb.aio_nbytes < doc_off || (io.aiocb.aio_nbytes - doc_off) < sizeof(Doc) ||
+          (io.aiocb.aio_nbytes - doc_off - sizeof(Doc)) < doc->hlen) {
+        might_need_overlap_read = true;
+        goto Lskip;
+      }
     }
     {
       char *tmp = doc->hdr();


### PR DESCRIPTION
Fix bounds check in CacheVC::scanObject, requires on disk corruption.

The prior check compared doc->data() - buf->data() against io.aiocb.aio_nbytes cast to int. The pointer arithmetic could wrap when doc->hlen (read from disk) was very large, and the int cast truncated size_t buffer sizes, so the check could pass while doc->hdr() and the subsequent HTTPInfo::unmarshal walked memory past the I/O buffer.                                                         
                                                                                
Re-express the check in the unsigned size_t domain and validate doc->hlen directly against the bytes remaining after the Doc header, guarding each subtraction so it cannot underflow.