### PR TITLE
Downgrade H2 stream error log

### DIFF
--- a/src/proxy/http2/Http2ServerSession.cc
+++ b/src/proxy/http2/Http2ServerSession.cc
@@ -328,7 +328,7 @@ Http2ServerSession::new_transaction()
 
   if (!stream || connection_state.is_peer_concurrent_stream_ub()) {
     if (error.cls != Http2ErrorClass::HTTP2_ERROR_CLASS_NONE) {
-      Error("HTTP/2 stream error code=0x%02x %s", static_cast<int>(error.code), error.msg);
+      Http2SsnDebug("HTTP/2 stream error code=0x%02x %s", static_cast<int>(error.code), error.msg);
     }
 
     remove_session();


### PR DESCRIPTION
Malformed HTTP/2 parse errors can hit this path during normal
bad-client traffic, and logging each one at ERROR keeps diags noisy.
PR #13059 now emits transaction log entries for these malformed
requests, so operators can diagnose the rejected request without this
default error log noise.

This downgrades the stream creation failure message to the existing
HTTP/2 session debug path. Operators can still enable the http2_cs
debug tag when they need the protocol-level detail.