### PR TITLE
autest: skip async handshake test when plugin is absent

### DIFF
--- a/tests/gold_tests/tls/tls_async_handshake.test.py
+++ b/tests/gold_tests/tls/tls_async_handshake.test.py
@@ -33,7 +33,8 @@ Test.SkipUnless(
 ts = Test.MakeATSProcess("ts", enable_tls=True)
 server = Test.MakeOriginServer("server")
 
-Test.PrepareTestPlugin(async_handshake, ts)
+if os.path.isfile(async_handshake):
+    Test.PrepareTestPlugin(async_handshake, ts)
 
 server.addResponse(
     "sessionlog.json", {


### PR DESCRIPTION
The async_handshake test plugin is only built with OpenSSL (TS_USE_TLS_ASYNC). SkipUnless does not evaluate its conditions where it appears; it only registers them for the framework to check later, so the test file keeps executing and PrepareTestPlugin ran at load time and raised a ValueError when the plugin was missing, reported as a test exception instead of a skip. Guard the call on file existence so the test skips cleanly on non-OpenSSL builds.