### PR TITLE
Handle HTTP/2 1xx interim responses from the origin

### DIFF
--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -548,6 +548,13 @@ Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
     // Discard an interim (1xx) response from the
     // origin and wait for the final response on this stream.
     if (is_outbound_interim_response(stream)) {
+      // RFC 9113 8.1: a HEADERS frame with END_STREAM carrying an informational (1xx)
+      // status code is malformed. change_state() has already moved the stream toward
+      // closed, so the final response would have nowhere to go; reject as a stream error.
+      if (stream->receive_end_stream) {
+        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
+                          "1xx interim response must not set END_STREAM");
+      }
       Http2StreamDebug(this->session, stream_id, "received interim 1xx response from origin; awaiting final response");
       discard_interim_response(stream);
       this->session->interrupt_reading_frames();
@@ -1181,6 +1188,13 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
     // Discard an interim (1xx) response from the
     // origin and wait for the final response on this stream.
     if (is_outbound_interim_response(stream)) {
+      // RFC 9113 8.1: a HEADERS frame with END_STREAM carrying an informational (1xx)
+      // status code is malformed. change_state() has already moved the stream toward
+      // closed, so the final response would have nowhere to go; reject as a stream error.
+      if (stream->receive_end_stream) {
+        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
+                          "1xx interim response must not set END_STREAM");
+      }
       Http2StreamDebug(this->session, stream_id, "received interim 1xx response from origin; awaiting final response");
       discard_interim_response(stream);
       this->session->interrupt_reading_frames();

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -289,6 +289,29 @@ Http2ConnectionState::rcv_data_frame(const Http2Frame &frame)
  *   2. A HEADERS frame without the END_HEADERS flag set MUST be followed by a
  *      CONTINUATION frame
  */
+namespace
+{
+// An interim (1xx) response received on an outbound
+// (origin) HTTP/2 connection is not the final response. Detect it after the
+// header block is decoded so the caller can discard it and wait for the final
+// response, instead of merging it with the final response headers (which would
+// produce a duplicate :status pseudo-header that fails validation).
+bool
+is_outbound_interim_response(Http2Stream *stream)
+{
+  if (!stream->is_outbound_connection() || stream->trailing_header_is_possible()) {
+    return false;
+  }
+  const MIMEField *status_field = stream->get_receive_header()->field_find(PSEUDO_HEADER_STATUS);
+  if (status_field == nullptr) {
+    return false;
+  }
+  // An HTTP/2 :status is always exactly three ASCII digits; 1xx is informational.
+  auto value{status_field->value_get()};
+  return value.length() == 3 && value[0] == '1';
+}
+} // namespace
+
 Http2Error
 Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
 {
@@ -508,6 +531,15 @@ Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
     if (stream->receive_end_stream && !stream->payload_length_is_valid()) {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv data bad payload length");
+    }
+
+    // Discard an interim (1xx) response from the
+    // origin and wait for the final response on this stream.
+    if (is_outbound_interim_response(stream)) {
+      Http2StreamDebug(this->session, stream_id, "received interim 1xx response from origin; awaiting final response");
+      stream->reset_receive_headers();
+      this->session->interrupt_reading_frames();
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
     }
 
     // Set up the State Machine
@@ -1057,6 +1089,15 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
                         "continuation half close remote");
     case Http2StreamState::HTTP2_STREAM_STATE_IDLE:
       break;
+    case Http2StreamState::HTTP2_STREAM_STATE_HALF_CLOSED_LOCAL:
+      // On an outbound (origin) connection the response is
+      // received while the stream is half-closed (local); its header block may legitimately
+      // span CONTINUATION frames. The per-minute CONTINUATION flood limit still applies below.
+      if (!stream->is_outbound_connection()) {
+        return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
+                          "continuation bad state");
+      }
+      break;
     default:
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_CONNECTION, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "continuation bad state");
@@ -1123,6 +1164,15 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
     if (stream->receive_end_stream && !stream->payload_length_is_valid()) {
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_STREAM, Http2ErrorCode::HTTP2_ERROR_PROTOCOL_ERROR,
                         "recv data bad payload length");
+    }
+
+    // Discard an interim (1xx) response from the
+    // origin and wait for the final response on this stream.
+    if (is_outbound_interim_response(stream)) {
+      Http2StreamDebug(this->session, stream_id, "received interim 1xx response from origin; awaiting final response");
+      stream->reset_receive_headers();
+      this->session->interrupt_reading_frames();
+      return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
     }
 
     // Set up the State Machine

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -310,6 +310,18 @@ is_outbound_interim_response(Http2Stream *stream)
   auto value{status_field->value_get()};
   return value.length() == 3 && value[0] == '1';
 }
