### PR TITLE
Restore cqssrt log field dropped by the 11-Dev merge

### DIFF
--- a/doc/admin-guide/logging/formatting.en.rst
+++ b/doc/admin-guide/logging/formatting.en.rst
@@ -687,6 +687,7 @@ SSL / Encryption
 .. _cscert:
 .. _cqssl:
 .. _cqssr:
+.. _cqssrt:
 .. _cqssv:
 .. _cqssc:
 .. _cqssu:
@@ -711,9 +712,15 @@ cscert Client Request 1 if |TS| requested certificate from client during TLS
                       handshake. 0 otherwise.
 cqssl  Client Request SSL client request status indicates if this client
                       connection is over SSL.
-cqssr  Client Request SSL session ticket reused status; indicates if the current
-                      request hit the SSL session ticket and avoided a full SSL
-                      handshake.
+cqssr  Client Request SSL session resumption status; indicates whether the
+                      current request was resumed from a previous SSL session
+                      and avoided a full TLS handshake. Resumption may have
+                      been via a server side session cache or via a TLS session
+                      ticket, see cqssrt_ for the resumption type.
+cqssrt Client Request SSL resumption type; indicates the type of TLS session
+                      resumption used for this request. 0 for no resumption,
+                      1 for server session cache resumption, 2 for TLS session
+                      ticket resumption.
 cqssv  Client Request SSL version used to communicate with the client.
 cqssc  Client Request SSL Cipher used by |TS| to communicate with the client.
 cqssu  Client Request SSL Elliptic Curve used by |TS| to communicate with the

--- a/include/proxy/logging/LogAccess.h
+++ b/include/proxy/logging/LogAccess.h
@@ -162,6 +162,7 @@ public:
   int marshal_client_req_tcp_reused(char *);         // INT
   int marshal_client_req_is_ssl(char *);             // INT
   int marshal_client_req_ssl_reused(char *);         // INT
+  int marshal_client_ssl_resumption_type(char *);    // INT
   int marshal_client_req_is_internal(char *);        // INT
   int marshal_client_req_mptcp_state(char *);        // INT
   int marshal_client_security_protocol(char *);      // STR

--- a/include/proxy/logging/TransactionLogData.h
+++ b/include/proxy/logging/TransactionLogData.h
@@ -139,6 +139,7 @@ public:
   bool get_client_tcp_reused() const;
   bool get_client_connection_is_ssl() const;
   bool get_client_ssl_reused() const;
+  int  get_client_ssl_resumption_type() const;
   bool get_is_internal() const;
   bool get_server_connection_is_ssl() const;
   bool get_server_ssl_reused() const;

--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -565,6 +565,11 @@ Log::init_fields()
   global_field_list.add(field, false);
   field_symbol_hash.emplace("cqssr", field);
 
+  field = new LogField("client_req_ssl_resumption_type", "cqssrt", LogField::Type::sINT,
+                       &LogAccess::marshal_client_ssl_resumption_type, &LogAccess::unmarshal_int_to_str);
+  global_field_list.add(field, false);
+  field_symbol_hash.emplace("cqssrt", field);
+
   field = new LogField("client_req_is_internal", "cqint", LogField::Type::sINT, &LogAccess::marshal_client_req_is_internal,
                        &LogAccess::unmarshal_int_to_str);
   global_field_list.add(field, false);

--- a/src/proxy/logging/LogAccess.cc
+++ b/src/proxy/logging/LogAccess.cc
@@ -2287,6 +2287,15 @@ LogAccess::marshal_client_req_ssl_reused(char *buf)
 }
 
 int
+LogAccess::marshal_client_ssl_resumption_type(char *buf)
+{
+  if (buf) {
+    marshal_int(buf, m_data->get_client_ssl_resumption_type());
+  }
+  return INK_MIN_ALIGN;
+}
+
+int
 LogAccess::marshal_client_req_is_internal(char *buf)
 {
   if (buf) {

--- a/src/proxy/logging/TransactionLogData.cc
+++ b/src/proxy/logging/TransactionLogData.cc
@@ -783,6 +783,15 @@ TransactionLogData::get_client_ssl_reused() const
   return false;
 }
 
+int
+TransactionLogData::get_client_ssl_resumption_type() const
+{
+  if (likely(m_http_sm != nullptr)) {
+    return m_http_sm->get_user_agent().get_client_ssl_resumption_type();
+  }
+  return 0;
+}
+
 bool
 TransactionLogData::get_is_internal() const
 {


### PR DESCRIPTION
The `cqssrt` (client_req_ssl_resumption_type) log field added in #12404 was silently dropped from master by the 11-Dev integration merge (#12983, 8415cef661). A criss-cross merge resolution removed its registration in Log.cc and the LogAccess marshal path, while the supporting `HttpUserAgent::get_client_ssl_resumption_type()` machinery survived, leaving that accessor as dead code with no caller.

Re-register the field and re-add the marshal function plus the TransactionLogData bridge accessor so the orphaned machinery is wired back into the log system. Declare it as `sINT` (it marshals a single int), not the original dINT, matching the type/marshal-framing fix in #13223.