### PR TITLE
Cache: fix cached-header HdrHeap growth on repeated 304 revalidation

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -5035,9 +5035,26 @@ HttpTransact::merge_and_update_headers_for_cache_update(State *s)
   // 10.3.5), but RFC 7232) is clear that the 304 and 200 responses
   // must be identical (see section 4.1). This code attempts to strike
   // a balance between the two.
-  cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
-  cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
-  cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
+  //
+  // Only delete a caching header that the server response does NOT carry.
+  // If the response carries it, the merge below overwrites the cached field
+  // in place (value_set reuses the existing slot). Deleting it here first
+  // would force the merge to recreate the field, and because a deleted
+  // MIMEField slot is never reused until its whole block is empty, a
+  // long-lived cached object that is revalidated repeatedly (e.g. a hot
+  // max-age=60 object whose Expires changes every 304) would accrete a dead
+  // slot per revalidation until its header heap crosses the aggregation
+  // fragment limit and the cache write can no longer commit (frozen stale).
+  HTTPHdr *server_response = &s->hdr_info.server_response;
+  if (!server_response->presence(MIME_PRESENCE_AGE)) {
+    cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
+  }
+  if (!server_response->presence(MIME_PRESENCE_ETAG)) {
+    cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
+  }
+  if (!server_response->presence(MIME_PRESENCE_EXPIRES)) {
+    cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
+  }
 
   merge_response_header_with_cached_header(cached_hdr, &s->hdr_info.server_response);
 
