### PR TITLE
net: count application bytes in read_bytes for TLS

### DIFF
--- a/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
+++ b/doc/admin-guide/monitoring/statistics/core/network-io.en.rst
@@ -79,9 +79,28 @@ Network I/O
    :type: counter
    :units: bytes
 
+   Application-layer bytes read from client and origin connections.  For TLS
+   connections this is the decrypted payload, symmetric with ``write_bytes``; it
+   does not include TLS handshake or record-layer framing.
+
+.. ts:stat:: global proxy.process.net.read_bytes_count integer
+   :type: counter
+
+   The number of read operations that contributed to ``read_bytes``.  For TLS
+   connections this is one per decrypted-read pass, not per socket read.
+
 .. ts:stat:: global proxy.process.net.write_bytes integer
    :type: counter
    :units: bytes
+
+   Application-layer bytes written to client and origin connections.  For TLS
+   connections this is the plaintext payload; it does not include TLS handshake
+   or record-layer framing.
+
+.. ts:stat:: global proxy.process.net.write_bytes_count integer
+   :type: counter
+
+   The number of write operations that contributed to ``write_bytes``.
 
 .. ts:stat:: global proxy.process.tcp.total_accepts integer
    :type: counter

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -287,6 +287,9 @@ SSLNetVConnection::_ssl_read_from_net(int64_t &ret)
     Dbg(dbg_ctl_ssl, "bytes_read=%" PRId64, bytes_read);
 
     s->vio.ndone += bytes_read;
+    // Decrypted application bytes, to match write_bytes (also plaintext for TLS).
+    Metrics::Counter::increment(net_rsb.read_bytes, bytes_read);
+    Metrics::Counter::increment(net_rsb.read_bytes_count);
     this->netActivity();
 
     ret = bytes_read;
@@ -351,8 +354,6 @@ SSLNetVConnection::read_raw_data()
       r = total_read - rattempted + r;
     }
   }
-  Metrics::Counter::increment(net_rsb.read_bytes, r);
-  Metrics::Counter::increment(net_rsb.read_bytes_count);
 
   if (!this->haveCheckedProxyProtocol) {
     // The PROXY Protocol, by spec, is designed to require only the first TCP packet of bytes


### PR DESCRIPTION
On TLS connections, net.read_bytes was only counting some bytes for the handshake, and none of the incoming ciphertext.  This is neither intuitive nor consistent with net.write_bytes.

The fix for now is to make it symmetric with net.write_bytes.  Count the plaintext bytes for TLS.  This means not counting the handshake bytes.

For a long term fix, I plan to add more comprehensive metrics for TLS.