+
+// Discard a decoded interim (1xx) response along with its encoded header block so the
+// following final response is decoded into a clean buffer. Freeing header_blocks here
+// avoids leaking it when the next HEADERS frame allocates a new buffer.
+void
+discard_interim_response(Http2Stream *stream)
+{
+  stream->reset_receive_headers();
+  ats_free(stream->header_blocks);
+  stream->header_blocks        = nullptr;
+  stream->header_blocks_length = 0;
+}
 } // namespace
 
 Http2Error
@@ -537,7 +549,7 @@ Http2ConnectionState::rcv_headers_frame(const Http2Frame &frame)
     // origin and wait for the final response on this stream.
     if (is_outbound_interim_response(stream)) {
       Http2StreamDebug(this->session, stream_id, "received interim 1xx response from origin; awaiting final response");
-      stream->reset_receive_headers();
+      discard_interim_response(stream);
       this->session->interrupt_reading_frames();
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
     }
@@ -1170,7 +1182,7 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
     // origin and wait for the final response on this stream.
     if (is_outbound_interim_response(stream)) {
       Http2StreamDebug(this->session, stream_id, "received interim 1xx response from origin; awaiting final response");
-      stream->reset_receive_headers();
+      discard_interim_response(stream);
       this->session->interrupt_reading_frames();
       return Http2Error(Http2ErrorClass::HTTP2_ERROR_CLASS_NONE);
     }

--- a/src/proxy/http2/Http2ConnectionState.cc
+++ b/src/proxy/http2/Http2ConnectionState.cc
@@ -307,7 +307,8 @@ is_outbound_interim_response(Http2Stream *stream)
   if (status_field == nullptr) {
     return false;
   }
-  // An HTTP/2 :status is always exactly three ASCII digits; 1xx is informational.
+  // :status is origin-controlled and HeaderValidator only checks that it is present, so
+  // bound the length before indexing. RFC 9110 15 requires exactly three digits.
   auto value{status_field->value_get()};
   return value.length() == 3 && value[0] == '1';
 }
@@ -1228,14 +1229,22 @@ Http2ConnectionState::rcv_continuation_frame(const Http2Frame &frame)
       }
     }
 
