### PR TITLE
tools/clang-format.sh: cache clang-format in the common git dir

### DIFF
--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -24,8 +24,12 @@ PKGDATE="20240430"
 function main() {
   set -e # exit on error
 
-  GIT_DIR=$(git rev-parse --absolute-git-dir)
-  ROOT=${ROOT:-${GIT_DIR}/fmt/${PKGDATE}}
+  # Resolve the common git directory, which is shared by all linked worktrees, so the
+  # downloaded clang-format is cached and found in one place.  --git-common-dir can return a
+  # relative path, so make it absolute without --path-format (which needs git 2.31+); this
+  # matches how CMakeLists.txt resolves GIT_COMMON_DIR.
+  GIT_COMMON_DIR=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
   # The presence of this file indicates clang-format was successfully installed.
   INSTALLED_SENTINEL=${ROOT}/.clang-format-installed
 
@@ -38,7 +42,7 @@ function main() {
       exit 2
     fi
   fi
-  DIR=${@:-$(dirname ${GIT_DIR})}
+  DIR=${@:-$(git rev-parse --show-toplevel)}
   PACKAGE="clang-format-${PKGDATE}.tar.bz2"
   VERSION="clang-format version 18.1.2 (https://github.com/llvm/llvm-project.git 26a1d6601d727a96f4301d0d8647b5a42760ae0c)"
 
@@ -119,6 +123,6 @@ EOF
 if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then
   main "$@"
 else
-  GIT_DIR=$(git rev-parse --absolute-git-dir)
-  ROOT=${ROOT:-${GIT_DIR}/fmt/${PKGDATE}}
+  GIT_COMMON_DIR=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+  ROOT=${ROOT:-${GIT_COMMON_DIR}/fmt/${PKGDATE}}
 fi


### PR DESCRIPTION
### Problem

In a linked `git worktree`, `cmake --build build -t format` and the pre-commit hook fail with `No clang-format found`. `tools/clang-format.sh` resolves its download/cache directory with `git rev-parse --absolute-git-dir`, which in a worktree is the per-worktree git dir (`.git/worktrees/<name>`), not the shared `.git`. clang-format is installed once under the common dir, so the worktree looks in the wrong, empty place.

### Fix

Resolve the **common** git dir, which is shared by all worktrees — the same thing `CMakeLists.txt` already does to compute `GIT_COMMON_DIR`, so the script and CMake now agree on the cache location. `--git-common-dir` can return a relative path, so it is made absolute with `cd … && pwd`.

I deliberately avoided `git rev-parse --path-format=absolute --git-common-dir`: that exact form was removed in #11495 for a cmake 3.28 incompatibility (it needs git 2.31+). This restores the worktree support originally added in #11015 *without* reverting the #11495 fix.

Only `clang-format.sh` is affected — `yapf.sh`/`cmake-format.sh` now use `uv` and no longer cache under the git dir.

### Testing (git 2.43.0, cmake 3.28.3)

- Main checkout: pre-commit hook and format target behave as before.
- Linked worktree, with the binary installed only under the common `.git/fmt`: the pre-commit hook now finds clang-format and commits succeed (previously `No clang-format found`) — verified end-to-end with the `clangFormat.binary` fallback removed.
