### PR TITLE
Downgrade inbound H2 stream error log

### DIFF
--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -1494,8 +1494,8 @@ Http2ConnectionState::rcv_frame(const Http2Frame *frame)
       // The Http2ClientSession will shutdown because connection_state.is_state_closed() will be true
     } else if (error.cls == Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM) {
       if (error.msg) {
-        Error("HTTP/2 stream error code=0x%02x client_ip=%s session_id=%" PRId64 " stream_id=%u %s", static_cast<int>(error.code),
-              client_ip, session->get_connection_id(), stream_id, error.msg);
+        Http2StreamDebug(session, stream_id, "HTTP/2 stream error code=0x%02x client_ip=%s %s", static_cast<int>(error.code),
+                         client_ip, error.msg);
       }
       this->send_rst_stream_frame(stream_id, error.code);
 

--- a/tests/gold_tests/connect/h2_malformed_request_logging.test.py
+++ b/tests/gold_tests/connect/h2_malformed_request_logging.test.py
@@ -121,7 +121,7 @@ logging:
       format: malformed_h2_request
       mode: ascii
 """.split('\n'))
-        self._ts.Disk.diags_log.Content = Testers.ContainsExpression(
+        self._ts.Disk.traffic_out.Content += Testers.ContainsExpression(
             'recv headers malformed request',
             'ATS should reject malformed requests at the HTTP/2 layer.',
         )


### PR DESCRIPTION
Malformed client HTTP/2 streams can produce noisy error-level
diagnostics even though the malformed parse details are now available
in transaction logs via apache/trafficserver#13059.

This downgrades the inbound rcv_frame stream-error diagnostic to
Http2StreamDebug while leaving outbound stream creation errors at Error
level. This also updates the malformed request AuTest to look for the
debug diagnostic in traffic.out.