### PR TITLE
ssl: remove the dead SSL_HOOK_OP_TERMINATE op

### DIFF
--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -81,9 +81,8 @@ constexpr int      SSL_DEF_TLS_RECORD_MSEC_THRESHOLD = 1000;
 struct SSLCertLookup;
 
 enum class SslVConnOp {
-  SSL_HOOK_OP_DEFAULT,  ///< Null / initialization value. Do normal processing.
-  SSL_HOOK_OP_TUNNEL,   ///< Switch to blind tunnel
-  SSL_HOOK_OP_TERMINATE ///< Termination connection / transaction.
+  SSL_HOOK_OP_DEFAULT, ///< Null / initialization value. Do normal processing.
+  SSL_HOOK_OP_TUNNEL   ///< Switch to blind tunnel
 };
 
 enum class SSLHandshakeStatus { SSL_HANDSHAKE_ONGOING, SSL_HANDSHAKE_DONE, SSL_HANDSHAKE_ERROR };

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1309,9 +1309,6 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
     // we get out of this callback, and then will shuffle
     // over the buffered handshake packets to the O.S.
     return EVENT_DONE;
-  } else if (SslVConnOp::SSL_HOOK_OP_TERMINATE == hookOpRequested) {
-    sslHandshakeStatus = SSLHandshakeStatus::SSL_HANDSHAKE_DONE;
-    return EVENT_DONE;
   }
 
   Dbg(dbg_ctl_ssl, "Go on with the handshake state=%s",


### PR DESCRIPTION
`SslVConnOp::SSL_HOOK_OP_TERMINATE` has never been assigned to `hookOpRequested`: the commit that introduced it (TS-3006, 2014) only wrote the corresponding public value into the example plugins' own config structs, and the public `TSSslVConnOp` type that exposed it was removed in 2016 (TS-4658).

No code in the tree assigns TERMINATE today: `hookOpRequested` is only ever reset to `SSL_HOOK_OP_DEFAULT` or set to `SSL_HOOK_OP_TUNNEL` (by the `ssl_multicert.config` `tunnel` option and `TSVConnTunnel()`). A hook that wants to end a handshake uses `TSVConnReenableEx` with `TS_EVENT_ERROR` instead.

Drop the enumerator and its unreachable arm in `sslServerHandShakeEvent()`. No functional change.