### PR TITLE
tests: give cripts ATS startup a longer readiness window

### DIFF
--- a/tests/gold_tests/autest-site/trafficserver.test.ext
+++ b/tests/gold_tests/autest-site/trafficserver.test.ext
@@ -419,6 +419,9 @@ def MakeATSProcess(
         })
         # ATS_ROOT is used by compiler.sh to find the ATS install directory.
         p.Env['ATS_ROOT'] = p.Variables.PREFIX
+        # Cripts are compiled at startup, which can exceed the default 10s readiness window
+        # under CI load and flake the "fully initialized" wait. Give cripts startup more room.
+        p.StartupTimeout = 60
 
     # The following message was added so that tests and users can know when
     # Traffic Server is ready to both receive and optimize traffic.


### PR DESCRIPTION
### Problem

The `cripts` autest (`tests/gold_tests/cripts/cripts.test.py`) intermittently fails in CI with:

```
Run: Exercise traffic through cripts.: Failed
  Checking that Process is ready within 10.0 seconds so we can start process: Default - Failed
  Reason: Process failed to become ready in time: 10.0 seconds.
```

ATS never opens its port in time, so the subsequent runs cascade to connection-refused (`curl: (7)`). It's not deterministic — the same commit passes on a faster worker — which makes it a flaky-CI nuisance unrelated to whatever PR happens to run it.

### Cause

Cripts plugins are **compiled at ATS startup** (via `proxy.config.plugin.compiler_path`). Under CI load that compile can take longer than autest's default **10s** process-readiness window (the wait for `NOTE: Traffic Server is fully initialized`), so the readiness check times out before ATS finishes coming up.

### Fix

Bump `StartupTimeout` to 60s for cripts-enabled ATS processes in `MakeATSProcess`, so the compile-at-startup step has headroom. This is scoped to the `enable_cripts` branch, so only cripts tests are affected, and it follows the existing precedent of slow-startup tests setting `ts.StartupTimeout` (e.g. `jsonrpc/config_reload_*` use 30).