@@ -5217,9 +5234,6 @@ HttpTransact::set_headers_for_cache_write(State *s, HTTPInfo *cache_info, HTTPHd
 void
 HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, HTTPHdr *response_header)
 {
-  MIMEField *new_field;
-  bool       dups_seen = false;
-
   for (auto spot = response_header->begin(), limit = response_header->end(); spot != limit; ++spot) {
     MIMEField &field{*spot};
     auto       name{field.name_get()};
@@ -5258,54 +5272,48 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
     if (name.data() == MIME_FIELD_WARNING.c_str()) {
       continue;
     }
-    // Copy all remaining headers with replacement
 
-    // Duplicate header fields cause a bug problem
-    //   since we need to duplicate with replacement.
-    //   Without dups, we can just nuke what is already
-    //   there in the cached header.  With dups, we
-    //   can't do this because what is already there
-    //   may be a dup we've already copied in.  If
-    //   dups show up we look through the remaining
-    //   header fields in the new response, nuke
-    //   them in the cached response and then add in
-    //   the remaining fields one by one from the
-    //   response header
+    // Reconcile the cached header's fields of this name to exactly match the
+    // response's values for this name. Each response field name is processed
+    // once, when we reach its dup-list head (dups are chained in slot order, so
+    // the head is encountered first). Response values are matched positionally
+    // against the cached fields of the same name: existing cached slots are
+    // overwritten in place, any extra response values are appended, and any
+    // surplus cached values are removed.
     //
-    if (field.m_next_dup) {
-      if (dups_seen == false) {
-        // use a second iterator to delete the
-        // remaining response headers in the cached response,
-        // so that they will be added in the next iterations.
-        for (auto spot2 = spot; spot2 != limit; ++spot2) {
-          MIMEField &field2{*spot2};
-          auto       name2{field2.name_get()};
-
-          // It is specified above that content type should not
-          // be altered here however when a duplicate header
-          // is present, all headers following are delete and
-          // re-added back. This includes content type if it follows
-          // any duplicate header. This leads to the loss of
-          // content type in the client response.
-          // This ensures that it is not altered when duplicate
-          // headers are present.
-          if (name2.data() == MIME_FIELD_CONTENT_TYPE.c_str()) {
-            continue;
-          }
-          cached_header->field_delete(name2);
-        }
-        dups_seen = true;
-      }
+    // Reusing cached slots in place (rather than deleting every cached value and
+    // recreating the field, as the previous sticky-"dups_seen" logic did once
+    // any duplicated field was seen) keeps the merge idempotent: re-merging an
+    // unchanged response mutates the existing MIMEFields instead of stranding
+    // dead slots. A deleted MIMEField slot is not reclaimed until its whole
+    // field block empties, so the old behavior grew the cached header heap by a
+    // slot per revalidation. For a long-lived object revalidated continuously
+    // (e.g. a hot max-age=60 object whose Expires changes every 304) that heap
+    // eventually crosses the aggregation fragment limit and the cache write can
+    // no longer commit, freezing the object stale.
+    if (!field.is_dup_head()) {
+      continue; // a non-head dup: already handled when its dup-list head was processed
     }
 
-    auto value{field.value_get()};
-
-    if (dups_seen == false) {
-      cached_header->value_set(name, value);
-    } else {
-      new_field = cached_header->field_create(name);
-      cached_header->field_attach(new_field);
-      cached_header->field_value_set(new_field, value);
+    MIMEField *cached_field = cached_header->field_find(name);
+    for (MIMEField *resp_field = &field; resp_field != nullptr; resp_field = resp_field->m_next_dup) {
+      auto value{resp_field->value_get()};
+      if (cached_field != nullptr) {
+        // overwrite an existing cached value of this name in place (reuses the slot)
+        cached_header->field_value_set(cached_field, value);
+        cached_field = cached_field->m_next_dup;
+      } else {
+        // the response has more values of this name than the cached header
+        MIMEField *new_field = cached_header->field_create(name);
+        cached_header->field_attach(new_field);
+        cached_header->field_value_set(new_field, value);
+      }
+    }
+    // remove any surplus cached values of this name the response no longer carries
+    while (cached_field != nullptr) {
+      MIMEField *next = cached_field->m_next_dup;
+      cached_header->field_delete(cached_field, false /* this dup only */);
+      cached_field = next;
     }
   }
 

--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -5038,13 +5038,8 @@ HttpTransact::merge_and_update_headers_for_cache_update(State *s)
   //
   // Only delete a caching header that the server response does NOT carry.
   // If the response carries it, the merge below overwrites the cached field
-  // in place (value_set reuses the existing slot). Deleting it here first
-  // would force the merge to recreate the field, and because a deleted
-  // MIMEField slot is never reused until its whole block is empty, a
-  // long-lived cached object that is revalidated repeatedly (e.g. a hot
-  // max-age=60 object whose Expires changes every 304) would accrete a dead
-  // slot per revalidation until its header heap crosses the aggregation
-  // fragment limit and the cache write can no longer commit (frozen stale).
+  // in place; deleting it first would strand a dead MIMEField slot on every
+  // revalidation (see merge_response_header_with_cached_header).
   HTTPHdr *server_response = &s->hdr_info.server_response;
   if (!server_response->presence(MIME_PRESENCE_AGE)) {
     cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
@@ -5056,7 +5051,7 @@ HttpTransact::merge_and_update_headers_for_cache_update(State *s)
     cached_hdr->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
   }
 
-  merge_response_header_with_cached_header(cached_hdr, &s->hdr_info.server_response);
+  merge_response_header_with_cached_header(cached_hdr, server_response);
 
   // Some special processing for 304
   if (s->hdr_info.server_response.status_get() == HTTPStatus::NOT_MODIFIED) {
@@ -5281,16 +5276,13 @@ HttpTransact::merge_response_header_with_cached_header(HTTPHdr *cached_header, H
     // overwritten in place, any extra response values are appended, and any
     // surplus cached values are removed.
     //
-    // Reusing cached slots in place (rather than deleting every cached value and
-    // recreating the field, as the previous sticky-"dups_seen" logic did once
-    // any duplicated field was seen) keeps the merge idempotent: re-merging an
+    // Reusing cached slots in place keeps the merge idempotent: re-merging an
     // unchanged response mutates the existing MIMEFields instead of stranding
     // dead slots. A deleted MIMEField slot is not reclaimed until its whole
-    // field block empties, so the old behavior grew the cached header heap by a
-    // slot per revalidation. For a long-lived object revalidated continuously
-    // (e.g. a hot max-age=60 object whose Expires changes every 304) that heap
-    // eventually crosses the aggregation fragment limit and the cache write can
-    // no longer commit, freezing the object stale.
+    // field block empties, so a delete-and-recreate merge grows the cached
+    // header heap on every revalidation until it crosses the aggregation
+    // fragment limit and the cache write can no longer commit, freezing the
+    // object stale.
     if (!field.is_dup_head()) {
       continue; // a non-head dup: already handled when its dup-list head was processed
     }

--- a/src/proxy/http/unit_tests/test_HttpTransact.cc
+++ b/src/proxy/http/unit_tests/test_HttpTransact.cc
@@ -22,6 +22,10 @@
  */
 
 #include <string_view>
+#include <vector>
+#include <cstdio>
+#include <chrono>
+#include <algorithm>
 
 using namespace std::string_view_literals;
 
@@ -29,9 +33,69 @@ using namespace std::string_view_literals;
 #include "tsutil/PostScript.h"
 
 #include "proxy/http/HttpTransact.h"
+#include "proxy/http/HttpTransactHeaders.h"
 #include "records/RecordsConfig.h"
 
 #include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+// Faithful copy of merge_response_header_with_cached_header BEFORE the fix, so the
+// old and new implementations can be timed head-to-head in one process (no
+// cross-build variance). Kept only for the "[.merge-bench]" benchmark below.
+void
+merge_OLD(HTTPHdr *cached_header, HTTPHdr *response_header)
+{
+  MIMEField *new_field;
+  bool       dups_seen = false;
+
+  for (auto spot = response_header->begin(), limit = response_header->end(); spot != limit; ++spot) {
+    MIMEField &field{*spot};
+    auto       name{field.name_get()};
+
+    if (HttpTransactHeaders::is_this_a_hop_by_hop_header(name.data())) {
+      continue;
+    }
+    if (name.data() == MIME_FIELD_CONTENT_LENGTH.c_str() || name.data() == MIME_FIELD_TRANSFER_ENCODING.c_str()) {
+      continue;
+    }
+    if (name.data() == MIME_FIELD_SET_COOKIE.c_str()) {
+      continue;
+    }
+    if (name.data() == MIME_FIELD_CONTENT_TYPE.c_str()) {
+      continue;
+    }
+    if (name.data() == MIME_FIELD_WARNING.c_str()) {
+      continue;
+    }
+    if (field.m_next_dup) {
+      if (dups_seen == false) {
+        for (auto spot2 = spot; spot2 != limit; ++spot2) {
+          MIMEField &field2{*spot2};
+          auto       name2{field2.name_get()};
+          if (name2.data() == MIME_FIELD_CONTENT_TYPE.c_str()) {
+            continue;
+          }
+          cached_header->field_delete(name2);
+        }
+        dups_seen = true;
+      }
+    }
+
+    auto value{field.value_get()};
+
+    if (dups_seen == false) {
+      cached_header->value_set(name, value);
+    } else {
+      new_field = cached_header->field_create(name);
+      cached_header->field_attach(new_field);
+      cached_header->field_value_set(new_field, value);
+    }
+  }
+
+  HttpTransact::merge_warning_header(cached_header, response_header);
+}
+} // namespace
 
 TEST_CASE("HttpTransact", "[http]")
 {
@@ -540,5 +604,424 @@ TEST_CASE("HttpTransact", "[http]")
       CHECK(field->has_dups() == false);
       ///////////////////////////////////////
     }
+
+    // Regression: repeated 304 revalidation of the same object must not grow the
+    // cached header without bound. In production a hot max-age=60 object is
+    // revalidated on ~every request; each 304 re-merges the server response into
+    // the cached header. If the merge grows the cached header's HdrHeap, its
+    // marshalled size eventually crosses the aggregation fragment limit and the
+    // cache write can never commit again (object frozen stale forever).
+    //
+    // The yardstick is HdrHeap::marshal_length() (the size that gates the cache
+    // write), NOT fields_count(): a deleted-then-recreated field strands a dead
+    // MIMEField slot that is not reclaimed until its whole block empties, so the
+    // heap grows even while the live field count is constant.
+    SECTION("Repeated revalidation does not grow the cached header heap")
+    {
+      struct header {
+        std::string_view name;
+        std::string_view value;
+      };
+
+      auto build = [](HTTPHdr &h, const std::vector<header> &fields) {
+        h.create(HTTPType::RESPONSE);
+        for (auto &&e : fields) {
+          MIMEField *f = h.field_create(e.name);
+          h.field_attach(f);
+          h.field_value_set(f, e.value);
+        }
+      };
+
+      // Merge `response` into a copy of `cached0` `iterations` times and return
+      // the growth in the cached header's marshalled heap size. A correct merge
+      // is idempotent, so the growth must be bounded (independent of iterations).
+      auto merge_growth = [&](const std::vector<header> &cached0, const std::vector<header> &response, int iterations) -> int {
+        HTTPHdr        cached;
+        HTTPHdr        resp;
+        ts::PostScript cached_defer([&]() -> void { cached.destroy(); });
+        ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
+        build(cached, cached0);
+        build(resp, response);
+        // One warm-up merge so any one-time restructuring settles before measuring.
+        HttpTransact::merge_response_header_with_cached_header(&cached, &resp);
+        int const before = cached.m_heap->marshal_length();
+        for (int i = 0; i < iterations; ++i) {
+          HttpTransact::merge_response_header_with_cached_header(&cached, &resp);
+        }
+        return cached.m_heap->marshal_length() - before;
+      };
+
+      // No duplicated fields: pure in-place replacement, bounded.
+      CHECK(merge_growth(
+              {
+                {"Date",    "d0"},
+                {"Expires", "e0"},
+                {"Etag",    "t0"}
+      },
+              {{"Date", "d1"}, {"Expires", "e1"}, {"Etag", "t1"}}, 4000) <= 2048);
+
+      // A duplicated field (e.g. Cache-Control: max-age=60, public) ahead of
+      // single-valued fields must not force those single-valued fields down an
+      // appending path. Before the fix the sticky "dups_seen" flag did exactly
+      // that and this grew ~132 bytes per merge (megabytes over a day).
+      CHECK(merge_growth(
+              {
+                {"Cache-Control", "max-age=60"},
+                {"Cache-Control", "public"    },
+                {"Expires",       "e0"        },
+                {"Etag",          "t0"        }
+      },
+              {{"Cache-Control", "max-age=60"}, {"Cache-Control", "public"}, {"Expires", "e0"}, {"Etag", "t0"}}, 4000) <= 2048);
+
+      // Response carries a duplicated field the cached copy does not yet have.
+      CHECK(merge_growth(
+              {
+                {"Date",    "d0"},
+                {"Expires", "e0"},
+                {"Etag",    "t0"}
+      },
+              {{"Date", "d0"}, {"Vary", "A"}, {"Vary", "B"}, {"Expires", "e0"}, {"Etag", "t0"}}, 4000) <= 2048);
+
+      // A response value that changes length every merge (as Expires does on a
+      // real 304) must still be bounded: value_set frees the old string (self-
+      // coalesced) and reuses the slot.
+      {
+        HTTPHdr        cached;
+        HTTPHdr        resp;
+        ts::PostScript cached_defer([&]() -> void { cached.destroy(); });
+        ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
+        build(cached, {
+                        {"Server",        "ATS"       },
+                        {"Cache-Control", "max-age=60"},
+                        {"Date",          "d0"        },
+                        {"Expires",       "e0"        },
+                        {"Etag",          "t0"        }
+        });
+        resp.create(HTTPType::RESPONSE);
+        MIMEField *rf = resp.field_create("Expires"sv);
+        resp.field_attach(rf);
+        resp.field_value_set(rf, "e0"sv);
+        HttpTransact::merge_response_header_with_cached_header(&cached, &resp);
+        int const before = cached.m_heap->marshal_length();
+        char      buf[64];
+        for (int i = 0; i < 2000; ++i) {
+          int n = std::snprintf(buf, sizeof(buf), "Sat, 18 Jul 2026 05:%02d:%02d GMT-%d", i % 60, (i * 7) % 60, i % 1000);
+          resp.field_value_set(rf, std::string_view(buf, n));
+          HttpTransact::merge_response_header_with_cached_header(&cached, &resp);
+        }
+        MIMEField *exp = cached.field_find("Expires"sv);
+        REQUIRE(exp != nullptr);
+        CHECK(exp->has_dups() == false);
+        CHECK(cached.m_heap->marshal_length() - before <= 4096);
+      }
+
+      // Correctness: merging a response that DROPS one of two duplicate values
+      // must leave the cached header with exactly the response's values.
+      {
+        HTTPHdr        cached;
+        HTTPHdr        resp;
+        ts::PostScript cached_defer([&]() -> void { cached.destroy(); });
+        ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
+        build(cached, {
+                        {"Vary", "A" },
+                        {"Vary", "B" },
+                        {"Vary", "C" },
+                        {"Etag", "t0"}
+        });
+        build(resp, {
+                      {"Vary", "X" },
+                      {"Vary", "Y" },
+                      {"Etag", "t1"}
+        });
+        HttpTransact::merge_response_header_with_cached_header(&cached, &resp);
+        int              count = 0;
+        std::string_view v0, v1;
+        for (MIMEField *d = cached.field_find("Vary"sv); d != nullptr; d = d->m_next_dup) {
+          if (count == 0) {
+            v0 = d->value_get();
+          } else if (count == 1) {
+            v1 = d->value_get();
+          }
+          ++count;
+        }
+        CHECK(count == 2); // surplus cached "C" removed
+        CHECK(v0 == "X"sv);
+        CHECK(v1 == "Y"sv);
+        MIMEField *etag = cached.field_find("Etag"sv);
+        REQUIRE(etag != nullptr);
+        CHECK(etag->value_get() == "t1"sv);
+        CHECK(etag->has_dups() == false);
+      }
+
+      // The production caller sequence: merge_and_update_headers_for_cache_update
+      // deletes a caching header only when the 304 OMITS it, then merges. This
+      // exercises the conditional-delete + the cooked WKS headers
+      // (Cache-Control/Expires/Age) end to end, over many revalidations with a
+      // changing Expires. The cached header heap and the cooked freshness values
+      // must stay correct and bounded.
+      {
+        HTTPHdr        cached;
+        ts::PostScript cached_defer([&]() -> void { cached.destroy(); });
+        build(cached, {
+                        {"Server",        "ATS"       },
+                        {"Cache-Control", "max-age=60"},
+                        {"Date",          "d0"        },
+                        {"Expires",       "e0"        },
+                        {"Etag",          "t0"        }
+        });
+
+        int settled = 0;
+        for (int i = 0; i < 2000; ++i) {
+          HTTPHdr        resp;
+          ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
+          resp.create(HTTPType::RESPONSE);
+          MIMEField *f = resp.field_create("Cache-Control"sv);
+          resp.field_attach(f);
+          resp.field_value_set(f, "max-age=60"sv);
+          char buf[64];
+          int  n = std::snprintf(buf, sizeof(buf), "Sat, 18 Jul 2026 05:%02d:%02d GMT", i % 60, (i * 7) % 60);
+          f      = resp.field_create("Expires"sv);
+          resp.field_attach(f);
+          resp.field_value_set(f, std::string_view(buf, n));
+
+          // Mirror merge_and_update_headers_for_cache_update: delete a caching
+          // header only if the response omits it, then merge.
+          if (!resp.presence(MIME_PRESENCE_AGE)) {
+            cached.field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
+          }
+          if (!resp.presence(MIME_PRESENCE_ETAG)) {
+            cached.field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
+          }
+          if (!resp.presence(MIME_PRESENCE_EXPIRES)) {
+            cached.field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
+          }
+          HttpTransact::merge_response_header_with_cached_header(&cached, &resp);
+          if (i == 0) {
+            settled = cached.m_heap->marshal_length();
+          }
+        }
+        // Etag was omitted by every 304, so it must have been dropped from cache.
+        CHECK(cached.field_find("Etag"sv) == nullptr);
+        // Expires stays single-valued and the cooked max-age is intact.
+        MIMEField *exp = cached.field_find("Expires"sv);
+        REQUIRE(exp != nullptr);
+        CHECK(exp->has_dups() == false);
+        CHECK(cached.get_cooked_cc_max_age() == 60);
+        // Heap stays bounded across 2000 revalidations.
+        CHECK(cached.m_heap->marshal_length() - settled <= 4096);
+      }
+    }
   }
+}
+
+// Hot-path microbenchmark: merge_response_header_with_cached_header runs on every
+// 304 revalidation. Compares the new implementation against a faithful copy of the
+// pre-fix one (merge_OLD), head-to-head in one process. Hidden by the '.' tag; run
+// explicitly with:  test_http "[merge-bench]"
+TEST_CASE("merge hot-path benchmark", "[.merge-bench]")
+{
+  url_init();
+  mime_init();
+  http_init();
+
+  struct header {
+    std::string_view name;
+    std::string_view value;
+  };
+
+  auto build = [](HTTPHdr &h, const std::vector<header> &fields) {
+    h.create(HTTPType::RESPONSE);
+    for (auto &&e : fields) {
+      MIMEField *f = h.field_create(e.name);
+      h.field_attach(f);
+      h.field_value_set(f, e.value);
+    }
+  };
+
+  // A realistic stored 200 for a small, frequently revalidated object (the cached
+  // object): a handful of headers including the caching triplet Cache-Control /
+  // Etag / Expires.
+  std::vector<header> const cached_tmpl = {
+    {"Server",                    "ATS"                                },
+    {"Date",                      "Sat, 18 Jul 2026 05:29:18 GMT"      },
+    {"Content-Type",              "text/xml"                           },
+    {"Content-Length",            "181"                                },
+    {"Last-Modified",             "Tue, 04 Apr 2023 17:58:01 GMT"      },
+    {"Accept-Ranges",             "bytes"                              },
+    {"Cache-Control",             "max-age=60"                         },
+    {"Content-Language",          "en-us"                              },
+    {"Strict-Transport-Security", "max-age=31536000; includeSubdomains"},
+    {"X-Frame-Options",           "SAMEORIGIN"                         },
+    {"X-Content-Type-Options",    "nosniff"                            },
+    {"X-XSS-Protection",          "1; mode=block"                      },
+    {"Etag",                      "\"0123456789abcdef\""               },
+    {"Expires",                   "Sat, 18 Jul 2026 05:30:18 GMT"      },
+  };
+
+  // A typical minimal 304 (no duplicated fields).
+  std::vector<header> const resp_typical = {
+    {"Server",        "ATS"                          },
+    {"Date",          "Sat, 18 Jul 2026 05:30:18 GMT"},
+    {"Cache-Control", "max-age=60"                   },
+    {"Expires",       "Sat, 18 Jul 2026 05:31:18 GMT"},
+  };
+
+  // The pathological 304 that triggered the leak: a duplicated Cache-Control.
+  std::vector<header> const resp_dup = {
+    {"Server",        "ATS"                          },
+    {"Date",          "Sat, 18 Jul 2026 05:30:18 GMT"},
+    {"Cache-Control", "max-age=60"                   },
+    {"Cache-Control", "public"                       },
+    {"Expires",       "Sat, 18 Jul 2026 05:31:18 GMT"},
+  };
+
+  using MergeFn = void (*)(HTTPHdr *, HTTPHdr *);
+
+  // Time pure merge cost: pre-build a pool of fresh cached copies (untimed), then
+  // time only the merges. Each copy is merged exactly once, so this is fair for
+  // both the idempotent new code and the leaking old code. Returns ns/merge.
+  auto bench = [&](MergeFn fn, const std::vector<header> &resp_fields, int total, int pool_sz) -> double {
+    HTTPHdr        resp;
+    ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
+    build(resp, resp_fields);
+
+    long long best_ns = -1;
+    for (int rep = 0; rep < 5; ++rep) {
+      long long rep_ns = 0;
+      int       done   = 0;
+      while (done < total) {
+        int      k    = std::min(pool_sz, total - done);
+        HTTPHdr *pool = new HTTPHdr[k];
+        // Build fresh cached copies (untimed) so the timed region is pure merges.
+        for (int i = 0; i < k; ++i) {
+          pool[i].create(HTTPType::RESPONSE);
+          for (auto &&e : cached_tmpl) {
+            MIMEField *f = pool[i].field_create(e.name);
+            pool[i].field_attach(f);
+            pool[i].field_value_set(f, e.value);
+          }
+        }
+        auto t0 = std::chrono::steady_clock::now();
+        for (int i = 0; i < k; ++i) {
+          fn(&pool[i], &resp);
+        }
+        auto t1  = std::chrono::steady_clock::now();
+        rep_ns  += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+        for (int i = 0; i < k; ++i) {
+          pool[i].destroy();
+        }
+        delete[] pool;
+        done += k;
+      }
+      if (best_ns < 0 || rep_ns < best_ns) {
+        best_ns = rep_ns;
+      }
+    }
+    return static_cast<double>(best_ns) / total;
+  };
+
+  // Equivalence sanity: old and new must produce the same field set.
+  {
+    HTTPHdr        c_old, c_new, resp;
+    ts::PostScript d1([&]() -> void { c_old.destroy(); });
+    ts::PostScript d2([&]() -> void { c_new.destroy(); });
+    ts::PostScript d3([&]() -> void { resp.destroy(); });
+    build(c_old, cached_tmpl);
+    build(c_new, cached_tmpl);
+    build(resp, resp_dup);
+    merge_OLD(&c_old, &resp);
+    HttpTransact::merge_response_header_with_cached_header(&c_new, &resp);
+    CHECK(c_old.fields_count() == c_new.fields_count());
+  }
+
+  int const N    = 300000;
+  int const POOL = 2000;
+
+  double old_typical = bench(&merge_OLD, resp_typical, N, POOL);
+  double new_typical = bench(&HttpTransact::merge_response_header_with_cached_header, resp_typical, N, POOL);
+  double old_dup     = bench(&merge_OLD, resp_dup, N, POOL);
+  double new_dup     = bench(&HttpTransact::merge_response_header_with_cached_header, resp_dup, N, POOL);
+
+  // Full revalidation unit = the caller's caching-header delete + the merge, i.e.
+  // what merge_and_update_headers_for_cache_update does per 304. OLD deletes
+  // Age/ETag/Expires unconditionally; NEW deletes only those the response omits,
+  // then merges. This is the real per-revalidation hot-path cost.
+  auto bench_unit = [&](bool is_new, const std::vector<header> &resp_fields, int total, int pool_sz) -> double {
+    HTTPHdr        resp;
+    ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
+    build(resp, resp_fields);
+    bool const resp_has_age     = resp.presence(MIME_PRESENCE_AGE) != 0;
+    bool const resp_has_etag    = resp.presence(MIME_PRESENCE_ETAG) != 0;
+    bool const resp_has_expires = resp.presence(MIME_PRESENCE_EXPIRES) != 0;
+
+    long long best_ns = -1;
+    for (int rep = 0; rep < 5; ++rep) {
+      long long rep_ns = 0;
+      int       done   = 0;
+      while (done < total) {
+        int      k    = std::min(pool_sz, total - done);
+        HTTPHdr *pool = new HTTPHdr[k];
+        for (int i = 0; i < k; ++i) {
+          pool[i].create(HTTPType::RESPONSE);
+          for (auto &&e : cached_tmpl) {
+            MIMEField *f = pool[i].field_create(e.name);
+            pool[i].field_attach(f);
+            pool[i].field_value_set(f, e.value);
+          }
+        }
+        auto t0 = std::chrono::steady_clock::now();
+        for (int i = 0; i < k; ++i) {
+          HTTPHdr *c = &pool[i];
+          if (is_new) {
+            if (!resp_has_age) {
+              c->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
+            }
+            if (!resp_has_etag) {
+              c->field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
+            }
+            if (!resp_has_expires) {
+              c->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
+            }
+            HttpTransact::merge_response_header_with_cached_header(c, &resp);
+          } else {
+            c->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
+            c->field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
+            c->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
+            merge_OLD(c, &resp);
+          }
+        }
+        auto t1  = std::chrono::steady_clock::now();
+        rep_ns  += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+        for (int i = 0; i < k; ++i) {
+          pool[i].destroy();
+        }
+        delete[] pool;
+        done += k;
+      }
+      if (best_ns < 0 || rep_ns < best_ns) {
+        best_ns = rep_ns;
+      }
+    }
+    return static_cast<double>(best_ns) / total;
+  };
+
+  double old_unit_typical = bench_unit(false, resp_typical, N, POOL);
+  double new_unit_typical = bench_unit(true, resp_typical, N, POOL);
+  double old_unit_dup     = bench_unit(false, resp_dup, N, POOL);
+  double new_unit_dup     = bench_unit(true, resp_dup, N, POOL);
+
+  std::printf("\n=== merge hot-path benchmark (ns/op, best of 5, N=%d) ===\n", N);
+  std::printf("merge only:\n");
+  std::printf("  typical 304 (no dup):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_typical, new_typical,
+              100.0 * (new_typical - old_typical) / old_typical);
+  std::printf("  dup 304 (Cache-Ctrl):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_dup, new_dup,
+              100.0 * (new_dup - old_dup) / old_dup);
+  std::printf("full revalidation unit (caller delete + merge):\n");
+  std::printf("  typical 304 (no dup):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_unit_typical, new_unit_typical,
+              100.0 * (new_unit_typical - old_unit_typical) / old_unit_typical);
+  std::printf("  dup 304 (Cache-Ctrl):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_unit_dup, new_unit_dup,
+              100.0 * (new_unit_dup - old_unit_dup) / old_unit_dup);
+  std::printf("  (negative %% = new is faster)\n\n");
+
+  CHECK(new_typical > 0.0);
 }

--- a/src/proxy/http/unit_tests/test_HttpTransact.cc
+++ b/src/proxy/http/unit_tests/test_HttpTransact.cc
@@ -24,8 +24,6 @@
 #include <string_view>
 #include <vector>
 #include <cstdio>
-#include <chrono>
-#include <algorithm>
 
 using namespace std::string_view_literals;
 
@@ -33,69 +31,9 @@ using namespace std::string_view_literals;
 #include "tsutil/PostScript.h"
 
 #include "proxy/http/HttpTransact.h"
-#include "proxy/http/HttpTransactHeaders.h"
 #include "records/RecordsConfig.h"
 
 #include <catch2/catch_test_macros.hpp>
-
-namespace
-{
-// Faithful copy of merge_response_header_with_cached_header BEFORE the fix, so the
-// old and new implementations can be timed head-to-head in one process (no
-// cross-build variance). Kept only for the "[.merge-bench]" benchmark below.
-void
-merge_OLD(HTTPHdr *cached_header, HTTPHdr *response_header)
-{
-  MIMEField *new_field;
-  bool       dups_seen = false;
-
-  for (auto spot = response_header->begin(), limit = response_header->end(); spot != limit; ++spot) {
-    MIMEField &field{*spot};
-    auto       name{field.name_get()};
-
-    if (HttpTransactHeaders::is_this_a_hop_by_hop_header(name.data())) {
-      continue;
-    }
-    if (name.data() == MIME_FIELD_CONTENT_LENGTH.c_str() || name.data() == MIME_FIELD_TRANSFER_ENCODING.c_str()) {
-      continue;
-    }
-    if (name.data() == MIME_FIELD_SET_COOKIE.c_str()) {
-      continue;
-    }
-    if (name.data() == MIME_FIELD_CONTENT_TYPE.c_str()) {
-      continue;
-    }
-    if (name.data() == MIME_FIELD_WARNING.c_str()) {
-      continue;
-    }
-    if (field.m_next_dup) {
-      if (dups_seen == false) {
-        for (auto spot2 = spot; spot2 != limit; ++spot2) {
-          MIMEField &field2{*spot2};
-          auto       name2{field2.name_get()};
-          if (name2.data() == MIME_FIELD_CONTENT_TYPE.c_str()) {
-            continue;
-          }
-          cached_header->field_delete(name2);
-        }
-        dups_seen = true;
-      }
-    }
-
-    auto value{field.value_get()};
-
-    if (dups_seen == false) {
-      cached_header->value_set(name, value);
-    } else {
-      new_field = cached_header->field_create(name);
-      cached_header->field_attach(new_field);
-      cached_header->field_value_set(new_field, value);
-    }
-  }
-
-  HttpTransact::merge_warning_header(cached_header, response_header);
-}
-} // namespace
 
 TEST_CASE("HttpTransact", "[http]")
 {
@@ -605,17 +543,11 @@ TEST_CASE("HttpTransact", "[http]")
       ///////////////////////////////////////
     }
 
-    // Regression: repeated 304 revalidation of the same object must not grow the
-    // cached header without bound. In production a hot max-age=60 object is
-    // revalidated on ~every request; each 304 re-merges the server response into
-    // the cached header. If the merge grows the cached header's HdrHeap, its
-    // marshalled size eventually crosses the aggregation fragment limit and the
-    // cache write can never commit again (object frozen stale forever).
-    //
-    // The yardstick is HdrHeap::marshal_length() (the size that gates the cache
-    // write), NOT fields_count(): a deleted-then-recreated field strands a dead
-    // MIMEField slot that is not reclaimed until its whole block empties, so the
-    // heap grows even while the live field count is constant.
+    // Regression: repeated 304 revalidation must not grow the cached header
+    // without bound (see merge_response_header_with_cached_header). The
+    // yardstick is HdrHeap::marshal_length() -- the size that gates the cache
+    // write -- NOT fields_count(): dead MIMEField slots grow the heap even
+    // while the live field count stays constant.
     SECTION("Repeated revalidation does not grow the cached header heap")
     {
       struct header {
@@ -812,216 +744,4 @@ TEST_CASE("HttpTransact", "[http]")
       }
     }
   }
-}
-
-// Hot-path microbenchmark: merge_response_header_with_cached_header runs on every
-// 304 revalidation. Compares the new implementation against a faithful copy of the
-// pre-fix one (merge_OLD), head-to-head in one process. Hidden by the '.' tag; run
-// explicitly with:  test_http "[merge-bench]"
-TEST_CASE("merge hot-path benchmark", "[.merge-bench]")
-{
-  url_init();
-  mime_init();
-  http_init();
-
-  struct header {
-    std::string_view name;
-    std::string_view value;
-  };
-
-  auto build = [](HTTPHdr &h, const std::vector<header> &fields) {
-    h.create(HTTPType::RESPONSE);
-    for (auto &&e : fields) {
-      MIMEField *f = h.field_create(e.name);
-      h.field_attach(f);
-      h.field_value_set(f, e.value);
-    }
-  };
-
-  // A realistic stored 200 for a small, frequently revalidated object (the cached
-  // object): a handful of headers including the caching triplet Cache-Control /
-  // Etag / Expires.
-  std::vector<header> const cached_tmpl = {
-    {"Server",                    "ATS"                                },
-    {"Date",                      "Sat, 18 Jul 2026 05:29:18 GMT"      },
-    {"Content-Type",              "text/xml"                           },
-    {"Content-Length",            "181"                                },
-    {"Last-Modified",             "Tue, 04 Apr 2023 17:58:01 GMT"      },
-    {"Accept-Ranges",             "bytes"                              },
-    {"Cache-Control",             "max-age=60"                         },
-    {"Content-Language",          "en-us"                              },
-    {"Strict-Transport-Security", "max-age=31536000; includeSubdomains"},
-    {"X-Frame-Options",           "SAMEORIGIN"                         },
-    {"X-Content-Type-Options",    "nosniff"                            },
-    {"X-XSS-Protection",          "1; mode=block"                      },
-    {"Etag",                      "\"0123456789abcdef\""               },
-    {"Expires",                   "Sat, 18 Jul 2026 05:30:18 GMT"      },
-  };
-
-  // A typical minimal 304 (no duplicated fields).
-  std::vector<header> const resp_typical = {
-    {"Server",        "ATS"                          },
-    {"Date",          "Sat, 18 Jul 2026 05:30:18 GMT"},
-    {"Cache-Control", "max-age=60"                   },
-    {"Expires",       "Sat, 18 Jul 2026 05:31:18 GMT"},
-  };
-
-  // The pathological 304 that triggered the leak: a duplicated Cache-Control.
-  std::vector<header> const resp_dup = {
-    {"Server",        "ATS"                          },
-    {"Date",          "Sat, 18 Jul 2026 05:30:18 GMT"},
-    {"Cache-Control", "max-age=60"                   },
-    {"Cache-Control", "public"                       },
-    {"Expires",       "Sat, 18 Jul 2026 05:31:18 GMT"},
-  };
-
-  using MergeFn = void (*)(HTTPHdr *, HTTPHdr *);
-
-  // Time pure merge cost: pre-build a pool of fresh cached copies (untimed), then
-  // time only the merges. Each copy is merged exactly once, so this is fair for
-  // both the idempotent new code and the leaking old code. Returns ns/merge.
-  auto bench = [&](MergeFn fn, const std::vector<header> &resp_fields, int total, int pool_sz) -> double {
-    HTTPHdr        resp;
-    ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
-    build(resp, resp_fields);
-
-    long long best_ns = -1;
-    for (int rep = 0; rep < 5; ++rep) {
-      long long rep_ns = 0;
-      int       done   = 0;
-      while (done < total) {
-        int      k    = std::min(pool_sz, total - done);
-        HTTPHdr *pool = new HTTPHdr[k];
-        // Build fresh cached copies (untimed) so the timed region is pure merges.
-        for (int i = 0; i < k; ++i) {
-          pool[i].create(HTTPType::RESPONSE);
-          for (auto &&e : cached_tmpl) {
-            MIMEField *f = pool[i].field_create(e.name);
-            pool[i].field_attach(f);
-            pool[i].field_value_set(f, e.value);
-          }
-        }
-        auto t0 = std::chrono::steady_clock::now();
-        for (int i = 0; i < k; ++i) {
-          fn(&pool[i], &resp);
-        }
-        auto t1  = std::chrono::steady_clock::now();
-        rep_ns  += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-        for (int i = 0; i < k; ++i) {
-          pool[i].destroy();
-        }
-        delete[] pool;
-        done += k;
-      }
-      if (best_ns < 0 || rep_ns < best_ns) {
-        best_ns = rep_ns;
-      }
-    }
-    return static_cast<double>(best_ns) / total;
-  };
-
-  // Equivalence sanity: old and new must produce the same field set.
-  {
-    HTTPHdr        c_old, c_new, resp;
-    ts::PostScript d1([&]() -> void { c_old.destroy(); });
-    ts::PostScript d2([&]() -> void { c_new.destroy(); });
-    ts::PostScript d3([&]() -> void { resp.destroy(); });
-    build(c_old, cached_tmpl);
-    build(c_new, cached_tmpl);
-    build(resp, resp_dup);
-    merge_OLD(&c_old, &resp);
-    HttpTransact::merge_response_header_with_cached_header(&c_new, &resp);
-    CHECK(c_old.fields_count() == c_new.fields_count());
-  }
-
-  int const N    = 300000;
-  int const POOL = 2000;
-
-  double old_typical = bench(&merge_OLD, resp_typical, N, POOL);
-  double new_typical = bench(&HttpTransact::merge_response_header_with_cached_header, resp_typical, N, POOL);
-  double old_dup     = bench(&merge_OLD, resp_dup, N, POOL);
-  double new_dup     = bench(&HttpTransact::merge_response_header_with_cached_header, resp_dup, N, POOL);
-
-  // Full revalidation unit = the caller's caching-header delete + the merge, i.e.
-  // what merge_and_update_headers_for_cache_update does per 304. OLD deletes
-  // Age/ETag/Expires unconditionally; NEW deletes only those the response omits,
-  // then merges. This is the real per-revalidation hot-path cost.
-  auto bench_unit = [&](bool is_new, const std::vector<header> &resp_fields, int total, int pool_sz) -> double {
-    HTTPHdr        resp;
-    ts::PostScript resp_defer([&]() -> void { resp.destroy(); });
-    build(resp, resp_fields);
-    bool const resp_has_age     = resp.presence(MIME_PRESENCE_AGE) != 0;
-    bool const resp_has_etag    = resp.presence(MIME_PRESENCE_ETAG) != 0;
-    bool const resp_has_expires = resp.presence(MIME_PRESENCE_EXPIRES) != 0;
-
-    long long best_ns = -1;
-    for (int rep = 0; rep < 5; ++rep) {
-      long long rep_ns = 0;
-      int       done   = 0;
-      while (done < total) {
-        int      k    = std::min(pool_sz, total - done);
-        HTTPHdr *pool = new HTTPHdr[k];
-        for (int i = 0; i < k; ++i) {
-          pool[i].create(HTTPType::RESPONSE);
-          for (auto &&e : cached_tmpl) {
-            MIMEField *f = pool[i].field_create(e.name);
-            pool[i].field_attach(f);
-            pool[i].field_value_set(f, e.value);
-          }
-        }
-        auto t0 = std::chrono::steady_clock::now();
-        for (int i = 0; i < k; ++i) {
-          HTTPHdr *c = &pool[i];
-          if (is_new) {
-            if (!resp_has_age) {
-              c->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
-            }
-            if (!resp_has_etag) {
-              c->field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
-            }
-            if (!resp_has_expires) {
-              c->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
-            }
-            HttpTransact::merge_response_header_with_cached_header(c, &resp);
-          } else {
-            c->field_delete(static_cast<std::string_view>(MIME_FIELD_AGE));
-            c->field_delete(static_cast<std::string_view>(MIME_FIELD_ETAG));
-            c->field_delete(static_cast<std::string_view>(MIME_FIELD_EXPIRES));
-            merge_OLD(c, &resp);
-          }
-        }
-        auto t1  = std::chrono::steady_clock::now();
-        rep_ns  += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
-        for (int i = 0; i < k; ++i) {
-          pool[i].destroy();
-        }
-        delete[] pool;
-        done += k;
-      }
-      if (best_ns < 0 || rep_ns < best_ns) {
-        best_ns = rep_ns;
-      }
-    }
-    return static_cast<double>(best_ns) / total;
-  };
-
-  double old_unit_typical = bench_unit(false, resp_typical, N, POOL);
-  double new_unit_typical = bench_unit(true, resp_typical, N, POOL);
-  double old_unit_dup     = bench_unit(false, resp_dup, N, POOL);
-  double new_unit_dup     = bench_unit(true, resp_dup, N, POOL);
-
-  std::printf("\n=== merge hot-path benchmark (ns/op, best of 5, N=%d) ===\n", N);
-  std::printf("merge only:\n");
-  std::printf("  typical 304 (no dup):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_typical, new_typical,
-              100.0 * (new_typical - old_typical) / old_typical);
-  std::printf("  dup 304 (Cache-Ctrl):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_dup, new_dup,
-              100.0 * (new_dup - old_dup) / old_dup);
-  std::printf("full revalidation unit (caller delete + merge):\n");
-  std::printf("  typical 304 (no dup):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_unit_typical, new_unit_typical,
-              100.0 * (new_unit_typical - old_unit_typical) / old_unit_typical);
-  std::printf("  dup 304 (Cache-Ctrl):  OLD %7.1f   NEW %7.1f   (%+.1f%%)\n", old_unit_dup, new_unit_dup,
-              100.0 * (new_unit_dup - old_unit_dup) / old_unit_dup);
-  std::printf("  (negative %% = new is faster)\n\n");
-
-  CHECK(new_typical > 0.0);
 }


