### PR TITLE
Remove unused RemapProcessor.h include from RemapPlugins.h

### DIFF
--- a/include/proxy/http/remap/RemapPlugins.h
+++ b/include/proxy/http/remap/RemapPlugins.h
@@ -26,7 +26,6 @@
 
 #include "tscore/ink_platform.h"
 #include "iocore/eventsystem/EventSystem.h"
-#include "proxy/http/remap/RemapProcessor.h"
 #include "proxy/http/remap/RemapPluginInfo.h"
 #include "proxy/http/HttpTransact.h"
 #include "proxy/ReverseProxy.h"


### PR DESCRIPTION
RemapPlugins.h includes RemapProcessor.h, and RemapProcessor.h includes RemapPlugins.h back, forming an include cycle. RemapPlugins.h does not use RemapProcessor: the class derives from Continuation and its members are HttpTransact::State, URL and HTTPHdr, none of which come from RemapProcessor.h.

Everything RemapPlugins.h needs already arrives through its other includes (EventSystem.h, HttpTransact.h, RemapPluginInfo.h), which are also the only things RemapProcessor.h contributed to the include closure. Removing the include breaks the cycle with no call-site changes.