### PR TITLE
HttpSM.cc: fix SNI/Host check to compare full length, not just prefix

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -4566,7 +4566,8 @@ HttpSM::check_sni_host()
         Log::error("%s", error_bw_buffer.c_str());
         this->t_state.client_connection_allowed = false;
       }
-    } else if (strncasecmp(host_name.data(), sni_value, host_len) != 0) { // Name mismatch
+    } else if (strlen(sni_value) != static_cast<size_t>(host_len) ||
+               strncasecmp(host_name.data(), sni_value, host_len) != 0) { // Name mismatch
       Warning("SNI/hostname mismatch sni=%s host=%.*s action=%s", sni_value, host_len, host_name.data(), action_value);
       SMDbg(dbg_ctl_ssl_sni, "SNI/hostname mismatch sni=%s host=%.*s action=%s", sni_value, host_len, host_name.data(),
             action_value);


### PR DESCRIPTION
## What

`HttpSM::check_sni_host()` compares the request Host against the TLS SNI with
`strncasecmp(host_name.data(), sni_value, host_len)`, which only compares the
first `host_len` bytes. When the SNI is strictly longer than the Host and the
Host is a prefix of it (e.g. `Host: secure.example.com` with
`SNI = secure.example.com.evil`), the comparison returns `0` ("match") and the
`host_sni_policy` SNI/Host-mismatch handling (warn / 403) is skipped.

This adds a length-equality guard so a differing-length SNI is correctly treated
as a name mismatch.

## Why

Without the length check, `host_sni_policy` (SNI/Host pinning) enforcement can be
side-stepped for any prefix relationship between Host and SNI. The check only
runs when `host_sni_policy` is configured (it is a no-op otherwise), so default
deployments are unaffected.

## Verification

Exercised `check_sni_host` with `host_sni_policy` enforced:

- `Host = secure.example.com`, `SNI = secure.example.com.evil` (prefix): before
  the fix the mismatch was not enforced (request allowed); after the fix it is
  correctly rejected (403).
- Control `SNI = xsecure.example.com` (non-prefix mismatch): rejected before and after.
- Exact match `SNI = secure.example.com`: allowed before and after (no regression).

Minimal one-line guard; happy to add an autest gold test if preferred.
