### PR TITLE
Preserve client port in transaction logs

### DIFF
--- a/src/proxy/logging/TransactionLogData.cc
+++ b/src/proxy/logging/TransactionLogData.cc
@@ -423,10 +423,7 @@ uint16_t
 TransactionLogData::get_client_port() const
 {
   if (likely(m_http_sm != nullptr)) {
-    if (auto txn = m_http_sm->get_ua_txn(); txn) {
-      return txn->get_client_port();
-    }
-    return 0;
+    return m_http_sm->t_state.effective_client_addr.host_order_port();
   }
   return m_non_http_sm_data->m_client_port;
 }


### PR DESCRIPTION
Fixes behavior introduced via #13123

---

Client source ports could be logged as zero when the live inbound
connection was cleared before transaction log marshalling. This
obscured the effective client endpoint in access logs.

This reads the port from the effective client endpoint retained by
HttpSM, keeping it available after connection cleanup.