### PR TITLE
logging: add a marshalled-bytes counter

### DIFF
--- a/include/proxy/logging/LogConfig.h
+++ b/include/proxy/logging/LogConfig.h
@@ -49,6 +49,7 @@ struct LogsStatsBlock {
   Metrics::Counter::AtomicType *event_log_access_aggr;
   Metrics::Counter::AtomicType *event_log_access_full;
   Metrics::Counter::AtomicType *event_log_access_fail;
+  Metrics::Counter::AtomicType *marshalled_bytes;
   Metrics::Counter::AtomicType *num_sent_to_network;
   Metrics::Counter::AtomicType *num_lost_before_sent_to_network;
   Metrics::Counter::AtomicType *num_received_from_network;

--- a/src/proxy/logging/LogConfig.cc
+++ b/src/proxy/logging/LogConfig.cc
@@ -497,6 +497,7 @@ LogConfig::register_stat_callbacks()
   log_rsb.event_log_access_aggr             = Metrics::Counter::createPtr("proxy.process.log.event_log_access_aggr");
   log_rsb.event_log_access_full             = Metrics::Counter::createPtr("proxy.process.log.event_log_access_full");
   log_rsb.event_log_access_fail             = Metrics::Counter::createPtr("proxy.process.log.event_log_access_fail");
+  log_rsb.marshalled_bytes                  = Metrics::Counter::createPtr("proxy.process.log.marshalled_bytes");
   log_rsb.num_sent_to_network               = Metrics::Counter::createPtr("proxy.process.log.num_sent_to_network");
   log_rsb.num_lost_before_sent_to_network   = Metrics::Counter::createPtr("proxy.process.log.num_lost_before_sent_to_network");
   log_rsb.num_received_from_network         = Metrics::Counter::createPtr("proxy.process.log.num_received_from_network");

--- a/src/proxy/logging/LogObject.cc
+++ b/src/proxy/logging/LogObject.cc
@@ -638,7 +638,6 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
     bytes_needed = m_format->field_count() * INK_MIN_ALIGN;
   } else if (lad) {
     bytes_needed = m_format->m_field_list.marshal_len(lad);
-    Metrics::Counter::increment(log_rsb.marshalled_bytes, bytes_needed);
   } else if (!text_entry.empty()) {
     bytes_needed = INK_ALIGN_DEFAULT(text_entry.size() + 1); // must include null terminator.
   }
@@ -678,6 +677,8 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
   } else if (lad) {
     bytes_used = m_format->m_field_list.marshal(lad, &(*buffer)[offset]);
     ink_assert(bytes_needed >= bytes_used);
+    // Count only entries that were successfully checked out and marshalled, not dropped ones.
+    Metrics::Counter::increment(log_rsb.marshalled_bytes, bytes_needed);
   } else if (!text_entry.empty()) {
     char *dst = &(*buffer)[offset];
     memcpy(dst, text_entry.data(), text_entry.size());

--- a/src/proxy/logging/LogObject.cc
+++ b/src/proxy/logging/LogObject.cc
@@ -638,6 +638,7 @@ LogObject::log(LogAccess *lad, std::string_view text_entry)
     bytes_needed = m_format->field_count() * INK_MIN_ALIGN;
   } else if (lad) {
     bytes_needed = m_format->m_field_list.marshal_len(lad);
+    Metrics::Counter::increment(log_rsb.marshalled_bytes, bytes_needed);
   } else if (!text_entry.empty()) {
     bytes_needed = INK_ALIGN_DEFAULT(text_entry.size() + 1); // must include null terminator.
   }


### PR DESCRIPTION
Adds proxy.process.log.marshalled_bytes, a counter that helps with estimating the cost of logging on an ATS instance.