### PR TITLE
Fix Fedora 44 CI on 9.2.x

### DIFF
--- a/example/plugins/c-api/thread_pool/psi.c
+++ b/example/plugins/c-api/thread_pool/psi.c
@@ -419,7 +419,7 @@ parse_data(TSCont contp, TSIOBufferReader input_reader, int avail, int *toconsum
 static const char *
 _basename(const char *filename)
 {
-  char *cptr;
+  const char *cptr;
   const char *ptr = filename;
 
   while ((cptr = strchr(ptr, '/')) != NULL) {

--- a/example/plugins/cpp-api/async_http_fetch/AsyncHttpFetch.cc
+++ b/example/plugins/cpp-api/async_http_fetch/AsyncHttpFetch.cc
@@ -39,19 +39,29 @@ namespace
 GlobalPlugin *plugin;
 }
 
-class AsyncHttpFetch2 : public AsyncHttpFetch
+class AsyncHttpFetch2 final : public AsyncHttpFetch
 {
 public:
   explicit AsyncHttpFetch2(const string &request) : AsyncHttpFetch(request){};
+  void
+  run() override
+  {
+    AsyncHttpFetch::run();
+  }
 };
 
-class AsyncHttpFetch3 : public AsyncHttpFetch
+class AsyncHttpFetch3 final : public AsyncHttpFetch
 {
 public:
   AsyncHttpFetch3(const string &request, HttpMethod method) : AsyncHttpFetch(request, method){};
+  void
+  run() override
+  {
+    AsyncHttpFetch::run();
+  }
 };
 
-class DelayedAsyncHttpFetch : public AsyncHttpFetch, public AsyncReceiver<AsyncTimer>
+class DelayedAsyncHttpFetch final : public AsyncHttpFetch, public AsyncReceiver<AsyncTimer>
 {
 public:
   DelayedAsyncHttpFetch(const string &request, HttpMethod method, std::shared_ptr<Mutex> mutex)

--- a/plugins/experimental/ssl_session_reuse/src/config.cc
+++ b/plugins/experimental/ssl_session_reuse/src/config.cc
@@ -76,9 +76,18 @@ Config::loadConfig(const std::string &filename)
       }
       line.ltrim_if(&isspace);
       ts::TextView field = line.take_prefix_at('=');
-      TSDebug(PLUGIN, "%.*s=%.*s", static_cast<int>(field.size()), field.data(), static_cast<int>(line.size()), line.data());
-      if (field.size() > 0) {
-        m_config[std::string(field.data(), field.size())] = std::string(line.data(), line.size());
+      std::string field_name;
+      std::string value;
+      if (!field.empty()) {
+        field_name.assign(field.data(), field.size());
+      }
+      if (!line.empty()) {
+        value.assign(line.data(), line.size());
+      }
+      TSDebug(PLUGIN, "%.*s=%.*s", static_cast<int>(field_name.size()), field_name.c_str(), static_cast<int>(value.size()),
+              value.c_str());
+      if (!field_name.empty()) {
+        m_config[field_name] = value;
       }
     }
 

--- a/plugins/experimental/statichit/statichit.cc
+++ b/plugins/experimental/statichit/statichit.cc
@@ -641,7 +641,7 @@ TSRemapDoRemap(void *ih, TSHttpTxn rh, TSRemapRequestInfo *rri)
     int pathsz;
     TSUrlPathGet(rri->requestBufp, rri->requestUrl, &pathsz);
     if (pathsz > 0) {
-      VERROR("Path is not an exact match. Rejecting!");
+      VDEBUG("Path is not an exact match. Rejecting!");
       TSHttpTxnStatusSet(rh, TS_HTTP_STATUS_NOT_FOUND);
       return TSREMAP_NO_REMAP;
     }

--- a/tests/gold_tests/command_argument/verify_global_plugin.test.py
+++ b/tests/gold_tests/command_argument/verify_global_plugin.test.py
@@ -38,12 +38,12 @@ def create_ts_process():
     # Ideally we would set the test run's Processes.Default to ts, but deep
     # copy of processes is not currently implemented in autest. Therefore we
     # replace the command which ts runs with a dummy command, and pull in
-    # piecemeal the values from ts that we want into the test run.
-    ts.Command = "sleep 100"
-    # sleep will return -2 when autest kills it. We set the expectation for the
-    # -2 return code here so the test doesn't fail because of this.
-    ts.ReturnCode = -2
-    # Clear the ready criteria because sleep is ready as soon as it is running.
+    # piecemeal the values from ts that we want into the test run. The helper
+    # only needs to create the ATS environment and runroot, so let it exit
+    # normally instead of depending on AuTest's cleanup signal behavior.
+    ts.Command = "true"
+    ts.ReturnCode = 0
+    # Clear the ready criteria because the helper is ready as soon as it runs.
     ts.Ready = None
     return ts
 

--- a/tests/gold_tests/command_argument/verify_remap_plugin.test.py
+++ b/tests/gold_tests/command_argument/verify_remap_plugin.test.py
@@ -38,12 +38,12 @@ def create_ts_process():
     # Ideally we would set the test run's Processes.Default to ts, but deep
     # copy of processes is not currently implemented in autest. Therefore we
     # replace the command which ts runs with a dummy command, and pull in
-    # piecemeal the values from ts that we want into the test run.
-    ts.Command = "sleep 100"
-    # sleep will return -2 when autest kills it. We set the expectation for the
-    # -2 return code here so the test doesn't fail because of this.
-    ts.ReturnCode = -2
-    # Clear the ready criteria because sleep is ready as soon as it is running.
+    # piecemeal the values from ts that we want into the test run. The helper
+    # only needs to create the ATS environment and runroot, so let it exit
+    # normally instead of depending on AuTest's cleanup signal behavior.
+    ts.Command = "true"
+    ts.ReturnCode = 0
+    # Clear the ready criteria because the helper is ready as soon as it runs.
     ts.Ready = None
     return ts
 

--- a/tests/gold_tests/connect/connect.test.py
+++ b/tests/gold_tests/connect/connect.test.py
@@ -87,7 +87,8 @@ logging:
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.stderr = "gold/connect_0_stderr.gold"
         tr.Processes.Default.Streams.stderr = Testers.ContainsExpression(
-            f'Connected to 127.0.0.1.*{self.ts.Variables.port}', 'Curl should connect through the ATS proxy port.')
+            rf'(Connected to|Established connection to) 127\.0\.0\.1.*{self.ts.Variables.port}',
+            'Curl should connect through the ATS proxy port.')
         tr.Processes.Default.TimeOut = 3
         self.__checkProcessAfter(tr)
 

--- a/tests/gold_tests/h2/http2_flow_control.replay.yaml
+++ b/tests/gold_tests/h2/http2_flow_control.replay.yaml
@@ -234,4 +234,3 @@ sessions:
       headers:
         fields:
         - [ X-Response, {value: 'fifth-response', as: equal } ]
-

--- a/tests/gold_tests/pipeline/pipeline_server.py
+++ b/tests/gold_tests/pipeline/pipeline_server.py
@@ -83,7 +83,11 @@ def receive_requests(sock: socket.socket) -> None:
     end_of_second_request: bytes = b'12345'
     end_of_third_request: bytes = b'\r\n\r\n'
     while not received_third_request:
-        data = sock.recv(1024)
+        try:
+            data = sock.recv(1024)
+        except socket.timeout:
+            print("Timed out waiting for an unexpected third request.")
+            break
         if not data:
             print("Socket closed.")
             break
@@ -126,6 +130,7 @@ def receive_requests(sock: socket.socket) -> None:
                 print()
                 time.sleep(0.01)
                 sock.sendall(second_response_bytes)
+                sock.settimeout(1.0)
                 continue
 
             elif processing_third_request:

--- a/tests/prepare_proxy_verifier.sh
+++ b/tests/prepare_proxy_verifier.sh
@@ -53,7 +53,7 @@ then
     if [ ! -e ${pv_tar} ]
     then
         # default to using native sha1sum command when available
-        if [ $(which sha1sum) ]
+        if command -v sha1sum >/dev/null 2>&1
         then
             SHASUM=${SHASUM:-sha1sum}
         else
@@ -68,20 +68,16 @@ EOF
         ${SHASUM} -c ${pv_top_dir}/sha1 || fail "SHA1 mismatch for downloaded ${pv_tar_filename}."
     fi
 
-    # 2. Untar the Proxy Verifier binaries.
-    mkdir -p ${pv_unpack_dir}
-    ${TAR} -x -C ${pv_unpack_dir} -f ${pv_tar}
-
-    # 3. Determine the target OS.
-    pv_os_dir=""
+    # 2. Determine the target OS.
+    pv_os_archive_dir=""
     case $(uname -s) in
     Darwin)
         case $(uname -m) in
         x86_64)
