### PR TITLE
Add per-plugin CPU workload counters

### DIFF
--- a/include/proxy/PluginVC.h
+++ b/include/proxy/PluginVC.h
@@ -40,6 +40,7 @@
 #include "tscore/ink_atomic.h"
 
 class PluginVCCore;
+class PluginThreadContext; // owning intercept plugin (for per-plugin byte accounting)
 
 struct PluginVCState {
   PluginVCState();
@@ -252,6 +253,11 @@ private:
 
   Continuation *connect_to = nullptr;
   bool          connected  = false;
+
+  // The plugin that created this intercept (thread-local pluginThreadContext captured at alloc()),
+  // used to attribute PluginVC transport bytes to proxy.process.plugin.<name>.bytes. May be null
+  // for core-internal PluginVCs.
+  PluginThreadContext *_owner = nullptr;
 
   IpEndpoint passive_addr_struct;
   IpEndpoint active_addr_struct;

--- a/include/proxy/http/remap/PluginDso.h
+++ b/include/proxy/http/remap/PluginDso.h
@@ -46,16 +46,65 @@
 namespace fs = swoc::file;
 
 #include "tscore/Ptr.h"
+#include "tsutil/Metrics.h"
 #include "iocore/eventsystem/EventSystem.h"
 
 #include "proxy/Plugin.h"
 
+#include <string_view>
+
 class PluginThreadContext : public RefCountObjInHeap
 {
 public:
-  virtual void                       acquire() = 0;
-  virtual void                       release() = 0;
-  static constexpr const char *const _tag      = "plugin_context"; /** @brief log tag used by this class */
+  virtual void acquire() = 0;
+  virtual void release() = 0;
+
+  /** @brief Register the per-plugin workload metrics (proxy.process.plugin.<name>.*) consumed by the
+   *  CPU-usage model. @a plugin_name is typically the DSO path; only its basename stem is used as the
+   *  metric token. Bounded by the number of named plugins. Safe to call once per plugin -- metric
+   *  names are de-duplicated by the Metrics registry. */
+  void registerPluginMetrics(std::string_view plugin_name);
+
+  /** @brief Bump this plugin's invocation counter, once per hook/remap callback dispatch. Cheap and
+   *  lock-free; a no-op until registerPluginMetrics() has run. */
+  void
+  countInvocation()
+  {
+    if (_invocations != nullptr) {
+      _invocations->increment(1);
+    }
+  }
+
+  /** @brief Add @a n application bytes this plugin moved through a plugin-owned transport (PluginVC
+   *  intercept). A workload driver for byte-scaling plugin CPU. No-op until registration has run. */
+  void
+  countBytes(int64_t n)
+  {
+    if (_bytes != nullptr && n > 0) {
+      _bytes->increment(n);
+    }
+  }
+
+  /** @brief Bump this plugin's intercept transfer-event counter, once per PluginVC write-side
+   *  processing pass. This is the primary driver for intercept (PluginVC) CPU: the cost is the
+   *  per-pass state-machine bookkeeping (buffer scans, VIO signals, reenables), not bytes, because
+   *  large transfers are zero-copy. No-op until registration has run. */
+  void
+  countTransfer()
+  {
+    if (_transfers != nullptr) {
+      _transfers->increment(1);
+    }
+  }
+
+  /// Per-plugin invocation counter (model driver); nullptr until registerPluginMetrics() runs.
+  ts::Metrics::Counter::AtomicType *_invocations = nullptr;
+  /// Per-plugin bytes-moved counter (model driver for intercept/transport CPU); nullptr until registered.
+  ts::Metrics::Counter::AtomicType *_bytes = nullptr;
+  /// Per-plugin intercept transfer-event counter (primary PluginVC driver); nullptr until registered.
+  ts::Metrics::Counter::AtomicType *_transfers = nullptr;
+
+  static constexpr const char *const _tag = "plugin_context"; /** @brief log tag used by this class */
 };
 
 class PluginDso : public PluginThreadContext

--- a/src/api/InkContInternal.cc
+++ b/src/api/InkContInternal.cc
@@ -157,8 +157,15 @@ INKContInternal::handle_event(int event, void *edata)
     /* set the plugin context */
     auto *previousContext = pluginThreadContext;
     pluginThreadContext   = reinterpret_cast<PluginThreadContext *>(m_context);
-    int retval            = m_event_func((TSCont)this, (TSEvent)event, edata);
-    pluginThreadContext   = previousContext;
+    // Count this plugin callback dispatch as a workload invocation. Global, transform and
+    // intercept hook plugins -- and remap plugins' deferred transaction hooks -- all flow
+    // through here, so this drives proxy.process.plugin.<name>.invocations for them. It is a
+    // no-op for core/internal continuations, which have no plugin context (m_context == nullptr).
+    if (pluginThreadContext != nullptr) {
+      pluginThreadContext->countInvocation();
+    }
+    int retval          = m_event_func((TSCont)this, (TSEvent)event, edata);
+    pluginThreadContext = previousContext;
     if (edata && event == EVENT_INTERVAL) {
       Event *e = reinterpret_cast<Event *>(edata);
       if (e->period != 0) {

--- a/src/proxy/Plugin.cc
+++ b/src/proxy/Plugin.cc
@@ -25,12 +25,15 @@
 #include <algorithm>
 #include <filesystem>
 #include <optional>
+#include <string_view>
+#include <vector>
 #include "tscore/ink_platform.h"
 #include "tscore/ink_file.h"
 #include "tscore/ParseRules.h"
 #include "records/RecCore.h"
 #include "tscore/Layout.h"
 #include "proxy/Plugin.h"
+#include "proxy/http/remap/RemapPluginInfo.h" // PluginThreadContext + the pluginThreadContext TLS
 #include "tscore/ink_cap.h"
 #include "tscore/Filenames.h"
 #include <yaml-cpp/yaml.h>
@@ -93,6 +96,38 @@ plugin_dir_init()
 }
 
 using init_func_t = void (*)(int, char **);
+
+namespace
+{
+/** Per-global-plugin execution context.
+ *
+ *  Global plugins are loaded with a raw dlopen in single_plugin_init() rather than through the
+ *  PluginFactory/PluginDso path, so unlike remap plugins they have no PluginThreadContext to carry
+ *  their identity. This minimal subclass provides one: it is installed as the thread-local
+ *  pluginThreadContext around the plugin's TSPluginInit so that the continuations the plugin creates
+ *  (directly, or later inside its hook/transform callbacks via TSContCreate/TSTransformCreate) are
+ *  stamped with it; INKContInternal::handle_event then bumps the per-plugin invocation counter.
+ *
+ *  Global plugins are never unloaded, so these contexts live for the process lifetime and the
+ *  continuation refcount hooks acquire()/release() are no-ops. They are retained in
+ *  g_global_plugin_contexts so they stay reachable. */
+class GlobalPluginContext : public PluginThreadContext
+{
+public:
+  explicit GlobalPluginContext(std::string_view name) { registerPluginMetrics(name); }
+  void
+  acquire() override
+  {
+  }
+  void
+  release() override
+  {
+  }
+};
+
+// Retains global-plugin contexts for the process lifetime (only mutated single-threaded at startup).
+std::vector<GlobalPluginContext *> g_global_plugin_contexts;
+} // namespace
 
 static PluginLoadSummary s_plugin_load_summary;
 
@@ -215,7 +250,19 @@ single_plugin_init(int argc, char *argv[], bool validateOnly)
 #endif
     opterr = 0;
     optarg = nullptr;
+
+    // Install a per-plugin context for the duration of TSPluginInit so that any continuations this
+    // global plugin creates -- directly here, or later inside its hook/transform callbacks -- carry
+    // its identity and drive proxy.process.plugin.<name>.invocations. Retained for the process
+    // lifetime (global plugins are never unloaded).
+    auto *global_context = new GlobalPluginContext(path);
+    g_global_plugin_contexts.push_back(global_context);
+    auto *prev_plugin_context = pluginThreadContext;
+    pluginThreadContext       = global_context;
+
     init(argc, argv);
+
+    pluginThreadContext = prev_plugin_context;
   } // done elevating access
 
   if (plugin_reg_current->plugin_registered) {

--- a/src/proxy/PluginVC.cc
+++ b/src/proxy/PluginVC.cc
@@ -72,6 +72,7 @@
  ****************************************************************************/
 
 #include "proxy/PluginVC.h"
+#include "proxy/http/remap/RemapPluginInfo.h" // PluginThreadContext + the pluginThreadContext TLS
 #include "../iocore/net/P_Net.h"
 #include "tscore/Regression.h"
 #if TS_HAS_TESTS
@@ -466,6 +467,12 @@ PluginVC::transfer_bytes(MIOBuffer *transfer_to, IOBufferReader *transfer_from, 
     total_added += moved;
   }
 
+  // Attribute the application bytes shuffled across this intercept to the owning plugin (both
+  // directions share core_obj->_owner); a no-op for core-internal PluginVCs.
+  if (core_obj->_owner != nullptr) {
+    core_obj->_owner->countBytes(total_added);
+  }
+
   return total_added;
 }
 
@@ -520,6 +527,14 @@ PluginVC::process_write_side()
       write_state.vio.cont->handleEvent(VC_EVENT_WRITE_READY, &write_state.vio);
     }
     return;
