### PR TITLE
traffic_crashlog: fix false-positive crash logs on clean shutdown

### DIFF
--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -201,7 +201,6 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   FILE           *fp;
   char           *logname;
   crashlog_target target;
-  pid_t           parent = getppid();
 
   DiagsPtr::set(new Diags("traffic_crashlog", "" /* tags */, "" /* actions */, new BaseLogFile("stderr")));
 
@@ -213,12 +212,14 @@ main(int /* argc ATS_UNUSED */, const char **argv)
   if (wait_mode) {
     EnableDeathSignal(SIGCONT);
     kill(getpid(), SIGSTOP);
-  }
 
-  // If our parent changed, then we were woken after traffic_server exited. There's no point trying to
-  // emit a crashlog because traffic_server is gone.
-  if (getppid() != parent) {
-    return 0;
+    // A real crash sends us a notification on this socket; any other parent exit just closes
+    // it, so EOF (or a short read) means there is nothing to log. getppid() is unreliable here:
+    // PR_SET_PDEATHSIG can fire while our parent pid is still alive.
+    int crash_signo = 0; // unused; an int keeps the framing aligned with the writer
+    if (read(STDIN_FILENO, &crash_signo, sizeof(crash_signo)) != sizeof(crash_signo)) {
+      return 0;
+    }
   }
 
   runroot_handler(argv);

--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -216,8 +216,16 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     // A real crash sends us a notification on this socket; any other parent exit just closes
     // it, so EOF (or a short read) means there is nothing to log. getppid() is unreliable here:
     // PR_SET_PDEATHSIG can fire while our parent pid is still alive.
-    int crash_signo = 0; // unused; an int keeps the framing aligned with the writer
-    if (read(STDIN_FILENO, &crash_signo, sizeof(crash_signo)) != sizeof(crash_signo)) {
+    //
+    //
+    //
+    int     crash_signo = 0; // value unused; an int keeps the socket framing aligned with the writer
+    ssize_t nbytes;
+    do {
+      nbytes = read(STDIN_FILENO, &crash_signo, sizeof(crash_signo));
+    } while (nbytes < 0 && errno == EINTR);
+
+    if (nbytes != static_cast<ssize_t>(sizeof(crash_signo))) {
       return 0;
     }
   }

--- a/src/traffic_server/Crash.cc
+++ b/src/traffic_server/Crash.cc
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <unistd.h>
+#include <fcntl.h>
 #if defined(__linux__)
 #include <sys/prctl.h>
 #include <sys/syscall.h>
@@ -146,6 +147,10 @@ crash_logger_init(const char *user)
   crash_logger_pid = child;
   crash_logger_fd  = pipe[0];
 
+  // Don't leak this socket into later fork+exec children; the logger relies on seeing EOF
+  // here when we (its parent) exit.
+  fcntl(crash_logger_fd, F_SETFD, FD_CLOEXEC);
+
 #if defined(__linux__)
   // Allow the crash logger to ptrace us. Without this, Yama's ptrace_scope=1
   // (the default on many distros) prevents a child process from tracing its parent.
@@ -173,6 +178,10 @@ crash_logger_invoke(int signo, siginfo_t *info, void *ctx)
 
     // Let the crash logger free ...
     kill(crash_logger_pid, SIGCONT);
+
+    // Notify the logger that this is a real crash; a plain exit closes the socket (EOF)
+    // instead. Written on every platform, ahead of the Linux-only thread payload below.
+    ATS_UNUSED_RETURN(write(crash_logger_fd, &signo, sizeof(signo)));
 
 #if defined(__linux__)
     // Write the crashing thread information to the crash logger. While the siginfo_t is blesses by POSIX, the

