### PR TITLE
authproxy: strip request-body framing from auth sub-requests

### DIFF
--- a/plugins/authproxy/authproxy.cc
+++ b/plugins/authproxy/authproxy.cc
@@ -296,6 +296,16 @@ AuthWriteHeadRequest(AuthRequestContext *auth)
   // Next, we need to rewrite the client request URL to be a HEAD request.
   TSReleaseAssert(TSHttpHdrMethodSet(rq.buffer, rq.header, TS_HTTP_METHOD_HEAD, -1) == TS_SUCCESS);
 
+  // This sub-request is bodyless (HEAD + Content-Length: 0), but the copied
+  // client request may carry request-body framing (e.g. a chunked POST or
+  // Expect: 100-continue). Left in place it is self-contradictory: ATS sets up
+  // a request-body tunnel for a body that never arrives (stalling the probe
+  // until timeout), and proxy.config.http.reject_head_with_content rejects a
+  // HEAD that declares content. Strip the framing when forcing Content-Length: 0.
+  HttpRemoveMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_TRANSFER_ENCODING);
+  HttpRemoveMimeHeader(rq.buffer, rq.header, "Trailer");
+  HttpRemoveMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_EXPECT);
+
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_CONTENT_LENGTH, 0u);
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_CACHE_CONTROL, "no-cache");
 
@@ -332,6 +342,13 @@ AuthWriteRangeRequest(AuthRequestContext *auth)
   if (TS_HTTP_METHOD_GET != auth->method) {
     TSReleaseAssert(TSHttpHdrMethodSet(rq.buffer, rq.header, TS_HTTP_METHOD_GET, -1) == TS_SUCCESS);
   }
+
+  // The body is dropped (Content-Length: 0), so strip any request-body framing
+  // (Transfer-Encoding/Trailer/Expect) copied from the client request to keep
+  // the sub-request well-formed.
+  HttpRemoveMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_TRANSFER_ENCODING);
+  HttpRemoveMimeHeader(rq.buffer, rq.header, "Trailer");
+  HttpRemoveMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_EXPECT);
 
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_CONTENT_LENGTH, 0u);
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_RANGE, "bytes=0-0");
@@ -386,6 +403,14 @@ AuthWriteRedirectedRequest(AuthRequestContext *auth)
   TSHandleMLocRelease(rq.buffer, rq.header, murl);
 
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_HOST, hostbuf);
+
+  // The body is dropped (Content-Length: 0), so strip any request-body framing
+  // (Transfer-Encoding/Trailer/Expect) copied from the client request to keep
+  // the sub-request well-formed.
+  HttpRemoveMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_TRANSFER_ENCODING);
+  HttpRemoveMimeHeader(rq.buffer, rq.header, "Trailer");
+  HttpRemoveMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_EXPECT);
+
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_CONTENT_LENGTH, 0u);
   HttpSetMimeHeader(rq.buffer, rq.header, TS_MIME_FIELD_CACHE_CONTROL, "no-cache");
 

--- a/plugins/authproxy/utils.cc
+++ b/plugins/authproxy/utils.cc
@@ -101,6 +101,18 @@ HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string_view name, cons
   TSHandleMLocRelease(mbuf, mhdr, mloc);
 }
 
+void
+HttpRemoveMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name)
+{
+  TSMLoc mloc;
+
+  // A field may be repeated on multiple lines; destroy every instance.
+  while ((mloc = TSMimeHdrFieldFind(mbuf, mhdr, name, -1)) != TS_NULL_MLOC) {
+    TSReleaseAssert(TSMimeHdrFieldDestroy(mbuf, mhdr, mloc) == TS_SUCCESS);
+    TSHandleMLocRelease(mbuf, mhdr, mloc);
+  }
+}
+
 unsigned
 HttpGetContentLength(TSMBuffer mbuf, TSMLoc mhdr)
 {

--- a/plugins/authproxy/utils.h
+++ b/plugins/authproxy/utils.h
@@ -108,6 +108,9 @@ void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, const char
 void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name, unsigned value);
 void HttpSetMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const std::string_view name, const std::string_view value);
 
+// Remove every instance of an HTTP header.
+void HttpRemoveMimeHeader(TSMBuffer mbuf, TSMLoc mhdr, const char *name);
+
 // Dump the given HTTP header to the debug log.
 void HttpDebugHeader(TSMBuffer mbuf, TSMLoc mhdr);
 


### PR DESCRIPTION
The head/range/redirect auth transforms in the `authproxy` plugin copy the
whole client request and then force it bodyless (method override +
`Content-Length: 0`) to probe the auth server, but left `Transfer-Encoding`,
`Trailer`, and `Expect` in place. A chunked or `Expect: 100-continue` client
request therefore produced a self-contradictory sub-request: a bodyless
HEAD/GET still advertising a body.

ATS honors the framing and sets up a request-body tunnel for a body that never
arrives, stalling the probe until the inactivity timeout; and
`proxy.config.http.reject_head_with_content` rejects a HEAD that declares
content outright. This strips `Transfer-Encoding`, `Trailer`, and `Expect`
when normalizing the sub-request to bodyless, in all three transforms
(head, range, redirect).

A small `HttpRemoveMimeHeader()` helper is added to `utils.{h,cc}` that
destroys every instance of a named field (these fields can be repeated across
multiple lines).