-    // Set up the State Machine
-    SCOPED_MUTEX_LOCK(stream_lock, stream->mutex, this_ethread());
-    stream->mark_milestone(Http2StreamMilestone::START_TXN);
-    // This should be fine, need to verify whether we need to replace this with the
-    // "from_early_data" flag from the associated HEADERS frame.
-    stream->new_transaction(frame.is_from_early_data());
-    // Send request header to SM
-    stream->send_headers(*this);
+    // Set up the State Machine. An outbound stream and a trailing header block both
+    // already have a state machine attached, so only a new inbound request may start
+    // one; new_transaction() asserts that none is attached yet. This mirrors the
+    // equivalent branch in rcv_headers_frame().
+    if (!stream->is_outbound_connection() && !stream->trailing_header_is_possible()) {
+      SCOPED_MUTEX_LOCK(stream_lock, stream->mutex, this_ethread());
+      stream->mark_milestone(Http2StreamMilestone::START_TXN);
+      // This should be fine, need to verify whether we need to replace this with the
+      // "from_early_data" flag from the associated HEADERS frame.
+      stream->new_transaction(frame.is_from_early_data());
+      // Send request header to SM
+      stream->send_headers(*this);
+    } else {
+      // Propagate the response (or the trailer) to the existing state machine.
+      stream->send_headers(*this);
+    }
     // Give a chance to send response before reading next frame.
     this->session->interrupt_reading_frames();
   } else {

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -147,7 +147,7 @@ def main():
         except Exception as e:
             sys.stderr.write(f"tls error: {e}\n")
             continue
-        threading.Thread(target=lambda: handle(tls, args.mode), daemon=True).start()
+        threading.Thread(target=handle, args=(tls, args.mode), daemon=True).start()
     return 0
 
 

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -108,8 +108,8 @@ def handle(sock, mode):
 
 
 def make_cert():
-    cert = tempfile.NamedTemporaryFile(suffix=".crt", delete=False).name
-    key = tempfile.NamedTemporaryFile(suffix=".key", delete=False).name
+    cert = tempfile.NamedTemporaryFile(dir=".", suffix=".crt", delete=False).name
+    key = tempfile.NamedTemporaryFile(dir=".", suffix=".key", delete=False).name
     subprocess.run(
         [
             "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes", "-keyout", key, "-out", cert, "-days", "3", "-subj",

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -73,6 +73,10 @@ def send_response(sock, mode, sid):
         half = len(blk) // 2
         sock.sendall(frame(0x1, 0x0, sid, blk[:half]))  # HEADERS, no END_HEADERS
         sock.sendall(frame(0x9, 0x4, sid, blk[half:]))  # CONTINUATION, END_HEADERS
+    elif mode == "endstream":
+        # RFC 9113 8.1 violation: an informational (1xx) response with END_STREAM.
+        sock.sendall(frame(0x1, 0x5, sid, interim_block("103")))  # HEADERS: END_HEADERS | END_STREAM
+        return
     # mode "none": no interim
     sock.sendall(frame(0x1, 0x4, sid, final_block()))  # final HEADERS, END_HEADERS
     sock.sendall(frame(0x0, 0x1, sid, BODY))  # DATA, END_STREAM
@@ -125,7 +129,7 @@ def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("address")
     p.add_argument("port", type=int)
-    p.add_argument("--mode", default="single", choices=["single", "multi", "continue", "cont", "none"])
+    p.add_argument("--mode", default="single", choices=["single", "multi", "continue", "cont", "none", "endstream"])
     return p.parse_args()
 
 

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -80,7 +80,6 @@ def send_response(sock, mode, sid):
 
 def handle(sock, mode):
     sock.sendall(frame(0x4, 0x0, 0, b""))  # server SETTINGS
-    sock.sendall(frame(0x4, 0x1, 0, b""))  # SETTINGS ACK
     preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
     buf = b""
     preface_done = False
@@ -99,8 +98,11 @@ def handle(sock, mode):
             if len(buf) < 9 + ln:
                 break
             ftype = buf[3]
+            flags = buf[4]
             sid = int.from_bytes(buf[5:9], "big") & 0x7FFFFFFF
             buf = buf[9 + ln:]
+            if ftype == 0x4 and not (flags & 0x1):  # client SETTINGS -> ACK it
+                sock.sendall(frame(0x4, 0x1, 0, b""))
             if ftype == 0x1:  # a request HEADERS -> respond on the same stream
                 send_response(sock, mode, sid)
 

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -150,6 +150,7 @@ def main():
             tls = ctx.wrap_socket(conn, server_side=True)
         except Exception as e:
             sys.stderr.write(f"tls error: {e}\n")
+            conn.close()
             continue
         threading.Thread(target=handle, args=(tls, args.mode), daemon=True).start()
     return 0

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""An HTTP/2 (TLS) origin that sends a 1xx interim response before the final 200.
+
+Proxy Verifier cannot emit interim/1xx responses, so this hand-frames HTTP/2 so we
+can exercise ATS origin-side handling of 1xx interim responses.
+
+Modes (chosen by --mode):
+  single   : 103 Early Hints, then 200            (the deepwiki/Vercel case)
+  multi    : 103, 103, 100, then 200              (multiple sequential interims)
+  continue : 100 Continue, then 200
+  cont     : a single 103 whose header block is split across HEADERS+CONTINUATION,
+             then 200                              (multi-frame interim)
+  none     : 200 only                             (control; must always pass)
+"""
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import socket
+import ssl
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+
+BODY = b"interim-origin-body"
+
+
+def frame(ftype, flags, sid, payload):
+    return struct.pack(">I", len(payload))[1:] + bytes([ftype, flags]) + struct.pack(">I", sid) + payload
+
+
+def lit(name, value):
+    # HPACK literal header field without indexing, new name, no Huffman.
+    n = name.encode()
+    v = value.encode()
+    return b"\x00" + bytes([len(n)]) + n + bytes([len(v)]) + v
+
+
+def final_block():
+    return b"\x88" + lit("content-type", "text/plain")  # :status 200 (static idx 8)
+
+
+def interim_block(status):
+    return lit(":status", status) + lit("link", "</style.css>; rel=preload; as=style")
+
+
+def send_response(sock, mode, sid):
+    if mode == "single":
+        sock.sendall(frame(0x1, 0x4, sid, interim_block("103")))
+    elif mode == "multi":
+        sock.sendall(frame(0x1, 0x4, sid, interim_block("103")))
+        sock.sendall(frame(0x1, 0x4, sid, interim_block("103")))
+        sock.sendall(frame(0x1, 0x4, sid, interim_block("100")))
+    elif mode == "continue":
+        sock.sendall(frame(0x1, 0x4, sid, interim_block("100")))
+    elif mode == "cont":
+        blk = interim_block("103")
+        half = len(blk) // 2
+        sock.sendall(frame(0x1, 0x0, sid, blk[:half]))  # HEADERS, no END_HEADERS
+        sock.sendall(frame(0x9, 0x4, sid, blk[half:]))  # CONTINUATION, END_HEADERS
+    # mode "none": no interim
+    sock.sendall(frame(0x1, 0x4, sid, final_block()))  # final HEADERS, END_HEADERS
+    sock.sendall(frame(0x0, 0x1, sid, BODY))  # DATA, END_STREAM
+
+
+def handle(sock, mode):
+    sock.sendall(frame(0x4, 0x0, 0, b""))  # server SETTINGS
+    sock.sendall(frame(0x4, 0x1, 0, b""))  # SETTINGS ACK
+    preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+    buf = b""
+    preface_done = False
+    while True:
+        data = sock.recv(65535)
+        if not data:
+            return
+        buf += data
+        if not preface_done:
+            if len(buf) < len(preface):
+                continue
+            buf = buf[len(preface):]
+            preface_done = True
+        while len(buf) >= 9:
+            ln = int.from_bytes(buf[0:3], "big")
+            if len(buf) < 9 + ln:
+                break
+            ftype = buf[3]
+            sid = int.from_bytes(buf[5:9], "big") & 0x7FFFFFFF
+            buf = buf[9 + ln:]
+            if ftype == 0x1:  # a request HEADERS -> respond on the same stream
+                send_response(sock, mode, sid)
+
+
+def make_cert():
+    cert = tempfile.NamedTemporaryFile(suffix=".crt", delete=False).name
+    key = tempfile.NamedTemporaryFile(suffix=".key", delete=False).name
+    subprocess.run(
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes", "-keyout", key, "-out", cert, "-days", "3", "-subj",
+            "/CN=interim-origin"
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL)
+    return cert, key
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("address")
+    p.add_argument("port", type=int)
+    p.add_argument("--mode", default="single", choices=["single", "multi", "continue", "cont", "none"])
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    cert, key = make_cert()
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cert, key)
+    ctx.set_alpn_protocols(["h2"])
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((args.address, args.port))
+    srv.listen(16)
+    print(f"interim h2 origin listening on {args.address}:{args.port} mode={args.mode}", flush=True)
+    while True:
+        conn, _ = srv.accept()
+        try:
+            tls = ctx.wrap_socket(conn, server_side=True)
+        except Exception as e:
+            sys.stderr.write(f"tls error: {e}\n")
+            continue
+        threading.Thread(target=lambda: handle(tls, args.mode), daemon=True).start()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -40,26 +40,26 @@ import threading
 BODY = b"interim-origin-body"
 
 
-def frame(ftype, flags, sid, payload):
+def frame(ftype: int, flags: int, sid: int, payload: bytes) -> bytes:
     return struct.pack(">I", len(payload))[1:] + bytes([ftype, flags]) + struct.pack(">I", sid) + payload
 
 
-def lit(name, value):
+def lit(name: str, value: str) -> bytes:
     # HPACK literal header field without indexing, new name, no Huffman.
     n = name.encode()
     v = value.encode()
     return b"\x00" + bytes([len(n)]) + n + bytes([len(v)]) + v
 
 
-def final_block():
+def final_block() -> bytes:
     return b"\x88" + lit("content-type", "text/plain")  # :status 200 (static idx 8)
 
 
-def interim_block(status):
+def interim_block(status: str) -> bytes:
     return lit(":status", status) + lit("link", "</style.css>; rel=preload; as=style")
 
 
-def send_response(sock, mode, sid):
+def send_response(sock: ssl.SSLSocket, mode: str, sid: int) -> None:
     if mode == "single":
         sock.sendall(frame(0x1, 0x4, sid, interim_block("103")))
     elif mode == "multi":
@@ -82,36 +82,39 @@ def send_response(sock, mode, sid):
     sock.sendall(frame(0x0, 0x1, sid, BODY))  # DATA, END_STREAM
 
 
-def handle(sock, mode):
-    sock.sendall(frame(0x4, 0x0, 0, b""))  # server SETTINGS
-    preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
-    buf = b""
-    preface_done = False
-    while True:
-        data = sock.recv(65535)
-        if not data:
-            return
-        buf += data
-        if not preface_done:
-            if len(buf) < len(preface):
-                continue
-            buf = buf[len(preface):]
-            preface_done = True
-        while len(buf) >= 9:
-            ln = int.from_bytes(buf[0:3], "big")
-            if len(buf) < 9 + ln:
-                break
-            ftype = buf[3]
-            flags = buf[4]
-            sid = int.from_bytes(buf[5:9], "big") & 0x7FFFFFFF
-            buf = buf[9 + ln:]
-            if ftype == 0x4 and not (flags & 0x1):  # client SETTINGS -> ACK it
-                sock.sendall(frame(0x4, 0x1, 0, b""))
-            if ftype == 0x1:  # a request HEADERS -> respond on the same stream
-                send_response(sock, mode, sid)
+def handle(sock: ssl.SSLSocket, mode: str) -> None:
+    try:
+        sock.sendall(frame(0x4, 0x0, 0, b""))  # server SETTINGS
+        preface = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+        buf = b""
+        preface_done = False
+        while True:
+            data = sock.recv(65535)
+            if not data:  # client closed the connection
+                return
+            buf += data
+            if not preface_done:
+                if len(buf) < len(preface):
+                    continue
+                buf = buf[len(preface):]
+                preface_done = True
+            while len(buf) >= 9:
+                ln = int.from_bytes(buf[0:3], "big")
+                if len(buf) < 9 + ln:
+                    break
+                ftype = buf[3]
+                flags = buf[4]
+                sid = int.from_bytes(buf[5:9], "big") & 0x7FFFFFFF
+                buf = buf[9 + ln:]
+                if ftype == 0x4 and not (flags & 0x1):  # client SETTINGS -> ACK it
+                    sock.sendall(frame(0x4, 0x1, 0, b""))
+                if ftype == 0x1:  # a request HEADERS -> respond on the same stream
+                    send_response(sock, mode, sid)
+    finally:
+        sock.close()
 
 
-def make_cert():
+def make_cert() -> tuple[str, str]:
     cert = tempfile.NamedTemporaryFile(dir=".", suffix=".crt", delete=False).name
     key = tempfile.NamedTemporaryFile(dir=".", suffix=".key", delete=False).name
     subprocess.run(
@@ -125,7 +128,7 @@ def make_cert():
     return cert, key
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("address")
     p.add_argument("port", type=int)
@@ -133,7 +136,7 @@ def parse_args():
     return p.parse_args()
 
 
-def main():
+def main() -> int:
     args = parse_args()
     cert, key = make_cert()
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)

--- a/tests/gold_tests/h2/h2_interim_origin.py
+++ b/tests/gold_tests/h2/h2_interim_origin.py
@@ -5,12 +5,18 @@ Proxy Verifier cannot emit interim/1xx responses, so this hand-frames HTTP/2 so 
 can exercise ATS origin-side handling of 1xx interim responses.
 
 Modes (chosen by --mode):
-  single   : 103 Early Hints, then 200            (the deepwiki/Vercel case)
-  multi    : 103, 103, 100, then 200              (multiple sequential interims)
-  continue : 100 Continue, then 200
-  cont     : a single 103 whose header block is split across HEADERS+CONTINUATION,
-             then 200                              (multi-frame interim)
-  none     : 200 only                             (control; must always pass)
+  single     : 103 Early Hints, then 200          (the common CDN/framework preload case)
+  multi      : 103, 103, 100, then 200            (multiple sequential interims)
+  continue   : 100 Continue, then 200
+  cont       : a single 103 whose header block is split across HEADERS+CONTINUATION,
+               then 200                            (multi-frame interim)
+  none       : 200 only                           (control; must always pass)
+  endstream  : a 103 carrying END_STREAM           (malformed, RFC 9113 8.1)
+  finalsplit : no interim; the FINAL 200 header block spans HEADERS+CONTINUATION
+
+Mode names are used as remap path prefixes, and remap matches first-rule-wins on the
+path prefix. Do not name a mode so that it extends another mode's name, or requests for
+the longer path will be routed to the shorter mode's origin.
 """
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
@@ -77,6 +83,16 @@ def send_response(sock: ssl.SSLSocket, mode: str, sid: int) -> None:
         # RFC 9113 8.1 violation: an informational (1xx) response with END_STREAM.
         sock.sendall(frame(0x1, 0x5, sid, interim_block("103")))  # HEADERS: END_HEADERS | END_STREAM
         return
+    elif mode == "finalsplit":
+        # The FINAL response header block spans HEADERS+CONTINUATION, with no interim
+        # response at all. Legal HTTP/2 at any block size; nothing requires the block to
+        # exceed SETTINGS_MAX_FRAME_SIZE for a sender to split it.
+        blk = final_block()
+        half = len(blk) // 2
+        sock.sendall(frame(0x1, 0x0, sid, blk[:half]))  # HEADERS, no END_HEADERS
+        sock.sendall(frame(0x9, 0x4, sid, blk[half:]))  # CONTINUATION, END_HEADERS
+        sock.sendall(frame(0x0, 0x1, sid, BODY))  # DATA, END_STREAM
+        return
     # mode "none": no interim
     sock.sendall(frame(0x1, 0x4, sid, final_block()))  # final HEADERS, END_HEADERS
     sock.sendall(frame(0x0, 0x1, sid, BODY))  # DATA, END_STREAM
@@ -132,7 +148,7 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("address")
     p.add_argument("port", type=int)
-    p.add_argument("--mode", default="single", choices=["single", "multi", "continue", "cont", "none", "endstream"])
+    p.add_argument("--mode", default="single", choices=["single", "multi", "continue", "cont", "none", "endstream", "finalsplit"])
     return p.parse_args()
 
 

--- a/tests/gold_tests/h2/http2_origin_interim_response.test.py
+++ b/tests/gold_tests/h2/http2_origin_interim_response.test.py
@@ -87,7 +87,7 @@ for mode in MODES:
     tr.Processes.Default.ReturnCode = 0
     tr.StillRunningAfter = ts
     for m in MODES + INTERIM_ONLY:
-        tr.StillRunningAfter = origins[m]
+        tr.StillRunningAfter += origins[m]
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(
         'HTTP/.* 200', f'mode={mode}: client must receive the final 200, not a 502')
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(

--- a/tests/gold_tests/h2/http2_origin_interim_response.test.py
+++ b/tests/gold_tests/h2/http2_origin_interim_response.test.py
@@ -27,6 +27,9 @@ from an origin over HTTP/2, returning the final 200 to the client.
 '''
 Test.ContinueOnFail = True
 
+# The test origin generates a self-signed certificate with the openssl CLI.
+Test.SkipUnless(Condition.HasProgram("openssl", "openssl needs to be installed and in PATH for this test"))
+
 ORIGIN = os.path.join(Test.TestDirectory, 'h2_interim_origin.py')
 
 # Each mode is a distinct origin behavior, routed by request path.

--- a/tests/gold_tests/h2/http2_origin_interim_response.test.py
+++ b/tests/gold_tests/h2/http2_origin_interim_response.test.py
@@ -36,6 +36,9 @@ ORIGIN = os.path.join(Test.TestDirectory, 'h2_interim_origin.py')
 #   cont     : 103 split across HEADERS+CONTINUATION, then 200
 #   none     : 200 only                 (control)
 MODES = ['single', 'multi', 'continue', 'cont', 'none']
+# 1xx with END_STREAM is malformed (RFC 9113 8.1); ATS must reject it so the client
+# does not hang waiting for a final response that can never arrive.
+INTERIM_ONLY = ['endstream']
 
 ts = Test.MakeATSProcess("ts", enable_tls=True)
 ts.addDefaultSSLFiles()
@@ -50,7 +53,7 @@ ssl_multicert:
 # Create an origin process per mode and build the remap table from their ports.
 origins = {}
 remap_lines = []
-for mode in MODES:
+for mode in MODES + INTERIM_ONLY:
     origin = Test.Processes.Process(f"origin-{mode}")
     port = get_port(origin, f"port_{mode}")
     origin.Command = f"{sys.executable} {ORIGIN} 127.0.0.1 {port} --mode {mode}"
@@ -76,16 +79,27 @@ first = True
 for mode in MODES:
     tr = Test.AddTestRun(f"h2 origin interim response: mode={mode}")
     if first:
-        for m in MODES:
+        for m in MODES + INTERIM_ONLY:
             tr.Processes.Default.StartBefore(origins[m])
         tr.Processes.Default.StartBefore(ts)
         first = False
     tr.MakeCurlCommand(f'-v -s -H "Host: ats.test" http://127.0.0.1:{ts.Variables.port}/{mode}', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.StillRunningAfter = ts
-    for m in MODES:
+    for m in MODES + INTERIM_ONLY:
         tr.StillRunningAfter = origins[m]
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(
         'HTTP/.* 200', f'mode={mode}: client must receive the final 200, not a 502')
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(
         'interim-origin-body', f'mode={mode}: client must receive the 200 response body')
+
+# 1xx + END_STREAM: ATS must reject the malformed interim response and fail the
+# transaction promptly (a 5xx), not silently drop it and leave the client hanging.
+tr = Test.AddTestRun("h2 origin interim response: mode=endstream (1xx with END_STREAM rejected)")
+tr.MakeCurlCommand(f'-v -s -H "Host: ats.test" http://127.0.0.1:{ts.Variables.port}/endstream', ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+    'HTTP/.* 5[0-9][0-9]', 'endstream: client must get a 5xx error, not hang')
+tr.Processes.Default.Streams.All += Testers.ExcludesExpression(
+    'interim-origin-body', 'endstream: client must not receive a 200 body')

--- a/tests/gold_tests/h2/http2_origin_interim_response.test.py
+++ b/tests/gold_tests/h2/http2_origin_interim_response.test.py
@@ -83,6 +83,8 @@ for mode in MODES:
     tr.MakeCurlCommand(f'-v -s -H "Host: ats.test" http://127.0.0.1:{ts.Variables.port}/{mode}', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.StillRunningAfter = ts
+    for m in MODES:
+        tr.StillRunningAfter = origins[m]
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(
         'HTTP/.* 200', f'mode={mode}: client must receive the final 200, not a 502')
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(

--- a/tests/gold_tests/h2/http2_origin_interim_response.test.py
+++ b/tests/gold_tests/h2/http2_origin_interim_response.test.py
@@ -1,0 +1,89 @@
+'''
+Verify ATS handles HTTP/2 1xx interim responses from the origin.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+from ports import get_port
+
+Test.Summary = '''
+Verify ATS correctly handles 1xx interim responses (e.g. 103 Early Hints) received
+from an origin over HTTP/2, returning the final 200 to the client.
+'''
+Test.ContinueOnFail = True
+
+ORIGIN = os.path.join(Test.TestDirectory, 'h2_interim_origin.py')
+
+# Each mode is a distinct origin behavior, routed by request path.
+#   single   : 103 then 200            (the deepwiki/Vercel case)
+#   multi    : 103,103,100 then 200     (multiple sequential interims)
+#   continue : 100 then 200
+#   cont     : 103 split across HEADERS+CONTINUATION, then 200
+#   none     : 200 only                 (control)
+MODES = ['single', 'multi', 'continue', 'cont', 'none']
+
+ts = Test.MakeATSProcess("ts", enable_tls=True)
+ts.addDefaultSSLFiles()
+ts.Disk.ssl_multicert_yaml.AddLines(
+    """
+ssl_multicert:
+  - dest_ip: "*"
+    ssl_cert_name: server.pem
+    ssl_key_name: server.key
+""".split("\n"))
+
+# Create an origin process per mode and build the remap table from their ports.
+origins = {}
+remap_lines = []
+for mode in MODES:
+    origin = Test.Processes.Process(f"origin-{mode}")
+    port = get_port(origin, f"port_{mode}")
+    origin.Command = f"{sys.executable} {ORIGIN} 127.0.0.1 {port} --mode {mode}"
+    origin.Ready = When.PortOpenv4(port)
+    origins[mode] = origin
+    remap_lines.append(f"map http://ats.test/{mode} https://127.0.0.1:{port}/")
+
+ts.Disk.remap_config.AddLines(remap_lines)
+ts.Disk.records_config.update(
+    {
+        'proxy.config.ssl.server.cert.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.server.private_key.path': ts.Variables.SSLDir,
+        'proxy.config.ssl.client.alpn_protocols': 'h2,http/1.1',
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
+        'proxy.config.http.server_session_sharing.pool': 'thread',
+        'proxy.config.exec_thread.autoconfig.enabled': 0,
+        'proxy.config.exec_thread.limit': 4,
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http2',
+    })
+
+first = True
+for mode in MODES:
+    tr = Test.AddTestRun(f"h2 origin interim response: mode={mode}")
+    if first:
+        for m in MODES:
+            tr.Processes.Default.StartBefore(origins[m])
+        tr.Processes.Default.StartBefore(ts)
+        first = False
+    tr.MakeCurlCommand(f'-v -s -H "Host: ats.test" http://127.0.0.1:{ts.Variables.port}/{mode}', ts=ts)
+    tr.Processes.Default.ReturnCode = 0
+    tr.StillRunningAfter = ts
+    tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+        'HTTP/.* 200', f'mode={mode}: client must receive the final 200, not a 502')
+    tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+        'interim-origin-body', f'mode={mode}: client must receive the 200 response body')

--- a/tests/gold_tests/h2/http2_origin_interim_response.test.py
+++ b/tests/gold_tests/h2/http2_origin_interim_response.test.py
@@ -42,6 +42,10 @@ MODES = ['single', 'multi', 'continue', 'cont', 'none']
 # 1xx with END_STREAM is malformed (RFC 9113 8.1); ATS must reject it so the client
 # does not hang waiting for a final response that can never arrive.
 INTERIM_ONLY = ['endstream']
+# finalsplit: the FINAL response header block spans HEADERS+CONTINUATION with no interim.
+# This is the only path the HALF_CLOSED_LOCAL relaxation newly makes reachable; the
+# `cont` mode returns early on the interim check and never gets there.
+PROBE = ['finalsplit']
 
 ts = Test.MakeATSProcess("ts", enable_tls=True)
 ts.addDefaultSSLFiles()
@@ -56,7 +60,7 @@ ssl_multicert:
 # Create an origin process per mode and build the remap table from their ports.
 origins = {}
 remap_lines = []
-for mode in MODES + INTERIM_ONLY:
+for mode in MODES + INTERIM_ONLY + PROBE:
     origin = Test.Processes.Process(f"origin-{mode}")
     port = get_port(origin, f"port_{mode}")
     origin.Command = f"{sys.executable} {ORIGIN} 127.0.0.1 {port} --mode {mode}"
@@ -75,21 +79,21 @@ ts.Disk.records_config.update(
         'proxy.config.exec_thread.autoconfig.enabled': 0,
         'proxy.config.exec_thread.limit': 4,
         'proxy.config.diags.debug.enabled': 1,
-        'proxy.config.diags.debug.tags': 'http2',
+        'proxy.config.diags.debug.tags': 'http2|http',
     })
 
 first = True
 for mode in MODES:
     tr = Test.AddTestRun(f"h2 origin interim response: mode={mode}")
     if first:
-        for m in MODES + INTERIM_ONLY:
+        for m in MODES + INTERIM_ONLY + PROBE:
             tr.Processes.Default.StartBefore(origins[m])
         tr.Processes.Default.StartBefore(ts)
         first = False
     tr.MakeCurlCommand(f'-v -s -H "Host: ats.test" http://127.0.0.1:{ts.Variables.port}/{mode}', ts=ts)
     tr.Processes.Default.ReturnCode = 0
     tr.StillRunningAfter = ts
-    for m in MODES + INTERIM_ONLY:
+    for m in MODES + INTERIM_ONLY + PROBE:
         tr.StillRunningAfter += origins[m]
     tr.Processes.Default.Streams.All += Testers.ContainsExpression(
         'HTTP/.* 200', f'mode={mode}: client must receive the final 200, not a 502')
@@ -106,3 +110,17 @@ tr.Processes.Default.Streams.All += Testers.ContainsExpression(
     'HTTP/.* 5[0-9][0-9]', 'endstream: client must get a 5xx error, not hang')
 tr.Processes.Default.Streams.All += Testers.ExcludesExpression(
     'interim-origin-body', 'endstream: client must not receive a 200 body')
+
+# A final (non-1xx) response whose header block spans HEADERS+CONTINUATION on an
+# outbound stream. This is the path the HALF_CLOSED_LOCAL relaxation actually opened:
+# the interim check returns early, so rcv_continuation_frame() runs to completion and
+# reaches the inbound-only new_transaction() call that rcv_headers_frame() guards with
+# !is_outbound_connection().
+tr = Test.AddTestRun("h2 origin: final response split across HEADERS+CONTINUATION")
+tr.MakeCurlCommand(f'-v -s --max-time 10 -H "Host: ats.test" http://127.0.0.1:{ts.Variables.port}/finalsplit', ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = ts
+tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+    'HTTP/.* 200', 'finalsplit: a CONTINUATION-split final response must yield a 200')
+tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+    'interim-origin-body', 'finalsplit: client must receive the 200 response body')


