### PR TITLE
Cleanup: remove unused functions related connect attempts

### DIFF
--- a/include/proxy/http/HttpTransact.h
+++ b/include/proxy/http/HttpTransact.h
@@ -1030,9 +1030,7 @@ public:
   static void handle_transform_ready(State *s);
   static void handle_transform_cache_write(State *s);
   static void handle_response_from_parent(State *s);
-  static void handle_response_from_parent_plugin(State *s);
   static void handle_response_from_server(State *s);
-  static void delete_server_rr_entry(State *s, int max_retries);
   static void retry_server_connection_not_open(State *s, unsigned max_retries);
   static void error_log_connection_failure(State *s, ServerState_t conn_state);
   static void handle_server_connection_not_open(State *s);
@@ -1084,7 +1082,6 @@ public:
   static void initialize_state_variables_from_request(State *s, HTTPHdr *obsolete_incoming_request);
 
   static void initialize_state_variables_from_response(State *s, HTTPHdr *incoming_response);
-  static bool is_server_negative_cached(State *s);
   static bool is_cache_response_returnable(State *s);
   static bool is_stale_cache_response_returnable(State *s);
   static bool need_to_revalidate(State *s);

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -540,28 +540,6 @@ update_cache_control_information_from_config(HttpTransact::State *s)
   }
 }
 
-bool
-HttpTransact::is_server_negative_cached(State *s)
-{
-  if (s->dns_info.active && s->dns_info.active->last_fail_time() != TS_TIME_ZERO &&
-      s->dns_info.active->last_fail_time() + s->txn_conf->down_server_timeout > ts_clock::from_time_t(s->client_request_time)) {
-    return true;
-  } else {
-    // Make sure some nasty clock skew has not happened
-    //  Use the server timeout to set an upperbound as to how far in the
-    //   future we should tolerate bogus last failure times.  This sets
-    //   the upper bound to the time that we would ever consider a server
-    //   down to 2*down_server_timeout
-    if (s->dns_info.active &&
-        ts_clock::from_time_t(s->client_request_time) + s->txn_conf->down_server_timeout < s->dns_info.active->last_fail_time()) {
-      s->dns_info.active->mark_up();
-      ink_assert(!"extreme clock skew");
-      return true;
-    }
-    return false;
-  }
-}
-
 /**
   ATS has two configuration options controlling how many times it retries a connection attempt against origin servers.
 


### PR DESCRIPTION
1. `is_server_negative_cached` is not called anymore
2. `handle_response_from_parent_plugin` and `delete_server_rr_entry` are declared, but no definitions.