### PR TITLE
Fix cache retry assert on ServerAddrSet

### DIFF
--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -3330,6 +3330,12 @@ HttpTransact::HandleCacheOpenReadMiss(State *s)
     s->cache_info.action = CACHE_DO_NO_ACTION;
   } else if (s->api_server_response_no_store) { // plugin may have decided not to cache the response
     s->cache_info.action = CACHE_DO_NO_ACTION;
+  } else if (s->cache_info.write_lock_state == CACHE_WL_SUCCESS && s->cache_info.action == CACHE_DO_WRITE) {
+    // Origin retry paths such as TSHttpTxnServerAddrSet() can loop back through
+    // HandleCacheOpenReadMiss after we already own the cache write lock. This
+    // is still the same request, so keep the existing write lock instead of
+    // re-preparing a write as if this were a redirect or a new cache miss.
+    TxnDebug("http_trans", "Reusing existing cache write lock while retrying origin selection");
   } else {
     HttpTransact::set_cache_prepare_write_action_for_new_request(s);
   }


### PR DESCRIPTION
A TSHttpTxnServerAddrSet retry can re-enter the cache miss path after ATS already holds a cache write lock for the same request. The redirect-only prepared-write reuse logic then asserts because this is not actually a redirect.

Preserve the existing cache write lock when the retry returns through HandleCacheOpenReadMiss.

Backport of #12972 to 9.2.x. The accompanying autest is omitted because its plugin infrastructure (#12733) is not present on 9.2.x; enum and debug-macro names were adapted to the 9.2.x code.

Fixes: #12971