+  }
+
+  // Past this point there is application data to move, so this is a real write-side processing
+  // pass: attribute it to the owning intercept plugin. This per-pass count -- not bytes -- is the
+  // primary driver of intercept (plugin:vc) CPU, which is the buffer-scan / VIO-signal / reenable
+  // bookkeeping of each pass (large transfers are zero-copy). No-op for core-internal PluginVCs.
+  if (core_obj->_owner != nullptr) {
+    core_obj->_owner->countTransfer();
   }
 
   // Check the state of the other side read buffer as well as ntodo
@@ -1002,6 +1017,9 @@ PluginVCCore::alloc(Continuation *acceptor, int64_t buffer_index, int64_t buffer
   PluginVCCore *pvc = new PluginVCCore;
   pvc->init(buffer_index, buffer_water_mark);
   pvc->connect_to = acceptor;
+  // Capture the plugin that is creating this intercept so its transport bytes can be attributed to
+  // proxy.process.plugin.<name>.bytes; null for core-internal PluginVCs.
+  pvc->_owner = pluginThreadContext;
   return pvc;
 }
 

--- a/src/proxy/http/remap/PluginDso.cc
+++ b/src/proxy/http/remap/PluginDso.cc
@@ -29,6 +29,7 @@
 
 #include "proxy/http/remap/PluginDso.h"
 #include "iocore/eventsystem/Freer.h"
