### PR TITLE
track remaining length while decoding qpack header block

### DIFF
--- a/src/proxy/http3/QPACK.cc
+++ b/src/proxy/http3/QPACK.cc
@@ -923,6 +923,7 @@ QPACK::_decode_header(const uint8_t *header_block, size_t header_block_len, HTTP
     return -1;
   }
   pos                        += ret;
+  remain_len                 -= ret;
   uint16_t largest_reference  = tmp;
 
   uint64_t delta_base_index;
@@ -939,7 +940,8 @@ QPACK::_decode_header(const uint8_t *header_block, size_t header_block_len, HTTP
   } else {
     base_index = largest_reference + delta_base_index;
   }
-  pos += ret;
+  pos        += ret;
+  remain_len -= ret;
 
   uint32_t decoded_header_list_size = 0;
 
@@ -969,7 +971,8 @@ QPACK::_decode_header(const uint8_t *header_block, size_t header_block_len, HTTP
       break;
     }
 
-    pos += ret;
+    pos        += ret;
+    remain_len -= ret;
   }
 
   return ret;


### PR DESCRIPTION
The QPACK header decoder takes a header block off an HTTP/3 request stream and walks it field by field. In _decode_header the remaining-length counter is set once to the full block size and then never reduced as the cursor moves forward, so every per-field decoder is handed a buffer end of pos plus the whole block length rather than pos plus what is actually left. After the first field is consumed that end sits past the real end of the buffer, by however many bytes have already been read. A client can lean on this by sending a block whose later field declares a string length that reaches beyond the true end but still fits inside the inflated bound, which slips past the length check and makes the following copy read off the end of the allocation. I noticed it while tracing why the end pointer handed to the sub-decoders did not match the block the frame layer had buffered, and an address-sanitiser run on a crafted block confirmed the over-read. The fix keeps remain_len in step with the cursor by subtracting each consumed length, so the derived end always points at the real end of the block. I kept the change inside _decode_header so the sub-decoders and the rest of the path are left alone.