### PR TITLE
[9.2.x] Backport format scripts fixes

### DIFF
--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -40,7 +40,8 @@ function main() {
     pip install -q virtualenv
   fi
 
-  AUTOPEP8_VENV=${AUTOPEP8_VENV:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_COMMON_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
   if [ ! -e ${AUTOPEP8_VENV} ]
   then
     virtualenv ${AUTOPEP8_VENV}
@@ -115,5 +116,6 @@ function main() {
 if [[ "$(basename -- "$0")" == 'autopep8.sh' ]]; then
   main "$@"
 else
-  AUTOPEP8_VENV=${AUTOPEP8_VENV:-$(git rev-parse --show-toplevel)/.git/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_COMMON_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
 fi

--- a/tools/autopep8.sh
+++ b/tools/autopep8.sh
@@ -40,8 +40,8 @@ function main() {
     pip install -q virtualenv
   fi
 
-  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
-  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_COMMON_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
+  GIT_DIR=$(git rev-parse --absolute-git-dir)
+  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
   if [ ! -e ${AUTOPEP8_VENV} ]
   then
     virtualenv ${AUTOPEP8_VENV}
@@ -116,6 +116,6 @@ function main() {
 if [[ "$(basename -- "$0")" == 'autopep8.sh' ]]; then
   main "$@"
 else
-  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
-  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_COMMON_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
+  GIT_DIR=$(git rev-parse --absolute-git-dir)
+  AUTOPEP8_VENV=${AUTOPEP8_VENV:-${GIT_DIR}/fmt/autopep8_${AUTOPEP8_VERSION}_venv}
 fi

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -24,8 +24,12 @@ PKGDATE="20200514"
 function main() {
   set -e # exit on error
 
-  GIT_DIR=$(git rev-parse --absolute-git-dir)
-  ROOT=${ROOT:-${GIT_DIR}/fmt/${PKGDATE}}
+  # Resolve the common git directory, which is shared by all linked worktrees, so the
+  # downloaded clang-format is cached and found in one place.  --git-common-dir can return a
+  # relative path, so make it absolute without --path-format (which needs git 2.31+); this
+  # matches how CMakeLists.txt resolves GIT_COMMON_DIR.
+  GIT_COMMON_DIR=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
   # The presence of this file indicates clang-format was successfully installed.
   INSTALLED_SENTINEL=${ROOT}/.clang-format-installed
 
@@ -38,7 +42,7 @@ function main() {
       exit 2
     fi
   fi
-  DIR=${@:-.}
+  DIR=${@:-$(git rev-parse --show-toplevel)}
   PACKAGE="clang-format-${PKGDATE}.tar.bz2"
   VERSION="clang-format version 10.0.0 (https://github.com/llvm/llvm-project.git d32170dbd5b0d54436537b6b75beaf44324e0c28)"
 
@@ -120,6 +124,6 @@ EOF
 if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then
   main "$@"
 else
-  GIT_DIR=$(git rev-parse --absolute-git-dir)
-  ROOT=${ROOT:-${GIT_DIR}/fmt/${PKGDATE}}
+  GIT_COMMON_DIR=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
 fi

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -24,8 +24,8 @@ PKGDATE="20200514"
 function main() {
   set -e # exit on error
 
-  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
-  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
+  GIT_DIR=$(git rev-parse --absolute-git-dir)
+  ROOT=${ROOT:-${GIT_DIR}/fmt/${PKGDATE}}
   # The presence of this file indicates clang-format was successfully installed.
   INSTALLED_SENTINEL=${ROOT}/.clang-format-installed
 
@@ -120,6 +120,6 @@ EOF
 if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then
   main "$@"
 else
-  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
-  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
+  GIT_DIR=$(git rev-parse --absolute-git-dir)
+  ROOT=${ROOT:-${GIT_DIR}/fmt/${PKGDATE}}
 fi

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -23,7 +23,9 @@ PKGDATE="20200514"
 
 function main() {
   set -e # exit on error
-  ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
   # The presence of this file indicates clang-format was successfully installed.
   INSTALLED_SENTINEL=${ROOT}/.clang-format-installed
 
@@ -118,5 +120,6 @@ EOF
 if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then
   main "$@"
 else
-  ROOT=${ROOT:-$(git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
 fi

--- a/tools/yapf.sh
+++ b/tools/yapf.sh
@@ -47,7 +47,8 @@ _END_
   fi
 
   REPO_ROOT=$(cd $(dirname $0) && git rev-parse --show-toplevel)
-  YAPF_VENV=${YAPF_VENV:-${REPO_ROOT}/.git/fmt/yapf_${YAPF_VERSION}_venv}
+  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
+  YAPF_VENV=${YAPF_VENV:-${GIT_COMMON_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
   if [ ! -e ${YAPF_VENV} ]
   then
     python3 -m virtualenv ${YAPF_VENV}
@@ -105,5 +106,6 @@ _END_
 if [[ "$(basename -- "$0")" == 'yapf.sh' ]]; then
   main "$@"
 else
-  YAPF_VENV=${YAPF_VENV:-$(git rev-parse --show-toplevel)/.git/fmt/yapf_${YAPF_VERSION}_venv}
+  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
+  YAPF_VENV=${YAPF_VENV:-${GIT_COMMON_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
 fi

--- a/tools/yapf.sh
+++ b/tools/yapf.sh
@@ -47,8 +47,8 @@ _END_
   fi
 
   REPO_ROOT=$(cd $(dirname $0) && git rev-parse --show-toplevel)
-  GIT_COMMON_DIR=$(cd $(dirname $0) && git rev-parse --path-format=absolute --git-common-dir)
-  YAPF_VENV=${YAPF_VENV:-${GIT_COMMON_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
+  GIT_DIR=$(git rev-parse --absolute-git-dir)
+  YAPF_VENV=${YAPF_VENV:-${GIT_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
   if [ ! -e ${YAPF_VENV} ]
   then
     python3 -m virtualenv ${YAPF_VENV}
@@ -106,6 +106,6 @@ _END_
 if [[ "$(basename -- "$0")" == 'yapf.sh' ]]; then
   main "$@"
 else
-  GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir)
-  YAPF_VENV=${YAPF_VENV:-${GIT_COMMON_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
+  GIT_DIR=$(git rev-parse --absolute-git-dir)
+  YAPF_VENV=${YAPF_VENV:-${GIT_DIR}/fmt/yapf_${YAPF_VERSION}_venv}
 fi


### PR DESCRIPTION
Backport #11015 and #11495 to run format scripts in git worktree directories.

Update: plus https://github.com/apache/trafficserver/pull/13302