### PR TITLE
TLS: add handshake full/resumed and signing-type counters

### DIFF
--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -991,6 +991,9 @@ SSLNetVConnection::clear()
   client_sess.reset();
 
   if (ssl != nullptr) {
+    // One SSL_free per VC that owned an SSL object -- the causal driver for ssl:close
+    // (cert-chain X509 free dominates the teardown).
+    Metrics::Counter::increment(ssl_rsb.connections_closed);
     SSL_free(ssl);
     ssl = nullptr;
   }

--- a/src/iocore/net/SSLStats.cc
+++ b/src/iocore/net/SSLStats.cc
@@ -223,19 +223,27 @@ SSLInitializeStatistics()
   ssl_rsb.total_sslv3                        = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_sslv3");
   ssl_rsb.total_success_handshake_count_in   = Metrics::Counter::createPtr("proxy.process.ssl.total_success_handshake_count_in");
   ssl_rsb.total_success_handshake_count_out  = Metrics::Counter::createPtr("proxy.process.ssl.total_success_handshake_count_out");
-  ssl_rsb.total_ticket_keys_renewed          = Metrics::Counter::createPtr("proxy.process.ssl.total_ticket_keys_renewed");
-  ssl_rsb.total_tickets_created              = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_created");
-  ssl_rsb.total_tickets_not_found            = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_not_found");
-  ssl_rsb.total_tickets_renewed              = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_renewed");
-  ssl_rsb.total_tickets_verified             = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_verified");
-  ssl_rsb.total_tickets_verified_old_key     = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_verified_old_key");
-  ssl_rsb.total_tlsv1                        = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv1");
-  ssl_rsb.total_tlsv11                       = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv11");
-  ssl_rsb.total_tlsv12                       = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv12");
-  ssl_rsb.total_tlsv13                       = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv13");
-  ssl_rsb.user_agent_bad_cert                = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_bad_cert");
-  ssl_rsb.user_agent_cert_verify_failed      = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_cert_verify_failed");
-  ssl_rsb.user_agent_decryption_failed       = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_decryption_failed");
+  ssl_rsb.total_success_handshake_count_in_full =
+    Metrics::Counter::createPtr("proxy.process.ssl.total_success_handshake_count_in_full");
+  ssl_rsb.total_success_handshake_count_in_resumed =
+    Metrics::Counter::createPtr("proxy.process.ssl.total_success_handshake_count_in_resumed");
+  ssl_rsb.handshake_sign_rsa             = Metrics::Counter::createPtr("proxy.process.ssl.handshake_sign_rsa");
+  ssl_rsb.handshake_sign_ecdsa           = Metrics::Counter::createPtr("proxy.process.ssl.handshake_sign_ecdsa");
+  ssl_rsb.handshake_sign_other           = Metrics::Counter::createPtr("proxy.process.ssl.handshake_sign_other");
+  ssl_rsb.connections_closed             = Metrics::Counter::createPtr("proxy.process.ssl.connections_closed");
+  ssl_rsb.total_ticket_keys_renewed      = Metrics::Counter::createPtr("proxy.process.ssl.total_ticket_keys_renewed");
+  ssl_rsb.total_tickets_created          = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_created");
+  ssl_rsb.total_tickets_not_found        = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_not_found");
+  ssl_rsb.total_tickets_renewed          = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_renewed");
+  ssl_rsb.total_tickets_verified         = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_verified");
+  ssl_rsb.total_tickets_verified_old_key = Metrics::Counter::createPtr("proxy.process.ssl.total_tickets_verified_old_key");
+  ssl_rsb.total_tlsv1                    = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv1");
+  ssl_rsb.total_tlsv11                   = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv11");
+  ssl_rsb.total_tlsv12                   = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv12");
+  ssl_rsb.total_tlsv13                   = Metrics::Counter::createPtr("proxy.process.ssl.ssl_total_tlsv13");
+  ssl_rsb.user_agent_bad_cert            = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_bad_cert");
+  ssl_rsb.user_agent_cert_verify_failed  = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_cert_verify_failed");
+  ssl_rsb.user_agent_decryption_failed   = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_decryption_failed");
   ssl_rsb.user_agent_decryption_failed_or_bad_record_mac =
     Metrics::Counter::createPtr("proxy.process.ssl.user_agent_decryption_failed_or_bad_record_mac");
   ssl_rsb.user_agent_expired_cert           = Metrics::Counter::createPtr("proxy.process.ssl.user_agent_expired_cert");

