### PR TITLE
fix: reject @ character in header names

### DIFF
--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -2426,12 +2426,11 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
     /////////////////////////////////////////////
 
     /**
-     * Fix for INKqa09141. The is_token function fails for '@' character.
-     * Header names starting with '@' signs are valid headers. Hence we
-     * have to add one more check to see if the first parameter is '@'
-     * character then, the header name is valid.
+     * RFC 9110 Section 5.1: Header field names must consist only of
+     * tchar characters. The '@' character is not a valid tchar, so
+     * header names containing '@' should be rejected as invalid.
      **/
-    if ((!ParseRules::is_token(*parsed)) && (*parsed != '@')) {
+    if (!ParseRules::is_token(*parsed)) {
       continue; // toss away garbage line
     }
 


### PR DESCRIPTION
## Summary

Remove the exception that allowed '@' character in header names.

## Changes

- Removed the special case that allowed '@' in header names
- Updated the comment to reference RFC 9110 Section 5.1

## Why

RFC 9110 Section 5.1 states that header field names must consist only of tchar characters:

```
tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
      / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
      / DIGIT / ALPHA
```

'@' is not in this list, so header names containing '@' should be rejected with a 400 response.

The previous fix for INKqa09141 incorrectly allowed '@' in header names.

Fixes #12082