--- a/tests/gold_tests/shutdown/crashlog_no_false_positive.test.py
+++ b/tests/gold_tests/shutdown/crashlog_no_false_positive.test.py
@@ -1,0 +1,73 @@
+'''
+Verify that a normal (SIGTERM) shutdown does not spuriously fire traffic_crashlog.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+
+Test.Summary = '''
+Verify that gracefully stopping traffic_server (SIGTERM) does not cause the crash
+log helper (traffic_crashlog) to emit a bogus crash log.
+
+Regression test: the crash log helper is parked with SIGSTOP and arms a
+parent-death signal (PR_SET_PDEATHSIG=SIGCONT). When traffic_server exits
+normally -- e.g. a routine SIGTERM shutdown -- the kernel resumes the helper via
+that death signal. The helper used to decide "did I wake because of a real crash
+or a plain exit?" with a racy getppid() check, and would lose the race and write
+an empty crash log against the already-exiting process. The fix replaces that
+guess with a handshake: crash_logger_invoke() writes the signal number to the
+helper, and a plain exit closes the socket so the helper reads EOF and stays
+quiet.
+
+Note: PR_SET_PDEATHSIG is a no-op on Darwin, so this false positive only occurs
+on Linux. On other platforms this test still confirms that the helper is armed
+and does not emit a crash log on a clean shutdown.
+'''
+
+ts = Test.MakeATSProcess('ts')
+
+ts.Disk.records_config.update(
+    {
+        # Enable the "server" debug tag so traffic_server emits the "received exit signal,
+        # shutting down" DIAG line (the shutdown anchor checked below) to traffic.out.
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'server',
+        # Force the crash log helper on regardless of the build's TS_USE_REMOTE_UNWINDING
+        # default (it is NULL on platforms without remote unwinding, e.g. Darwin).
+        'proxy.config.crash_log_helper': os.path.join(ts.Variables.BINDIR, 'traffic_crashlog'),
+    })
+
+tr = Test.AddTestRun('Start traffic_server with the crash log helper armed, then let AuTest SIGTERM it')
+tr.Processes.Default.Command = 'printf "crash log helper armed"'
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(ts)
+tr.StillRunningAfter = ts
+
+# Anchor the scenario: confirm traffic_server actually ran the graceful (SIGTERM) shutdown
+# path -- the exact trigger that woke the crash log helper in production. Without this the
+# ExcludesExpression checks below could pass without ever exercising shutdown. (The crash
+# log helper itself is forced on via proxy.config.crash_log_helper above, and debug/DIAG
+# output is emitted to traffic.out.)
+ts.Disk.traffic_out.Content = Testers.ContainsExpression(
+    'received exit signal, shutting down', 'traffic_server should have run the graceful shutdown path')
+
+# The crash log helper shares traffic_server's stderr (bound to traffic.out). On a clean
+# shutdown it must neither wake nor write a crash log.
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
+    'crashlog started', 'the crash log helper must not wake on a clean SIGTERM shutdown')
+ts.Disk.traffic_out.Content += Testers.ExcludesExpression(
+    'wrote crash log', 'a clean SIGTERM shutdown must not produce a crash log')


### PR DESCRIPTION
## Problem

On a normal `traffic_server` shutdown (e.g. SIGTERM), `traffic_crashlog` can
spuriously emit an empty crash log against the already-exiting process.

## Background

At startup, `traffic_server` forks `traffic_crashlog --wait`, which parks
itself:

```cpp
EnableDeathSignal(SIGCONT);   // prctl(PR_SET_PDEATHSIG, SIGCONT)
kill(getpid(), SIGSTOP);
```

The helper is therefore resumed by `SIGCONT` in **two** indistinguishable
situations:

1. **A real crash** — the crash signal handler `crash_logger_invoke()` explicitly sends `SIGCONT`.
2. **Any other parent exit** — the kernel's parent-death signal
   (`PR_SET_PDEATHSIG`, set to `SIGCONT` in #11614) resumes it.

To tell these apart the helper used `getppid() != parent`. That check is
racy: `PR_SET_PDEATHSIG` fires when the **thread that forked the helper**
terminates, which during a graceful shutdown happens while the rest of
`traffic_server` — and thus its PID — is still alive. So `getppid()` still
equals the original parent, the guard doesn't trip, and the helper proceeds
to write a crash log for a process that merely exited.

## Fix

Replace the `getppid()` guess with an explicit handshake over the socket
that already connects the two processes:

- `crash_logger_invoke()` writes the crashing signal number to the helper
  **before** the existing (Linux-only) thread payload. This is the only path
  that writes it.
- The helper, after being resumed, does a blocking `read()`:
  - **data** ⇒ a real crash ⇒ proceed and write the log;
  - **EOF / short read** ⇒ the parent is gone with no notification ⇒ exit
    quietly.
- `FD_CLOEXEC` is set on the parent's end of the socket so the write end is
  solely owned by `traffic_server`; that guarantees the helper sees EOF on
  parent death rather than blocking on an end inherited by a
  `popen()`/`system()` child.

`SIGCONT` (rather than `SIGKILL`) is retained deliberately: it lets the
helper survive a spurious/early wake, `read()` for the answer, and stay ready
for a later real crash — whereas `SIGKILL` would prematurely kill the helper
on the same forking-thread race and silently drop crash logging (and was
already moved away from in #11614).

## Testing

- New regression test
  `tests/gold_tests/shutdown/crashlog_no_false_positive.test.py`: arms the
  helper, lets AuTest SIGTERM `traffic_server`, and asserts the
  graceful-shutdown path ran (`received exit signal, shutting down`) while no
  crash log was produced (`crashlog started` / `wrote crash log` excluded).
- Existing `crash_test` (real crash → crash log produced) still passes on the
  parts this code governs.

## Notes

`PR_SET_PDEATHSIG` is Linux-only, so the false positive itself only occurs on
Linux; on macOS/FreeBSD the helper is simply never woken on a clean exit. The
regression test still confirms the "armed but quiet" behavior there.