--- a/src/iocore/net/SSLStats.h
+++ b/src/iocore/net/SSLStats.h
@@ -85,6 +85,12 @@ struct SSLStatsBlock {
   Metrics::Counter::AtomicType *total_sslv3                                    = nullptr;
   Metrics::Counter::AtomicType *total_success_handshake_count_in               = nullptr;
   Metrics::Counter::AtomicType *total_success_handshake_count_out              = nullptr;
+  Metrics::Counter::AtomicType *total_success_handshake_count_in_full          = nullptr;
+  Metrics::Counter::AtomicType *total_success_handshake_count_in_resumed       = nullptr;
+  Metrics::Counter::AtomicType *handshake_sign_rsa                             = nullptr;
+  Metrics::Counter::AtomicType *handshake_sign_ecdsa                           = nullptr;
+  Metrics::Counter::AtomicType *handshake_sign_other                           = nullptr;
+  Metrics::Counter::AtomicType *connections_closed                             = nullptr;
   Metrics::Counter::AtomicType *total_ticket_keys_renewed                      = nullptr;
   Metrics::Counter::AtomicType *total_tickets_created                          = nullptr;
   Metrics::Counter::AtomicType *total_tickets_not_found                        = nullptr;

--- a/src/iocore/net/TLSBasicSupport.cc
+++ b/src/iocore/net/TLSBasicSupport.cc
@@ -319,6 +319,34 @@ TLSBasicSupport::_update_end_of_handshake_stats()
 {
   Metrics::Counter::increment(ssl_rsb.total_success_handshake_count_in);
 
+  // Split inbound handshakes into full vs. resumed, and for full handshakes
+  // record the server private-key type. A full handshake runs an asymmetric
+  // signature (RSA being far heavier than ECDSA), while a resumed handshake
+  // skips it -- these are the causal workload drivers behind ssl:accept CPU.
+  {
+    SSL *ssl = this->_get_ssl_object();
+    if (ssl != nullptr) {
+      if (SSL_session_reused(ssl)) {
+        Metrics::Counter::increment(ssl_rsb.total_success_handshake_count_in_resumed);
+      } else {
+        Metrics::Counter::increment(ssl_rsb.total_success_handshake_count_in_full);
+        if (EVP_PKEY *pkey = SSL_get_privatekey(ssl); pkey != nullptr) {
+          switch (EVP_PKEY_id(pkey)) {
+          case EVP_PKEY_RSA:
+            Metrics::Counter::increment(ssl_rsb.handshake_sign_rsa);
+            break;
+          case EVP_PKEY_EC:
+            Metrics::Counter::increment(ssl_rsb.handshake_sign_ecdsa);
+            break;
+          default:
+            Metrics::Counter::increment(ssl_rsb.handshake_sign_other);
+            break;
+          }
+        }
+      }
+    }
+  }
+
 #if defined(OPENSSL_IS_BORINGSSL)
   SSL     *ssl      = this->_get_ssl_object();
   uint16_t group_id = SSL_get_group_id(ssl);


### PR DESCRIPTION
These counters feed a per-component CPU model that attributes ssl:accept
and ssl:close User CPU to its causal workload drivers instead of folding
it into a fixed intercept.

The dominant cost of a TLS accept is the asymmetric signature, which only
a full handshake performs -- a resumed handshake skips it.  Splitting the
existing proxy.process.ssl.total_success_handshake_count_in into _in_full
and _in_resumed, and recording the server private-key type (RSA being far
heavier than ECDSA), exposes that cost as a workload count.

New counters:
  * proxy.process.ssl.total_success_handshake_count_in_full
  * proxy.process.ssl.total_success_handshake_count_in_resumed
  * proxy.process.ssl.handshake_sign_rsa / _ecdsa / _other
  * proxy.process.ssl.connections_closed -- one per SSL_free, the driver
    behind ssl:close where cert-chain teardown dominates.