-            pv_os_dir="${pv_unpack_dir}/${pv_dir}/darwin-amd64"
+            pv_os_archive_dir="${pv_dir}/darwin-amd64"
             ;;
         arm64)
-            pv_os_dir="${pv_unpack_dir}/${pv_dir}/darwin-arm64"
+            pv_os_archive_dir="${pv_dir}/darwin-arm64"
             ;;
         *)
             fail "Unrecognized Mac architecture: $(uname -m)"
@@ -89,13 +85,12 @@ EOF
         esac
         ;;
     Linux)
-        pv_os_dir="${pv_unpack_dir}/${pv_dir}/linux"
         case $(uname -m) in
         x86_64)
-            pv_os_dir="${pv_unpack_dir}/${pv_dir}/linux-amd64"
+            pv_os_archive_dir="${pv_dir}/linux-amd64"
             ;;
         aarch64)
-            pv_os_dir="${pv_unpack_dir}/${pv_dir}/linux-arm64"
+            pv_os_archive_dir="${pv_dir}/linux-arm64"
             ;;
         *)
             fail "Unrecognized Linux architecture: $(uname -m)"
@@ -106,10 +101,14 @@ EOF
         fail "We need to build proxy-verifier for $(uname -s)"
     esac
 
-    # 4. Link the OS-specific binaries to the bin directory.
+    # 3. Extract the OS-specific binaries to the bin directory.
     mkdir -p ${bin_dir}
