### PR TITLE
cripts: build against fmt 11+ (incl. 12.x)

### DIFF
--- a/include/cripts/Instance.hpp
+++ b/include/cripts/Instance.hpp
@@ -18,8 +18,11 @@
 #pragma once
 
 #include <array>
+#include <utility>
 #include <variant>
 #include <unordered_map>
+
+#include <fmt/format.h>
 
 #include "ts/ts.h"
 #include "ts/remap.h"
@@ -106,7 +109,7 @@ public:
   debug(fmt::format_string<T...> fmt, T &&...args) const
   {
     if (DebugOn()) {
-      auto str = fmt::vformat(fmt, fmt::make_format_args(args...));
+      auto str = fmt::format(fmt, std::forward<T>(args)...);
 
       Dbg(dbg_ctl_cript, "%s", str.c_str());
     }

--- a/include/cripts/Lulu.hpp
+++ b/include/cripts/Lulu.hpp
@@ -26,7 +26,7 @@
 #include <type_traits>
 #include <chrono>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "swoc/TextView.h"
 #include "ts/ts.h"

--- a/include/cripts/Preamble.hpp
+++ b/include/cripts/Preamble.hpp
@@ -27,7 +27,7 @@
 #include <climits>
 #include <iostream> // Useful for debugging
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "ts/ts.h"
 #include "ts/remap.h"


### PR DESCRIPTION
fmt 11 dropped fmt::format/vformat from fmt/core.h; include fmt/format.h instead, and use fmt::format directly to avoid a deprecated format_string conversion. Still builds on fmt 8.1+.