### PR TITLE
traffic_crashlog: emit a well-formed report when the backtrace is empty

### DIFF
--- a/src/traffic_crashlog/traffic_crashlog.cc
+++ b/src/traffic_crashlog/traffic_crashlog.cc
@@ -145,14 +145,18 @@ crashlog_write_backtrace(FILE *fp, const crashlog_target &target)
   // can also happen without a debugger. Possibly in that case, there is a race with the
   // kernel locking the process information?
 
-  if (mgmterr == 0 && trace != nullptr) {
+  if (mgmterr == 0 && trace != nullptr && trace[0] != '\0') {
     // ServerBacktrace succeeded - this gives us backtraces for all threads.
     fprintf(fp, "%s", trace);
     free(trace);
     return true;
   }
+  free(trace);
 
-  // ServerBacktrace failed. Fall back to the in-process backtrace from the crashing thread.
+  // ServerBacktrace reports success but yields no frames when the target's thread list is
+  // unreadable -- e.g. a fast-aborting target has already exited by the time the forked
+  // helper attaches. Fall back to the in-process backtrace from the crashing thread rather
+  // than emitting an empty report.
   if ((target.flags & CRASHLOG_HAVE_BACKTRACE) && !target.backtrace.empty()) {
     fprintf(fp, "Crashing Thread Backtrace:\n%s", target.backtrace.c_str());
     return true;


### PR DESCRIPTION
#### Problem
`ServerBacktrace()` can succeed with an empty backtrace — the target's thread list was unreadable, e.g. a fast-aborting target already exited before the forked helper attached. The success check only tests for a null trace, so the crash log ends up with no backtrace section and the existing fallbacks (in-process backtrace, diagnostic message) never run.

#### Fix
Require a non-empty trace before taking the success path, so the empty case falls through to the fallbacks; free the trace when falling through.

Easy to hit with any startup `Fatal` (e.g. a listen-port bind failure): the process is gone before the helper attaches.