-    ln -s ${pv_os_dir}/verifier-client ${bin_dir}
-    ln -s ${pv_os_dir}/verifier-server ${bin_dir}
-    chmod +x ${pv_client}
-    chmod +x ${pv_server}
+    rm -f "${pv_client}" "${pv_server}" "${pv_client}.tmp" "${pv_server}.tmp"
+    ${TAR} -x -O -f "${pv_tar}" "${pv_os_archive_dir}/verifier-client" > "${pv_client}.tmp" || \
+        fail "Failed to extract ${pv_os_archive_dir}/verifier-client from ${pv_tar_filename}."
+    ${TAR} -x -O -f "${pv_tar}" "${pv_os_archive_dir}/verifier-server" > "${pv_server}.tmp" || \
+        fail "Failed to extract ${pv_os_archive_dir}/verifier-server from ${pv_tar_filename}."
+    mv "${pv_client}.tmp" "${pv_client}"
+    mv "${pv_server}.tmp" "${pv_server}"
+    chmod +x "${pv_client}" "${pv_server}"
 fi


### PR DESCRIPTION
Fedora 44 exposes several stale 9.2.x CI assumptions: newer curl
changed its CONNECT progress wording, proxy-verifier setup cannot rely
on host tools or full archive extraction in the CI bind mount, newer GCC
rejects plugin warning paths under -Werror, and several AuTest helpers
can stay alive after useful assertions finish.

This updates affected AuTests for current tool behavior, restores the
HTTP/2 flow-control replay payload size, keeps the plugin warning fixes
local, normalizes statichit's expected rejection logging, and backports
Fedora 44 helper fixes so proxy-verifier, pipeline, and command-argument
tests report behavior instead of cleanup races.