### PR DESCRIPTION
## Problem

A hot, frequently-revalidated cached object slowly grows the `HdrHeap` of its
**cached response header** without bound. Once the header's marshalled size
crosses the aggregation-buffer fragment limit (`AGG_SIZE`, 4 MiB), the cache
write of the updated header can never be admitted again
(`Stripe::add_writer` rejects `agg_len > AGG_SIZE` → `AIO_SOFT_FAILURE` →
`openWriteCloseHeadDone` bails before `dir_overwrite`). The stored object is
then **frozen**: its headers never update, it is always stale, and every request
re-runs the doomed revalidation write + serve-stale path.

The growth is invisible to `fields_count()` — the *live* field count stays
constant. It shows up only in `HdrHeap::marshal_length()` (the value that gates
the cache write): dead `MIMEField`/field-block objects accumulate in the
bump-allocated object area.

## Root cause

Two independent contributors, both in the 304 cache-update path:

1. **`merge_and_update_headers_for_cache_update`** unconditionally deletes
   `Age`/`ETag`/`Expires` from the cached header before re-merging the 304's
   values. A deleted `MIMEField` slot is only reclaimed when its entire 16-slot
   block becomes empty, and `HdrHeap::allocate_obj` never reuses an EMPTY slot —
   it only bump-allocates. So each revalidation of an object whose 304 carries a
   changing `Expires` strands one dead slot. `HdrHeap::marshal` is a raw region
   `memcpy` (it does not compact), so the dead slots are persisted to disk, read
   back, and re-marshalled larger on the next revalidation — unbounded growth.