+#include "tsutil/Metrics.h"
 #ifdef PLUGIN_DSO_TESTS
 #include "unit-tests/plugin_testing_common.h"
 #else
@@ -37,8 +38,13 @@
 #define PluginError Error
 #endif
 
+#include <cctype>
 #include <cstdlib>
+#include <string>
+#include <string_view>
 #include <utility>
+
+using ts::Metrics;
 
 namespace
 {
@@ -55,7 +61,44 @@ concat_error(std::string &error, const std::string &msg)
   }
 }
 
+// plugin_metric_token derives a metric-safe token from a plugin path or name: it
+// takes the file basename, drops the extension, and replaces any character outside
+// [A-Za-z0-9_-] with '_', so the result is a single dotted segment in
+// proxy.process.plugin.<token>.* (e.g. "/.../header_rewrite.so" -> "header_rewrite",
+// "asset_token.cc" -> "asset_token").
+std::string
+plugin_metric_token(std::string_view name)
+{
+  if (auto slash = name.find_last_of('/'); slash != std::string_view::npos) {
+    name.remove_prefix(slash + 1);
+  }
+  if (auto dot = name.find_first_of('.'); dot != std::string_view::npos) {
+    name = name.substr(0, dot);
+  }
+
+  std::string token{name};
+  for (auto &c : token) {
+    if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
+      c = '_';
+    }
+  }
+  if (token.empty()) {
+    token = "unknown";
+  }
+  return token;
+}
+
 } // namespace
