### PR TITLE
Fix txn_box unused find result

### DIFF
--- a/plugins/experimental/txn_box/unit_tests/test_accl_utils.cc
+++ b/plugins/experimental/txn_box/unit_tests/test_accl_utils.cc
@@ -337,8 +337,9 @@ TEST_CASE("Very basic perf test")
     }
     {
       func_timer<> f;
-      auto const  &took = f.run([&map]() { map.find("ASF.com"); });
-      std::cout << "std::unordered_map - insert(\"ASF.com\") took " << took << to_string<func_timer<>::unit>::value << std::endl;
+      // Only time the lookup dispatch; the returned iterator is intentionally unused.
+      auto const &took = f.run([&map]() { static_cast<void>(map.find("ASF.com")); });
+      std::cout << "std::unordered_map - find(\"ASF.com\") took " << took << to_string<func_timer<>::unit>::value << std::endl;
     }
   }
 }


### PR DESCRIPTION
Clang 22 treats the ignored std::unordered_map::find result in the
txn_box unit perf test as a warning, and the project builds with
warnings promoted to errors. The test therefore fails to compile even
though the lookup is intentionally only being timed.

This explicitly discards the lookup result in the benchmark lambda and
corrects the printed label to describe the lookup operation.