### PR DESCRIPTION
## Problem

ATS did not handle 1xx interim responses (for example `103 Early Hints`) on an outbound HTTP/2 connection. The interim headers decoded into the same buffer as the following final response, producing a duplicate `:status` that failed validation. ATS reset the stream and reported "Server closed connection while reading response header" to the client, returning a 502 even though the origin had not closed the connection. It reproduces against any origin sending `103` before the final response.

## Fix

- Detect a `1xx` status after an outbound header block decodes, discard the interim headers and their encoded buffer, and wait for the final response. Both the HEADERS and CONTINUATION paths, and any number of consecutive interim responses. The interim response is not forwarded to the client.
- An interim response carrying END_STREAM is malformed per RFC 9113 section 8.1. Discarding it left the final response nowhere to go and the client hanging, so it returns a stream `PROTOCOL_ERROR`.
- Accept CONTINUATION on an outbound stream in half-closed (local), the state an origin response arrives in. Previously rejected as "continuation bad state". The flood limit still applies.
- Start a transaction in `rcv_continuation_frame()` only for a new inbound request. Relaxing the state above reached the rest of that function, which is inbound-only: `new_transaction()` opens with `ink_release_assert(_sm == nullptr)`, and an outbound stream always has a state machine, so any origin splitting a response header block aborted `traffic_server`. A 26 byte block reproduces.

## Testing

Adds `tests/gold_tests/h2/http2_origin_interim_response.test.py` with a hand-framed HTTP/2 origin, since Proxy Verifier cannot emit interim responses. Modes cover a single `103`, consecutive interim responses, `100-continue`, a CONTINUATION-split interim, an interim with END_STREAM, and `finalsplit`, a final `200` split across HEADERS and CONTINUATION with no interim at all. That last one exists because `cont` returns early on the interim check and never reaches `new_transaction()`. Confirmed failing before and passing after; `early_hints` and `h2origin` still pass.

Fixes #13334

<!-- merge-description-updated:2026-09-22T04:11:25Z -->