### PR TITLE
Revert "Downgrade H2 stream error log"

### DIFF
--- a/src/proxy/http2/Http2ServerSession.cc
+++ b/src/proxy/http2/Http2ServerSession.cc
@@ -328,7 +328,7 @@ Http2ServerSession::new_transaction()
 
   if (!stream || connection_state.is_peer_concurrent_stream_ub()) {
     if (error.cls != Http2ErrorClass::HTTP2_ERROR_CLASS_NONE) {
-      Http2SsnDebug("HTTP/2 stream error code=0x%02x %s", static_cast<int>(error.code), error.msg);
+      Error("HTTP/2 stream error code=0x%02x %s", static_cast<int>(error.code), error.msg);
     }
 
     remove_session();


### PR DESCRIPTION
Reverts apache/trafficserver#13298

Claude noticed that there are two messages like this, and this is the wrong one. I thought "new_transaction", chosen by Codex, made sense. But we really want the one in `Http2ConnectionState::rcv_frame` for inbound client errors.