### PR TITLE
tls_renegotiation autest: gate the detection-line check to OpenSSL

### DIFF
--- a/tests/gold_tests/tls/tls_renegotiation.test.py
+++ b/tests/gold_tests/tls/tls_renegotiation.test.py
@@ -86,10 +86,15 @@ ssl_multicert:
         # The refused renegotiation must not abort the process.
         ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
             "received signal|failed assertion", "ATS must refuse the renegotiation without crashing")
-        # ...and it must actually reach the renegotiation-detection path (otherwise
-        # a no-crash pass could mean the client never managed to renegotiate at all).
-        ts.Disk.traffic_out.Content += Testers.ContainsExpression(
-            "trying to renegotiate from the client", "ATS must detect the client-initiated renegotiation")
+        # ...and, on OpenSSL, it must actually reach ATS's renegotiation-detection
+        # path (otherwise a no-crash pass could mean the client never managed to
+        # renegotiate at all). BoringSSL rejects a peer-initiated renegotiation inside
+        # the library before ATS's info callback runs -- SSL_get_state() there only
+        # ever returns SSL_ST_INIT or SSL_ST_OK, never SSL_ST_RENEGOTIATE -- so the
+        # detection line is never logged. The no-crash check above still covers it.
+        if Condition.IsOpenSSL():
+            ts.Disk.traffic_out.Content += Testers.ContainsExpression(
+                "trying to renegotiate from the client", "ATS must detect the client-initiated renegotiation")
         return ts
 
     def run(self) -> None:


### PR DESCRIPTION
## Problem

The `tls_renegotiation.test.py` gold test added in #13306 fails on BoringSSL. It passes on OpenSSL, so the ASF CI is green and the gap went unnoticed.

The test's `ContainsExpression("trying to renegotiate from the client")` asserts on a debug line emitted by `ssl_callback_info()` in `SSLUtils.cc`, which lives behind the `state == SSL_ST_RENEGOTIATE` branch. On BoringSSL that branch is *compiled* (`SSL_ST_RENEGOTIATE` is `#define`d) but never *taken*: per BoringSSL's `ssl.h`, `SSL_get_state()`/`SSL_state()` "only ever return `SSL_ST_INIT` or `SSL_ST_OK`", never `SSL_ST_RENEGOTIATE`. BoringSSL also rejects a peer-initiated renegotiation inside the library before the callback runs, so ATS never logs the line — the connection is refused safely, but the detection assertion has nothing to match.

## Fix

Gate only the detection-line assertion behind `Condition.IsOpenSSL()`. The crash-safety `ExcludesExpression` stays unconditional, so BoringSSL keeps that coverage; only the detection-line check is now OpenSSL-only. This mirrors the `Condition.IsOpenSSL()` pattern already used in `tls_async_handshake.test.py`. `tls_renegotiation_allowed.test.py` needs no change — it only asserts on client-side output.

## Follow-up (not in this PR)

On BoringSSL the `SSL_ST_RENEGOTIATE` branch in `ssl_callback_info()` is effectively dead, so ATS's own renegotiation logging/abort never fires and `allow_client_renegotiation=1` is a no-op there. Not a security issue — BoringSSL enforces the refusal regardless — but the branch is misleading and could be cleaned up or wired to a mechanism that actually fires.
