### PR TITLE
Fix Proxy-Protocol log field symbols

### DIFF
--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -1067,12 +1067,12 @@ Log::init_fields()
   field = new LogField("proxy_protocol_src_ip", "pps", LogField::Type::IP, &LogAccess::marshal_proxy_protocol_src_ip,
                        &LogAccess::unmarshal_ip_to_str);
   global_field_list.add(field, false);
-  field_symbol_hash.emplace("ppsip", field);
+  field_symbol_hash.emplace("pps", field);
 
   field = new LogField("proxy_protocol_dst_ip", "ppd", LogField::Type::IP, &LogAccess::marshal_proxy_protocol_dst_ip,
                        &LogAccess::unmarshal_ip_to_str);
   global_field_list.add(field, false);
-  field_symbol_hash.emplace("ppdip", field);
+  field_symbol_hash.emplace("ppd", field);
 
   field = new LogField("proxy_protocol_authority", "ppa", LogField::Type::STRING, &LogAccess::marshal_proxy_protocol_authority,
                        &LogAccess::unmarshal_str);


### PR DESCRIPTION
## What

`Log::init_fields()` registered the Proxy Protocol source/destination IP log
fields into `field_symbol_hash` under `ppsip`/`ppdip`, but the `LogField`s
(and the documentation) use the symbols `pps`/`ppd`. This aligns the hash keys
with the actual symbols.

## Why this is not a critical bug

Obviously this is a bug, but logging output was not broken. Because 
`LogFieldList::find_by_symbol()` falls back to a linear scan by symbol on a 
hash miss, so `%<pps>`/`%<ppd>`  still resolved correctly. 

The mismatch only meant:

- the O(1) hash fast-path was skipped for these two fields (resolved via the
  slower fallback instead),
- the undocumented `ppsip`/`ppdip` aliases were silently accepted, and
- the hash-only conflict/replace check in `TSLogFieldRegister()` could
  mis-handle the `pps`/`ppd` symbols.

Note: formats that relied on the bogus `ppsip`/`ppdip` aliases will now be
rejected as unknown symbols; use the documented `pps`/`ppd`.