+
+void
+PluginThreadContext::registerPluginMetrics(std::string_view plugin_name)
+{
+  std::string prefix = "proxy.process.plugin." + plugin_metric_token(plugin_name) + ".";
+
+  _invocations = Metrics::Counter::createPtr(prefix + "invocations");
+  _bytes       = Metrics::Counter::createPtr(prefix + "bytes");
+  _transfers   = Metrics::Counter::createPtr(prefix + "transfers");
+}
 
 PluginDso::PluginDso(const fs::path &configPath, const fs::path &effectivePath, const fs::path &runtimePath)
   : _configPath(configPath), _effectivePath(effectivePath), _runtimePath(runtimePath)
@@ -138,6 +181,13 @@ PluginDso::load(std::string &error, const fs::path &compilerPath)
     }
   }
   PluginDbg(_dbg_ctl(), "plugin '%s' finished loading DSO", _configPath.c_str());
+
+  if (result) {
+    // Now that the DSO is loaded, register its per-plugin workload metrics. The remap
+    // dispatch path (RemapPlugins::run_plugin) and any continuations this plugin creates
+    // bump proxy.process.plugin.<name>.invocations through this PluginThreadContext.
+    registerPluginMetrics(_effectivePath.string());
+  }
 
   return result;
 }

--- a/src/proxy/http/remap/RemapPlugins.cc
+++ b/src/proxy/http/remap/RemapPlugins.cc
@@ -59,6 +59,9 @@ RemapPlugins::run_plugin(RemapPluginInst *plugin)
     _s->os_response_plugin_inst = plugin;
   }
 
+  // Count this remap-plugin invocation (model driver: proxy.process.plugin.<name>.invocations).
+  plugin->_plugin.countInvocation();
+
   HttpTransact::milestone_start_api_time(_s);
   plugin_retcode = plugin->doRemap(reinterpret_cast<TSHttpTxn>(_s->state_machine), &rri);
   HttpTransact::milestone_update_api_time(_s);

