### PR TITLE
reject over-long integers in xpack_decode_integer

### DIFF
--- a/src/proxy/hdrs/XPACK.cc
+++ b/src/proxy/hdrs/XPACK.cc
@@ -78,7 +78,7 @@ xpack_decode_integer(uint64_t &dst, const uint8_t *buf_start, const uint8_t *buf
       }
 
       uint64_t added_value = *p & 0x7f;
-      if ((UINT64_MAX >> m) < added_value) {
+      if (m >= 64 || (UINT64_MAX >> m) < added_value) {
         // Excessively large integer encodings - in value or octet
         // length - MUST be treated as a decoding error.
         return XPACK_ERROR_COMPRESSION_ERROR;

--- a/src/proxy/hdrs/unit_tests/test_XPACK.cc
+++ b/src/proxy/hdrs/unit_tests/test_XPACK.cc
@@ -79,6 +79,20 @@ TEST_CASE("XPACK_Integer", "[xpack]")
       REQUIRE(actual == i.raw_integer);
     }
   }
+
+  SECTION("Decoding overlong integer")
+  {
+    // A continuation run long enough to drive the 7-bit shift amount past 64 bits.
+    // The prefix is all-ones so the continuation is entered, then eleven 0x80 bytes
+    // keep it going while contributing nothing. This must be rejected rather than
+    // shifting by a count wider than the accumulator.
+    uint8_t encoded[] = {0x7f, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00};
+
+    uint64_t actual = 0;
+    int64_t  len    = xpack_decode_integer(actual, encoded, encoded + sizeof(encoded), 7);
+
+    REQUIRE(len == XPACK_ERROR_COMPRESSION_ERROR);
+  }
 }
 
 TEST_CASE("XPACK_String", "[xpack]")


### PR DESCRIPTION
xpack_decode_integer accumulates the continuation bytes of an HPACK/QPACK integer by shifting each 7-bit group left by an amount that grows seven per byte and is never bounded, so a header field carrying a long run of continuation bytes drives that shift width past 64. Once it does the guard on the preceding line that is meant to reject over-large encodings shifts by the same out-of-range amount and quietly stops rejecting anything, which is undefined behaviour on the wire-facing path shared by both the HTTP/2 and HTTP/3 header decoders. The loop now stops as soon as the shift width reaches the width of the accumulator so an over-long encoding is treated as a compression error, and I have added a decoding case to test_XPACK.cc that fails without the change.