2. **`merge_response_header_with_cached_header`** used a sticky `dups_seen` flag:
   once *any* response field had a duplicate, every *later* single-valued field
   took the `field_create`/`field_attach` **append** path instead of an in-place
   `value_set`, stranding a slot per merge for those fields too.

## Fix

1. In `merge_and_update_headers_for_cache_update`, delete a caching header only
   when the server response **omits** it (guarded on `presence()`). When the 304
   carries it, the merge overwrites the cached field in place — no delete +
   recreate, so no stranded slot. Final header state is unchanged.

2. Rewrite `merge_response_header_with_cached_header` to reconcile each field
   name **independently** at its dup-list head: overwrite existing cached values
   in place (reusing the slot via `field_value_set`), append only genuine extra
   values, and delete any surplus cached values. This makes the merge idempotent
   — re-merging an unchanged response mutates existing fields instead of
   stranding dead ones — and removes the sticky-`dups_seen` behavior. It also
   preserves the documented `Warning`/`Content-Type` handling.

## Tests

`test_HttpTransact.cc` gains a "Repeated revalidation does not grow the cached
header heap" section asserting `HdrHeap::marshal_length()` stays bounded across
up to 4000 merges for: no-dup, leading-dup, response-only-dup, and
changing-length-value cases; plus a correctness case (dropping a duplicate value
leaves exactly the response's values) and an end-to-end case that mirrors the
caller's conditional-delete sequence over the cooked WKS caching headers
(`Cache-Control`/`Expires`/`Age`), checking the cooked `max-age` and bounded
heap. All existing merge assertions are unchanged.

Verified locally: full `test_http` passes under `dev`, `dev-asan`
(ASAN+UBSAN, no errors), and `release`.

## Performance

Because the merge no longer deletes-then-recreates (and the caller skips
unnecessary deletes), the hot path is **faster**, not slower. Measured with a
local A/B microbenchmark (not included in this PR) that timed the new merge
against a copy of the previous implementation head-to-head in one process, on a
realistic ~14-field cached 200 + a 304 (release build, ns/op, best of 5, 3
runs):

```
merge only:
  typical 304 (no dup):  ~ -2% to -8%   (in-place replace, ~neutral)
  dup 304 (Cache-Ctrl):  ~ -27% to -29% (no more append+delete churn)
full revalidation unit (caller delete + merge):
  typical 304 (no dup):  ~ -18% to -21% (caller skips redundant deletes)
  dup 304 (Cache-Ctrl):  ~ -26% to -28%
```

## Compatibility / risk

- The resulting cached header field set is equivalent to the previous code for
  realistic 304/200 responses (names, values, dup count, dup value order). Only
  the physical ordering of *distinct* field names can differ when appending
  extra dup values, which is not significant (RFC 7230 §3.2.2) and no cached-
  response consumer depends on it.
- One corner-case divergence, which is a fix: once a duplicated field was seen,
  the old code's second sweep also deleted cached fields for names the copy loop
  never re-adds (`Set-Cookie`, `Warning`, hop-by-hop headers, `Content-Length`,
  `Transfer-Encoding`; only `Content-Type` was exempted). The new code never
  touches those cached fields, restoring `merge_warning_header`'s documented
  precondition that the cached `Warning` codes reach it untouched.
- This prevents the bloat from forming. It does **not** shrink or unfreeze an
  object that is *already* bloated on disk: an in-place update cannot reclaim
  existing dead object-area bytes (only a fresh full store / copy does). Objects
  already wedged need to leave the cache (purge, full 200 re-store, or eviction).

## Notes for reviewers

- A broader hardening, not done here: give the `HdrHeap` object area a
  compaction valve analogous to the existing string-heap `coalesce_str_heaps`
  (which already exists precisely to bound "infinite build up of dead strings on
  header merge", see the `INKqa08287` comment in `HdrHeap::allocate_str`). The
  object area has no such valve today.