--- a/tests/gold_tests/pluginTest/per_plugin_metrics/per_plugin_metrics.test.py
+++ b/tests/gold_tests/pluginTest/per_plugin_metrics/per_plugin_metrics.test.py
@@ -1,0 +1,107 @@
+'''
+Verify the per-plugin CPU workload counters proxy.process.plugin.<name>.{invocations,bytes,transfers}.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify the per-plugin workload counters proxy.process.plugin.<name>.invocations (global and remap
+dispatch), .bytes and .transfers (PluginVC intercept transport).
+'''
+
+Test.ContinueOnFail = True
+
+ts = Test.MakeATSProcess("ts")
+server = Test.MakeOriginServer("server")
+
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: test.example\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_header)
+
+# A global header_rewrite continuation is dispatched through INKContInternal::handle_event, and the
+# conf_remap remap plugin through RemapPlugins::run_plugin -- the two per-plugin invocation-counter
+# sites. The generator remap plugin serves its body through a PluginVC intercept, exercising the
+# per-plugin bytes and transfers counters.
+ts.Setup.CopyAs('rules/global.conf', Test.RunDirectory)
+ts.Disk.plugin_config.AddLine(f'header_rewrite.so {Test.RunDirectory}/global.conf')
+ts.Disk.remap_config.AddLine(
+    f'map http://test.example http://127.0.0.1:{server.Variables.Port} '
+    f'@plugin=conf_remap.so @pparam=proxy.config.url_remap.pristine_host_hdr=1')
+ts.Disk.remap_config.AddLine('map http://gen.example http://127.0.0.1/ @plugin=generator.so')
+
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 0,
+    'proxy.config.diags.debug.tags': 'plugin',
+})
+
+# Drive a transaction through the global + remap plugins. curl as a forward proxy sends an
+# absolute-URI request so the named remap rule (and conf_remap) is matched; a 200 confirms the
+# request was served rather than a 404 (which would still fire the global header_rewrite hook).
+tr = Test.AddTestRun("Drive traffic through global + remap plugins")
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts)
+tr.MakeCurlCommand(f'-s -D - -o /dev/null --proxy 127.0.0.1:{ts.Variables.port} "http://test.example/"', ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression('200 OK', 'request should match the remap rule and be served')
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+# Drive a generator request: it serves a 4096-byte body through a PluginVC intercept.
+tr = Test.AddTestRun("Drive traffic through a PluginVC intercept plugin")
+tr.MakeCurlCommand(f'-s -o /dev/null --proxy 127.0.0.1:{ts.Variables.port} "http://gen.example/nocache/4096"', ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+
+# The global plugin (header_rewrite) is invoked through the transaction-hook dispatch path.
+tr = Test.AddTestRun("Global plugin invocation counter is non-zero")
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.Command = 'traffic_ctl metric get proxy.process.plugin.header_rewrite.invocations'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    r'proxy\.process\.plugin\.header_rewrite\.invocations [1-9]', 'global header_rewrite invocations should be counted')
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+
+# The remap plugin (conf_remap) is invoked through the remap dispatch path.
+tr = Test.AddTestRun("Remap plugin invocation counter is non-zero")
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.Command = 'traffic_ctl metric get proxy.process.plugin.conf_remap.invocations'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    r'proxy\.process\.plugin\.conf_remap\.invocations [1-9]', 'remap conf_remap invocations should be counted')
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+
+# The generator plugin moved its response body through a PluginVC; the bytes are attributed to it.
+tr = Test.AddTestRun("PluginVC intercept bytes counter is non-zero")
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.Command = 'traffic_ctl metric get proxy.process.plugin.generator.bytes'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    r'proxy\.process\.plugin\.generator\.bytes [1-9]', 'generator PluginVC transport bytes should be counted')
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+
+# Per-write-pass intercept transfer-event counter (a diagnostic of transport activity).
+tr = Test.AddTestRun("PluginVC intercept transfers counter is non-zero")
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.Command = 'traffic_ctl metric get proxy.process.plugin.generator.transfers'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    r'proxy\.process\.plugin\.generator\.transfers [1-9]', 'generator PluginVC transfer events should be counted')
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/per_plugin_metrics/rules/global.conf
+++ b/tests/gold_tests/pluginTest/per_plugin_metrics/rules/global.conf
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fire on every response so the global header_rewrite continuation is dispatched (through
+# INKContInternal::handle_event) for each transaction, exercising the per-plugin invocation counter.
+cond %{SEND_RESPONSE_HDR_HOOK}
+set-header X-Per-Plugin-Metrics "1"


### PR DESCRIPTION
A CPU-usage model that attributes process CPU to workload needs a per-plugin
driver; today plugin CPU has no metric and lands in an unexplained baseline.
Add proxy.process.plugin.<name>.{invocations,bytes,transfers}, keyed by the
plugin DSO basename and bounded by the number of loaded plugins.

invocations counts hook and remap callback dispatches, incremented at
INKContInternal::handle_event and RemapPlugins::run_plugin.  bytes and transfers
attribute PluginVC intercept transport to the owning plugin, captured on
PluginVCCore at alloc.  Global plugins load via raw dlopen and previously carried
no identity, so they are given a PluginThreadContext around TSPluginInit; the
continuations they create then carry plugin identity the same way remap plugins
already do.

transfers is bumped once per PluginVC write-side pass; it reflects buffering and
reenable behavior, so it is a diagnostic of transport activity rather than an
external workload driver.
