### PR TITLE
Fix stale_response FORCE_SIE enum

### DIFF
--- a/tests/gold_tests/pluginTest/stale_response/stale_response.test.py
+++ b/tests/gold_tests/pluginTest/stale_response/stale_response.test.py
@@ -33,7 +33,10 @@ class OptionType(Enum):
     NONE = 0
     DEFAULT_DIRECTIVES = 1
     FORCE_SWR = 2
-    FORCE_SIE = 2
+    FORCE_SIE = 3
+
+
+assert len({option.value for option in OptionType.__members__.values()}) == len(OptionType.__members__)
 
 
 class TestStaleResponse:


### PR DESCRIPTION
Give the FORCE_SIE test mode its own enum value so the stale-if-error rows are not aliases of FORCE_SWR. Add a load-time guard to catch future duplicate OptionType values before the autest runs.