### PR TITLE
Schedule HTTP/2 re-enable on NetVConnection owner thread

### DIFF
--- a/src/proxy/http2/Http2CommonSession.cc
+++ b/src/proxy/http2/Http2CommonSession.cc
@@ -312,8 +312,10 @@ Http2CommonSession::state_complete_frame_read(int event, void *edata)
     if (this->_should_do_something_else()) {
       if (this->_reenable_event == nullptr) {
         vio->disable();
-        this->_reenable_event = this->get_mutex()->thread_holding->schedule_in(this->get_proxy_session(), HRTIME_MSECONDS(1),
-                                                                               HTTP2_SESSION_EVENT_REENABLE, vio);
+        auto *netvc = this->get_netvc();
+        ink_assert(netvc != nullptr);
+        this->_reenable_event =
+          netvc->thread->schedule_in(this->get_proxy_session(), HRTIME_MSECONDS(1), HTTP2_SESSION_EVENT_REENABLE, vio);
       } else {
         vio->reenable();
       }
@@ -403,8 +405,10 @@ Http2CommonSession::do_process_frame_read(int /* event ATS_UNUSED */, VIO *vio, 
       if (this->_reenable_event == nullptr) {
         this->connection_state.restart_receiving(nullptr);
         vio->disable();
-        this->_reenable_event = this->get_mutex()->thread_holding->schedule_in(this->get_proxy_session(), HRTIME_MSECONDS(1),
-                                                                               HTTP2_SESSION_EVENT_REENABLE, vio);
+        auto *netvc = this->get_netvc();
+        ink_assert(netvc != nullptr);
+        this->_reenable_event =
+          netvc->thread->schedule_in(this->get_proxy_session(), HRTIME_MSECONDS(1), HTTP2_SESSION_EVENT_REENABLE, vio);
         return 0;
       }
     }


### PR DESCRIPTION
Refs: #13358

## Summary

`Http2CommonSession::state_complete_frame_read()` schedules
`HTTP2_SESSION_EVENT_REENABLE` on the thread currently holding the session
mutex.

That thread can differ from the underlying `NetVConnection` owner thread.
When the re-enable handler later processes frames or releases streams, it can
reach `UnixNetVConnection` queue operations from the wrong thread and trigger
the NetHandler lock assertion described in #13358.

This change schedules the re-enable event on the session `NetVConnection`'s
owner thread instead.

## Changes

At both HTTP/2 re-enable scheduling sites:

- Keeps the existing continuation, delay, event type, and `VIO` unchanged.
- Uses `get_netvc()->thread` as the scheduling target instead of
  `get_mutex()->thread_holding`.
- Asserts that the session has an associated `NetVConnection` before
  scheduling.

## Validation

- Built successfully with:
  cmake --build build-dev -j4

- Ran:
  ctest --test-dir build-dev -j4

## Scope

This PR addresses the HTTP/2 re-enable path from #13358 only. The separate
HTTP/1.1 cache-write teardown path remains under investigation.