### PR TITLE
Fix server entry cleanup after request tunnel setup

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -2227,6 +2227,11 @@ HttpSM::state_send_server_request_header(int event, void *data)
           }
         }
       }
+      // The request body tunnel setup can synchronously abort the chain, which
+      // cleans up server_entry before returning here.
+      if (server_entry == nullptr) {
+        break;
+      }
       // Any other events to these read response
       if (server_entry->vc_type == HttpVC_t::SERVER_VC) {
         server_entry->vc_read_handler = &HttpSM::state_read_server_response_header;


### PR DESCRIPTION
A crash was observed while an HTTP/2 stream finished sending an
origin request header and started the client request body tunnel:

    #0 HttpSM::state_send_server_request_header(...)
       at src/proxy/http/HttpSM.cc:2176
    #1 HttpSM::main_handler(...)
       at src/proxy/http/HttpSM.cc:2731
    #5 Http2Stream::signal_write_event(...)
       at src/proxy/http2/Http2Stream.cc:954

The core had server_entry == nullptr at the vc_type check after the
request-body tunnel setup. The tunnel can synchronously abort the chain
and clean up the server VC before returning.

This checks whether the server entry still exists after setting up the
request body tunnel or transform tunnel. When setup already cleaned it
up, the state handler stops before installing a response-read handler
on a null entry.

