### PR TITLE
Fix tsapi build with ENABLE_PROBES=ON

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -28,6 +28,9 @@ set(TSAPI_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/ts/ts.h ${PROJECT_SOURCE_
 
 # OpenSSL needs to be listed in before other libraries that can be found in the system default lib directory (See #11511)
 target_link_libraries(tsapi PRIVATE libswoc::libswoc yaml-cpp::yaml-cpp OpenSSL::SSL)
+if(ENABLE_PROBES)
+  target_link_libraries(tsapi PRIVATE systemtap::systemtap)
+endif()
 set_target_properties(tsapi PROPERTIES PUBLIC_HEADER "${TSAPI_PUBLIC_HEADERS}")
 
 # Items common between api and other ts libraries


### PR DESCRIPTION
Cache headers transitively pull in <ts/ats_probe.h> via P_CacheDir.h. When ENABLE_PROBES=ON, ENABLE_SYSTEMTAP_PROBES is defined and ats_probe.h `#include <sys/sdt.h>`. tsapi's include path didn't have lib/systemtap.