### PR TITLE
Enable probes in Fedora C++20 CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -194,13 +194,9 @@
       "name": "ci-fedora-cxx20",
       "displayName": "CI Fedora c++20",
       "description": "CI Pipeline config for Fedora Linux compiled with c++20",
-      "inherits": ["ci"],
+      "inherits": ["ci-fedora"],
       "cacheVariables": {
-        "opentelemetry_ROOT": "/opt",
-        "CURL_ROOT": "/opt",
-        "wamr_ROOT": "/opt",
-        "CMAKE_CXX_STANDARD": "20",
-        "ENABLE_CRIPTS": "ON"
+        "CMAKE_CXX_STANDARD": "20"
       }
     },
     {
@@ -450,4 +446,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Fedora CI runs the C++20 preset rather than the base Fedora preset, so
probe coverage drifted out of that build even though ci-fedora had the
option enabled.

This makes the C++20 preset inherit the Fedora preset and keeps only the
C++ standard override locally, so shared Fedora CI settings stay in one
place.