### PR TITLE
copy only len_in bytes in the escapify no-escape path

### DIFF
--- a/src/tscore/Encoding.cc
+++ b/src/tscore/Encoding.cc
@@ -77,7 +77,7 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
 
   static char hex_digit[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
-  if (!url || (dst && dst_size < len_in + 1)) {
+  if (!url || (dst && dst_size <= len_in)) {
     *len_out = 0;
     return nullptr;
   }

--- a/src/tscore/Encoding.cc
+++ b/src/tscore/Encoding.cc
@@ -77,7 +77,7 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
 
   static char hex_digit[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
-  if (!url || (dst && dst_size < len_in)) {
+  if (!url || (dst && dst_size < len_in + 1)) {
     *len_out = 0;
     return nullptr;
   }
@@ -105,7 +105,8 @@ escapify_url_common(Arena *arena, char *url, size_t len_in, int *len_out, char *
     //
     *len_out = len_in;
     if (dst) {
-      ink_strlcpy(dst, url, dst_size);
+      memcpy(dst, url, len_in);
+      dst[len_in] = '\0';
     }
     return url;
   }

--- a/src/tscore/unit_tests/test_Encoding.cc
+++ b/src/tscore/unit_tests/test_Encoding.cc
@@ -22,6 +22,7 @@
  */
 
 #include <string_view>
+#include <vector>
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
@@ -63,21 +64,22 @@ TEST_CASE("Encoding escapify url without a terminator", "[esc_url_unterminated]"
   // Sized exactly so that a read past the end is caught by a sanitizer.
   constexpr std::string_view src{"abcdef"};
 
-  char *unterminated = static_cast<char *>(std::malloc(src.size()));
-  std::memcpy(unterminated, src.data(), src.size());
+  std::vector<char> unterminated(src.begin(), src.end());
 
   char output[128];
   int  output_len;
 
-  REQUIRE(Encoding::pure_escapify_url(nullptr, unterminated, src.size(), &output_len, output, sizeof(output)) != nullptr);
+  REQUIRE(Encoding::pure_escapify_url(nullptr, unterminated.data(), unterminated.size(), &output_len, output, sizeof(output)) !=
+          nullptr);
   CHECK(output_len == static_cast<int>(src.size()));
   CHECK(std::string_view(output, output_len) == src);
+  CHECK(output[output_len] == '\0');
 
-  REQUIRE(Encoding::escapify_url(nullptr, unterminated, src.size(), &output_len, output, sizeof(output)) != nullptr);
+  REQUIRE(Encoding::escapify_url(nullptr, unterminated.data(), unterminated.size(), &output_len, output, sizeof(output)) !=
+          nullptr);
   CHECK(output_len == static_cast<int>(src.size()));
   CHECK(std::string_view(output, output_len) == src);
-
-  std::free(unterminated);
+  CHECK(output[output_len] == '\0');
 }
 
 TEST_CASE("Encoding escapify url", "[esc_url]")

--- a/src/tscore/unit_tests/test_Encoding.cc
+++ b/src/tscore/unit_tests/test_Encoding.cc
@@ -57,6 +57,29 @@ TEST_CASE("Encoding pure escapify url", "[pure_esc_url]")
   }
 }
 
+TEST_CASE("Encoding escapify url without a terminator", "[esc_url_unterminated]")
+{
+  // The source is a counted string, not a C string, so nothing may be read past len_in.
+  // Sized exactly so that a read past the end is caught by a sanitizer.
+  constexpr std::string_view src{"abcdef"};
+
+  char *unterminated = static_cast<char *>(std::malloc(src.size()));
+  std::memcpy(unterminated, src.data(), src.size());
+
+  char output[128];
+  int  output_len;
+
+  REQUIRE(Encoding::pure_escapify_url(nullptr, unterminated, src.size(), &output_len, output, sizeof(output)) != nullptr);
+  CHECK(output_len == static_cast<int>(src.size()));
+  CHECK(std::string_view(output, output_len) == src);
+
+  REQUIRE(Encoding::escapify_url(nullptr, unterminated, src.size(), &output_len, output, sizeof(output)) != nullptr);
+  CHECK(output_len == static_cast<int>(src.size()));
+  CHECK(std::string_view(output, output_len) == src);
+
+  std::free(unterminated);
+}
+
 TEST_CASE("Encoding escapify url", "[esc_url]")
 {
   char input[][32] = {


### PR DESCRIPTION
escapify_url_common takes a counted string, (url, len_in), and every caller that hands it a destination buffer relies on that. In the common case where nothing in the input needs escaping it took a shortcut and used ink_strlcpy to copy the source over, which walks the source looking for a NUL rather than stopping at len_in. A lot of the callers have no terminator to find: TSStringPercentEncode is handed pointers straight into the MIME header heap by plugins like cachekey and slice, and Crypto::Escape::Encode in cripts passes a string_view, so an ordinary header or URL value with no escapable byte reads off the end and can drop unrelated adjacent bytes into the destination while len_out still claims len_in. I noticed it while looking at how the cripts helper sizes its output and then reran the existing test with an exactly-sized heap allocation under ASan, which reports a heap-buffer-overflow at the ink_strlcpy line. Copying len_in bytes and terminating explicitly keeps the fast path honest about its own contract, and I tightened the entry guard to require room for that terminator since dst_size == len_in previously passed and left nowhere to put it. Added the unterminated case to test_Encoding.cc so it stays covered.