### PR TITLE
Reject over-long unix socket paths in server_ports

### DIFF
--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1609,7 +1609,7 @@ IpAddr::hash() const
 struct UnAddr {
   using self = UnAddr;
 
-  UnAddr() = default;
+  UnAddr() { _path[0] = 0; }
 
   UnAddr(self const &addr) { ink_strlcpy(_path, addr._path, TS_UNIX_SIZE); }
   explicit UnAddr(const char *path) { ink_strlcpy(_path, path, TS_UNIX_SIZE); }
@@ -1620,7 +1620,7 @@ struct UnAddr {
   /// Construct from @c IpEndpoint.
   explicit UnAddr(IpEndpoint const &addr) { this->assign(&addr.sa); }
   /// Construct from @c IpEndpoint.
-  explicit UnAddr(IpEndpoint const *addr)
+  explicit UnAddr(IpEndpoint const *addr) : UnAddr()
   {
     if (addr) {
       this->assign(&addr->sa);
@@ -1650,9 +1650,7 @@ struct UnAddr {
     return *this;
   }
 
-  // Default-initialized so a constructor whose assign() gets a null address (which leaves
-  // the buffer untouched) still yields a valid empty C string instead of uninitialized bytes.
-  char _path[TS_UNIX_SIZE]{};
+  char _path[TS_UNIX_SIZE];
 };
 
 inline UnAddr &
@@ -1662,6 +1660,8 @@ UnAddr::assign(sockaddr const *addr)
     // A kernel sockaddr_un may carry a full, unterminated sun_path.
     strncpy(_path, ats_unix_cast(addr)->sun_path, TS_UNIX_SIZE - 1);
     _path[TS_UNIX_SIZE - 1] = '\0';
+  } else {
+    _path[0] = '\0';
   }
   return *this;
 }

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1610,8 +1610,13 @@ struct UnAddr {
 
   UnAddr() { _path[0] = 0; }
 
-  UnAddr(self const &addr) { strncpy(_path, addr._path, TS_UNIX_SIZE); }
-  // strncpy writes no terminator when it truncates.
+  // strncpy writes no terminator when it truncates, so every path that fills _path
+  // terminates it explicitly.
+  UnAddr(self const &addr)
+  {
+    strncpy(_path, addr._path, TS_UNIX_SIZE - 1);
+    _path[TS_UNIX_SIZE - 1] = '\0';
+  }
   explicit UnAddr(const char *path)
   {
     strncpy(_path, path, TS_UNIX_SIZE - 1);
@@ -1648,7 +1653,8 @@ struct UnAddr {
   operator=(self const &addr)
   {
     if (this != &addr) {
-      strncpy(_path, addr._path, TS_UNIX_SIZE);
+      strncpy(_path, addr._path, TS_UNIX_SIZE - 1);
+      _path[TS_UNIX_SIZE - 1] = '\0';
     }
     return *this;
   }
@@ -1660,7 +1666,9 @@ inline UnAddr &
 UnAddr::assign(sockaddr const *addr)
 {
   if (addr) {
-    strncpy(_path, ats_unix_cast(addr)->sun_path, TS_UNIX_SIZE);
+    // A kernel sockaddr_un may carry a full, unterminated sun_path.
+    strncpy(_path, ats_unix_cast(addr)->sun_path, TS_UNIX_SIZE - 1);
+    _path[TS_UNIX_SIZE - 1] = '\0';
   }
   return *this;
 }

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -34,6 +34,7 @@
 
 #include "tscore/ink_memory.h"
 #include "tscore/ink_apidefs.h"
+#include "tscore/ink_string.h"
 #include "swoc/bwf_fwd.h"
 
 #if !TS_HAS_IN6_IS_ADDR_UNSPECIFIED
@@ -1610,23 +1611,9 @@ struct UnAddr {
 
   UnAddr() { _path[0] = 0; }
 
-  // strncpy writes no terminator when it truncates, so every path that fills _path
-  // terminates it explicitly.
-  UnAddr(self const &addr)
-  {
-    strncpy(_path, addr._path, TS_UNIX_SIZE - 1);
-    _path[TS_UNIX_SIZE - 1] = '\0';
-  }
-  explicit UnAddr(const char *path)
-  {
-    strncpy(_path, path, TS_UNIX_SIZE - 1);
-    _path[TS_UNIX_SIZE - 1] = '\0';
-  }
-  explicit UnAddr(const std::string &path)
-  {
-    strncpy(_path, path.c_str(), TS_UNIX_SIZE - 1);
-    _path[TS_UNIX_SIZE - 1] = '\0';
-  }
+  UnAddr(self const &addr) { ink_strlcpy(_path, addr._path, TS_UNIX_SIZE); }
+  explicit UnAddr(const char *path) { ink_strlcpy(_path, path, TS_UNIX_SIZE); }
+  explicit UnAddr(const std::string &path) { ink_strlcpy(_path, path.c_str(), TS_UNIX_SIZE); }
 
   explicit UnAddr(sockaddr const *addr) { this->assign(addr); }
   explicit UnAddr(sockaddr_un const *addr) { this->assign(ats_ip_sa_cast(addr)); }
@@ -1653,8 +1640,7 @@ struct UnAddr {
   operator=(self const &addr)
   {
     if (this != &addr) {
-      strncpy(_path, addr._path, TS_UNIX_SIZE - 1);
-      _path[TS_UNIX_SIZE - 1] = '\0';
+      ink_strlcpy(_path, addr._path, TS_UNIX_SIZE);
     }
     return *this;
   }

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1611,8 +1611,17 @@ struct UnAddr {
   UnAddr() { _path[0] = 0; }
 
   UnAddr(self const &addr) { strncpy(_path, addr._path, TS_UNIX_SIZE); }
-  explicit UnAddr(const char *path) { strncpy(_path, path, TS_UNIX_SIZE - 1); }
-  explicit UnAddr(const std::string &path) { strncpy(_path, path.c_str(), TS_UNIX_SIZE); }
+  // strncpy writes no terminator when it truncates.
+  explicit UnAddr(const char *path)
+  {
+    strncpy(_path, path, TS_UNIX_SIZE - 1);
+    _path[TS_UNIX_SIZE - 1] = '\0';
+  }
+  explicit UnAddr(const std::string &path)
+  {
+    strncpy(_path, path.c_str(), TS_UNIX_SIZE - 1);
+    _path[TS_UNIX_SIZE - 1] = '\0';
+  }
 
   explicit UnAddr(sockaddr const *addr) { this->assign(addr); }
   explicit UnAddr(sockaddr_un const *addr) { this->assign(ats_ip_sa_cast(addr)); }

--- a/include/tscore/ink_inet.h
+++ b/include/tscore/ink_inet.h
@@ -1609,7 +1609,7 @@ IpAddr::hash() const
 struct UnAddr {
   using self = UnAddr;
 
-  UnAddr() { _path[0] = 0; }
+  UnAddr() = default;
 
   UnAddr(self const &addr) { ink_strlcpy(_path, addr._path, TS_UNIX_SIZE); }
   explicit UnAddr(const char *path) { ink_strlcpy(_path, path, TS_UNIX_SIZE); }
@@ -1620,7 +1620,12 @@ struct UnAddr {
   /// Construct from @c IpEndpoint.
   explicit UnAddr(IpEndpoint const &addr) { this->assign(&addr.sa); }
   /// Construct from @c IpEndpoint.
-  explicit UnAddr(IpEndpoint const *addr) { this->assign(&addr->sa); }
+  explicit UnAddr(IpEndpoint const *addr)
+  {
+    if (addr) {
+      this->assign(&addr->sa);
+    }
+  }
   /// Assign sockaddr storage.
   self &assign(sockaddr const *addr);
 
@@ -1645,7 +1650,9 @@ struct UnAddr {
     return *this;
   }
 
-  char _path[TS_UNIX_SIZE];
+  // Default-initialized so a constructor whose assign() gets a null address (which leaves
+  // the buffer untouched) still yields a valid empty C string instead of uninitialized bytes.
+  char _path[TS_UNIX_SIZE]{};
 };
 
 inline UnAddr &

--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -368,10 +368,16 @@ HttpProxyPort::processOptions(const char *opts)
 
   for (auto item : values) {
     if (item[0] == '/') {
-      m_family    = AF_UNIX;
-      m_unix_path = UnAddr(item);
-      af_set_p    = true;
-      zret        = true;
+      if (size_t len = strlen(item); len >= TS_UNIX_SIZE) {
+        // A longer path would be silently truncated and the listener bound to the wrong
+        // filesystem path.
+        Warning("Unix path '%s' in port configuration '%s' is too long (%zu bytes, max %zu)", item, opts, len, TS_UNIX_SIZE - 1);
+      } else {
+        m_family    = AF_UNIX;
+        m_unix_path = UnAddr(item);
+        af_set_p    = true;
+        zret        = true;
+      }
     } else if (isdigit(item[0])) { // leading digit -> port value
       char *ptr;
       int   port = strtoul(item, &ptr, 10);

--- a/src/records/RecHttp.cc
+++ b/src/records/RecHttp.cc
@@ -370,14 +370,15 @@ HttpProxyPort::processOptions(const char *opts)
     if (item[0] == '/') {
       if (size_t len = strlen(item); len >= TS_UNIX_SIZE) {
         // A longer path would be silently truncated and the listener bound to the wrong
-        // filesystem path.
+        // filesystem path. Reject the whole descriptor so a later token (e.g. a numeric
+        // port) can't silently turn this into an INET listener.
         Warning("Unix path '%s' in port configuration '%s' is too long (%zu bytes, max %zu)", item, opts, len, TS_UNIX_SIZE - 1);
-      } else {
-        m_family    = AF_UNIX;
-        m_unix_path = UnAddr(item);
-        af_set_p    = true;
-        zret        = true;
+        return false;
       }
+      m_family    = AF_UNIX;
+      m_unix_path = UnAddr(item);
+      af_set_p    = true;
+      zret        = true;
     } else if (isdigit(item[0])) { // leading digit -> port value
       char *ptr;
       int   port = strtoul(item, &ptr, 10);

--- a/src/records/unit_tests/test_RecHttp.cc
+++ b/src/records/unit_tests/test_RecHttp.cc
@@ -97,6 +97,35 @@ TEST_CASE("RecHttp", "[librecords][RecHttp]")
     REQUIRE(view.find(":ssl") != TextView::npos);
     REQUIRE(view.find(":proto") == TextView::npos); // it's default, should not have this.
   }
+
+  SECTION("unix-path")
+  {
+    HttpProxyPort::loadValue(ports, "/run/ats/uds.socket");
+    REQUIRE(ports.size() == 1);
+    REQUIRE(ports[0].m_family == AF_UNIX);
+    REQUIRE(std::string_view(ports[0].m_unix_path._path) == "/run/ats/uds.socket");
+  }
+
+  SECTION("unix-path-max")
+  {
+    // Exactly TS_UNIX_SIZE - 1 bytes: the longest path that fits sun_path with its terminator.
+    std::string path = "/" + std::string(TS_UNIX_SIZE - 2, 'x');
+    HttpProxyPort::loadValue(ports, path.c_str());
+    REQUIRE(ports.size() == 1);
+    REQUIRE(ports[0].m_family == AF_UNIX);
+    REQUIRE(std::string_view(ports[0].m_unix_path._path) == path);
+  }
+
+  SECTION("unix-path-too-long")
+  {
+    // One byte past what sun_path can hold.
+    std::string path = "/" + std::string(TS_UNIX_SIZE - 1, 'x');
+    HttpProxyPort::loadValue(ports, path.c_str());
+    REQUIRE(ports.size() == 0);
+    // The reject itself, then loadValue's "No valid definition" for the dropped descriptor.
+    REQUIRE(cdiag->messages.size() == 2);
+    REQUIRE(cdiag->messages[0].find("too long") != std::string::npos);
+  }
 }
 
 struct ConvertAlpnToWireFormatTestCase {

--- a/src/records/unit_tests/test_RecHttp.cc
+++ b/src/records/unit_tests/test_RecHttp.cc
@@ -126,6 +126,16 @@ TEST_CASE("RecHttp", "[librecords][RecHttp]")
     REQUIRE(cdiag->messages.size() == 2);
     REQUIRE(cdiag->messages[0].find("too long") != std::string::npos);
   }
+
+  SECTION("unix-path-too-long-with-port")
+  {
+    // An over-long unix path followed by a numeric port must reject the whole descriptor,
+    // not silently fall back to an INET port listener.
+    std::string path = "/" + std::string(TS_UNIX_SIZE - 1, 'x') + ":8080";
+    HttpProxyPort::loadValue(ports, path.c_str());
+    REQUIRE(ports.size() == 0);
+    REQUIRE(cdiag->messages[0].find("too long") != std::string::npos);
+  }
 }
 
 struct ConvertAlpnToWireFormatTestCase {

--- a/src/records/unit_tests/test_RecHttp.cc
+++ b/src/records/unit_tests/test_RecHttp.cc
@@ -134,6 +134,8 @@ TEST_CASE("RecHttp", "[librecords][RecHttp]")
     std::string path = "/" + std::string(TS_UNIX_SIZE - 1, 'x') + ":8080";
     HttpProxyPort::loadValue(ports, path.c_str());
     REQUIRE(ports.size() == 0);
+    // The reject itself, then loadValue's "No valid definition" for the dropped descriptor.
+    REQUIRE(cdiag->messages.size() == 2);
     REQUIRE(cdiag->messages[0].find("too long") != std::string::npos);
   }
 }

--- a/src/tscore/unit_tests/test_ink_inet.cc
+++ b/src/tscore/unit_tests/test_ink_inet.cc
@@ -303,4 +303,13 @@ TEST_CASE("ink_inet_unix", "[libts][inet][unix]")
   UnAddr assigned;
   assigned = from_sockaddr;
   REQUIRE(assigned._path[TS_UNIX_SIZE - 1] == '\0');
+
+  // Constructing from a null address must leave _path an empty, terminated string so the copy
+  // paths don't read uninitialized memory.
+  UnAddr from_null_sa{static_cast<sockaddr const *>(nullptr)};
+  REQUIRE(from_null_sa._path[0] == '\0');
+  UnAddr from_null_ep{static_cast<IpEndpoint const *>(nullptr)};
+  REQUIRE(from_null_ep._path[0] == '\0');
+  UnAddr copied_null(from_null_sa);
+  REQUIRE(copied_null._path[0] == '\0');
 }

--- a/src/tscore/unit_tests/test_ink_inet.cc
+++ b/src/tscore/unit_tests/test_ink_inet.cc
@@ -280,4 +280,13 @@ TEST_CASE("ink_inet_unix", "[libts][inet][unix]")
 #if HAVE_STRUCT_SOCKADDR_UN_SUN_LEN
   REQUIRE(ep.sun.sun_len == SUN_LEN(&ep.sun));
 #endif
+
+  // An over-long path must still yield a null terminated _path.
+  std::string long_path(TS_UNIX_SIZE + 10, 'y');
+  UnAddr      from_cstr(long_path.c_str());
+  REQUIRE(from_cstr._path[TS_UNIX_SIZE - 1] == '\0');
+  REQUIRE(strlen(from_cstr._path) == TS_UNIX_SIZE - 1);
+  UnAddr from_string(long_path);
+  REQUIRE(from_string._path[TS_UNIX_SIZE - 1] == '\0');
+  REQUIRE(strlen(from_string._path) == TS_UNIX_SIZE - 1);
 }

--- a/src/tscore/unit_tests/test_ink_inet.cc
+++ b/src/tscore/unit_tests/test_ink_inet.cc
@@ -289,4 +289,18 @@ TEST_CASE("ink_inet_unix", "[libts][inet][unix]")
   UnAddr from_string(long_path);
   REQUIRE(from_string._path[TS_UNIX_SIZE - 1] == '\0');
   REQUIRE(strlen(from_string._path) == TS_UNIX_SIZE - 1);
+
+  // A kernel sockaddr_un may carry a full, unterminated sun_path; assign() and the copy
+  // paths must still yield a terminated _path.
+  IpEndpoint raw;
+  raw.sa.sa_family = AF_UNIX;
+  memset(raw.sun.sun_path, 'z', TS_UNIX_SIZE); // deliberately no terminator
+  UnAddr from_sockaddr(&raw.sa);
+  REQUIRE(from_sockaddr._path[TS_UNIX_SIZE - 1] == '\0');
+  REQUIRE(strlen(from_sockaddr._path) == TS_UNIX_SIZE - 1);
+  UnAddr copied(from_sockaddr);
+  REQUIRE(copied._path[TS_UNIX_SIZE - 1] == '\0');
+  UnAddr assigned;
+  assigned = from_sockaddr;
+  REQUIRE(assigned._path[TS_UNIX_SIZE - 1] == '\0');
 }


### PR DESCRIPTION
#### Problem
A unix domain socket path in `proxy.config.http.server_ports` longer than `sun_path` (108 bytes including the terminator) is silently truncated: `UnAddr`'s constructors `strncpy` into the 108-byte buffer, and an over-long input also leaves it unterminated (`strncpy` writes no terminator when it truncates). ATS then binds a listener on the wrong filesystem path — observed as the 107-byte truncated path plus a garbage byte in `ss -xl` — or dies at startup with `Could not bind or listen to port 0 ... (error: 98) Address already in use` when the truncated prefix happens to name an existing directory. Nothing tells the operator the configured path was too long. (The jsonrpc server already rejects an over-long socket path with a clear error; the traffic listener did not.)

#### Fix
- `HttpProxyPort::processOptions`: reject a unix path that cannot fit `sun_path`, with a Warning naming the limit, like other invalid port tokens. The descriptor is dropped; as with any fully-invalid descriptor, ATS falls back to the default port if nothing valid remains.
- `UnAddr(const char *)` / `UnAddr(const std::string &)`: always null-terminate `_path`, so no future caller can produce an unterminated path buffer.

#### Tests
- `test_RecHttp`: a normal unix path parses; the maximum-length (107-byte) path parses intact; a 108-byte path is rejected with the new warning.
- `test_ink_inet`: over-long `UnAddr` construction yields a terminated, truncated `_path` from both string constructors.