### PR TITLE
rate_limit: don't update metrics when a selector has no metrics: block

### DIFF
--- a/plugins/experimental/rate_limit/limiter.h
+++ b/plugins/experimental/rate_limit/limiter.h
@@ -180,7 +180,7 @@ template <class T> class RateLimiter
   using self_type = RateLimiter;
 
 public:
-  RateLimiter()                           = default;
+  RateLimiter() { _metrics.fill(TS_ERROR); }
   RateLimiter(self_type &&)               = delete;
   self_type &operator=(const self_type &) = delete;
   self_type &operator=(self_type &&)      = delete;


### PR DESCRIPTION
A rate_limit selector configured without a `metrics:` block should be a metrics no-op. It isn't.

`_metrics` is value-initialized to `0`, but `incrementMetric()` only suppresses the update when an entry equals the `TS_ERROR` (−1) sentinel that `metric_helper()` uses for "not registered":

```cpp
std::array<int, RATE_LIMITER_METRIC_MAX> _metrics{};   // value-initialized to 0

void incrementMetric(uint metric) {
  if (_metrics[metric] != TS_ERROR) {                  // 0 != -1 → true → does NOT skip
    TSStatIntIncrement(_metrics[metric], 1);           // increments an unregistered ID
  }
}
```

`_metrics` is only populated by `initializeMetrics()`, which `parseYaml()` calls only when a selector has a `metrics:` block. Without that block the guard never fires, so every queue/reject/expire/resume (`sni_limiter.cc`, `sni_selector.cc`, `txn_limiter.cc`) calls `TSStatIntIncrement()` on an unregistered ID. It currently lands on the reserved `proxy.process.api.metrics.bad_id` slot (id 0), so it's absorbed rather than fatal — but the plugin still shouldn't be emitting anything.

## Fix

Default `_metrics` to `TS_ERROR` in the constructor — the same "not registered" marker `metric_helper()` writes per element — so `incrementMetric()` stays a no-op until metrics are actually registered.

## Testing

The equivalent fix was validated under AddressSanitizer on a 10.x branch. Not built against `master` locally — relying on CI for the compile.
