### PR TITLE
header_rewrite: count operators executed and conditions evaluated

### DIFF
--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -49,6 +49,11 @@ public:
   bool
   do_eval(const Resources &res)
   {
+    // Count each condition evaluated (CPU-model work driver); do_eval runs once per condition,
+    // respecting short-circuit so only conditions that actually executed are counted.
+    if (TS_ERROR != hrw_stat_conditions) {
+      TSStatIntIncrement(hrw_stat_conditions, 1);
+    }
     bool rt = eval(res);
 
     if (has_modifier(_mods, CondModifiers::NOT)) {

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -569,6 +569,8 @@ TSPluginInit(int argc, const char *argv[])
     return;
   }
 
+  init_hrw_work_stats();
+
   std::string geoDBpath;
   int         inboundIpSource = 0;
   int         timezone        = 0;
@@ -662,6 +664,8 @@ TSRemapInit(TSRemapInterface *api_info, char *errbuf, int errbuf_size)
 {
   CHECK_REMAP_API_COMPATIBILITY(api_info, errbuf, errbuf_size);
   Dbg(pi_dbg_ctl, "Remap plugin is successfully initialized");
+
+  init_hrw_work_stats();
 
   return TS_SUCCESS;
 }

--- a/plugins/header_rewrite/operator.h
+++ b/plugins/header_rewrite/operator.h
@@ -78,6 +78,10 @@ public:
   unsigned
   do_exec(const Resources &res) const
   {
+    // Count each operator executed (CPU-model work driver); do_exec runs once per operator.
+    if (TS_ERROR != hrw_stat_operators) {
+      TSStatIntIncrement(hrw_stat_operators, 1);
+    }
     unsigned no_reenable{exec(res) ? 0U : 1U};
     if (nullptr != _next) {
       no_reenable += static_cast<Operator *>(_next)->do_exec(res);

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -21,6 +21,25 @@
 //
 #include "statement.h"
 
+// CPU-model work counters; see statement.h. TS_ERROR until init_hrw_work_stats() runs.
+int hrw_stat_operators  = TS_ERROR;
+int hrw_stat_conditions = TS_ERROR;
+
+void
+init_hrw_work_stats()
+{
+  // Plugin init is single-threaded; create each counter once so global + remap loading of
+  // header_rewrite.so share one process-wide stat.
+  if (TS_ERROR == hrw_stat_operators) {
+    hrw_stat_operators = TSStatCreate("proxy.process.plugin.header_rewrite.operators", TS_RECORDDATATYPE_INT,
+                                      TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_COUNT);
+  }
+  if (TS_ERROR == hrw_stat_conditions) {
+    hrw_stat_conditions = TSStatCreate("proxy.process.plugin.header_rewrite.conditions", TS_RECORDDATATYPE_INT,
+                                       TS_STAT_NON_PERSISTENT, TS_STAT_SYNC_COUNT);
+  }
+}
+
 void
 Statement::append(Statement *stmt)
 {

--- a/plugins/header_rewrite/statement.h
+++ b/plugins/header_rewrite/statement.h
@@ -32,6 +32,17 @@
 #include "parser.h"
 #include "lulu.h"
 
+// Per-plugin work counters for the CPU-usage model:
+// proxy.process.plugin.header_rewrite.{operators,conditions} accumulate the total number of
+// operators executed and conditions evaluated across all transactions. Together with the bare
+// invocation count this captures per-script work -- the cost of a transaction's header_rewrite
+// hook scales with how many operators/conditions the configured rules run, not just the call
+// count. Created once via init_hrw_work_stats(); both are TS_ERROR until then, so increments
+// are guarded.
+extern int hrw_stat_operators;
+extern int hrw_stat_conditions;
+void       init_hrw_work_stats();
+
 namespace header_rewrite_ns
 {
 constexpr int NUM_STATE_FLAGS = 16;

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_metrics.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_metrics.test.py
@@ -1,0 +1,71 @@
+'''
+Verify header_rewrite work counters proxy.process.plugin.header_rewrite.{operators,conditions}.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify header_rewrite increments proxy.process.plugin.header_rewrite.operators per operator
+executed and .conditions per condition evaluated.
+'''
+
+Test.ContinueOnFail = True
+
+ts = Test.MakeATSProcess("ts")
+server = Test.MakeOriginServer("server")
+
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: test.example\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_header)
+
+# The global ruleset evaluates one condition and runs two operators per response.
+ts.Setup.CopyAs('rules/metrics.conf', Test.RunDirectory)
+ts.Disk.plugin_config.AddLine(f'header_rewrite.so {Test.RunDirectory}/metrics.conf')
+ts.Disk.remap_config.AddLine(f'map http://test.example http://127.0.0.1:{server.Variables.Port}')
+
+ts.Disk.records_config.update(
+    {
+        'proxy.config.url_remap.pristine_host_hdr': 1,
+        'proxy.config.diags.debug.enabled': 0,
+        'proxy.config.diags.debug.tags': 'header_rewrite',
+    })
+
+tr = Test.AddTestRun("Drive a transaction through the global ruleset")
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts)
+tr.MakeCurlCommand(f'-s -D - -o /dev/null --proxy 127.0.0.1:{ts.Variables.port} "http://test.example/"', ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression('200 OK', 'request should be served')
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun("operators-executed counter is non-zero")
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.Command = 'traffic_ctl metric get proxy.process.plugin.header_rewrite.operators'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    r'proxy\.process\.plugin\.header_rewrite\.operators [1-9]', 'header_rewrite operators executed should be counted')
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server
+
+tr = Test.AddTestRun("conditions-evaluated counter is non-zero")
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.Command = 'traffic_ctl metric get proxy.process.plugin.header_rewrite.conditions'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = Testers.ContainsExpression(
+    r'proxy\.process\.plugin\.header_rewrite\.conditions [1-9]', 'header_rewrite conditions evaluated should be counted')
+tr.StillRunningAfter = ts
+tr.StillRunningAfter = server

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/metrics.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/metrics.conf
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# On every response evaluate one condition (%{STATUS}) and run two operators
+# (set-header), so the operators and conditions work counters both advance.
+cond %{SEND_RESPONSE_HDR_HOOK}
+cond %{STATUS} >0
+set-header X-HRW-Metrics "1"
+set-header X-HRW-Metrics-Two "2"


### PR DESCRIPTION
A transaction's header_rewrite CPU scales with how many operators it runs and
conditions it evaluates, which is set by the configured rules -- the per-hook
invocation count alone cannot distinguish a small ruleset from a large one.  Add
proxy.process.plugin.header_rewrite.{operators,conditions}, incremented in the
inline Operator::do_exec and Condition::do_eval chain walkers.  do_eval respects
short-circuit, so only conditions actually evaluated are counted.  The counters
are created once, from both TSPluginInit and TSRemapInit.
