### PR TITLE
dns: destruct HostEnt on free to fix SRV vector leak

### DIFF
--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -94,7 +94,7 @@ DNSProcessor                    dnsProcessor;
 ClassAllocator<DNSEntry, false> dnsEntryAllocator("dnsEntryAllocator");
 // Users are expected to free these entries in short order!
 // We could page align this buffer to enable page flipping for recv...
-ClassAllocator<HostEnt, false> dnsBufAllocator("dnsBufAllocator", 2);
+ClassAllocator<HostEnt> dnsBufAllocator("dnsBufAllocator", 2);
 
 //
 // Function Prototypes


### PR DESCRIPTION
## Summary

`dnsBufAllocator` is declared `ClassAllocator<HostEnt, false>` (i.e.
`Destruct_on_free = false`), so `HostEnt::free()` returns the block to the
free pool without running `~HostEnt`. `HostEnt` embeds an `SRVHosts` whose
`std::vector<SRV> hosts` owns heap storage. `ClassAllocator::alloc()`
always placement-constructs (`::new (ptr) C(...)`), so the next allocation
of a recycled block default-constructs a fresh empty vector over it,
overwriting and orphaning the previous buffer.

Result: every recycle of a `HostEnt` that held one or more SRV records
(populated via `srv_hosts.hosts.push_back` in `dns_process`) leaks one
vector buffer, up to `hostdb_round_robin_max_count` × `sizeof(SRV)` bytes.
The leak is conditional on `T_SRV` responses; A/AAAA/PTR responses leave
the vector empty and are unaffected.

This is a long-standing latent leak: it was harmless while `SRVHosts::hosts`
was a fixed array and became a leak once it changed to `std::vector`.

## Fix

Drop the `false` and use the default `Destruct_on_free = true` so
`~HostEnt` (hence `~vector<SRV>`) runs on free. `alloc()` already
placement-constructs, so construction and destruction stay balanced.

`HostEnt::free()` (reached only when a `Ptr<HostEnt>` refcount hits zero)
is the sole destruction path, no `HostEnt` field is read after free, and
the type is never treated as POD, so running the destructor is safe. The
hot A/AAAA path only destructs an empty vector.

## Testing

Verified under AddressSanitizer/LeakSanitizer with a standalone
reproduction faithful to the `ClassAllocator` alloc/free semantics: 1000
SRV recycle cycles leak ~16 MB with `Destruct_on_free = false` and zero
with `true`.
