### PR TITLE
Add live HostDB cache clearing

### DIFF
--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -1290,6 +1290,13 @@ traffic_ctl hostdb
 
    If ``HOSTNAME`` is specified, the output is filtered to show only records whose names contain the given string.
 
+.. option:: clear
+
+   :ref:`admin_hostdb_clear`
+
+   Remove all DNS resolution records from HostDB without restarting |TS|. In-flight transactions retain their current resolution,
+   while subsequent transactions resolve their upstream hosts again.
+
 traffic_ctl rpc
 ---------------
 .. program:: traffic_ctl rpc

--- a/doc/appendices/command-line/traffic_ctl.en.rst
+++ b/doc/appendices/command-line/traffic_ctl.en.rst
@@ -1316,6 +1316,13 @@ traffic_ctl hostdb
 
    If ``HOSTNAME`` is specified, the output is filtered to show only records whose names contain the given string.
 
+.. option:: clear
+
+   :ref:`admin_hostdb_clear`
+
+   Remove all cached DNS resolution records from HostDB without restarting |TS|. Entries loaded from the host file remain. In-flight
+   transactions retain their current resolution, while subsequent transactions resolve their upstream hosts again.
+
 traffic_ctl rpc
 ---------------
 .. program:: traffic_ctl rpc

--- a/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
@@ -453,6 +453,8 @@ JSONRPC API
 
 * `admin_host_set_status`_
 
+* `admin_hostdb_clear`_
+
 * `admin_server_stop_drain`_
 
 * `admin_server_start_drain`_
@@ -1393,6 +1395,58 @@ Response:
          ]
          ,"errorList":[]
       }
+   }
+
+
+HostDB
+======
+
+.. _admin_hostdb_clear:
+
+admin_hostdb_clear
+------------------
+
+|method|
+
+Description
+~~~~~~~~~~~
+
+Remove all cached DNS resolution records from HostDB. In-flight transactions retain their current resolution, while subsequent
+transactions resolve their upstream hosts again.
+
+Parameters
+~~~~~~~~~~
+
+* ``params``: Omitted
+
+Result
+~~~~~~
+
+The response will contain the default `success_response` or an error. :ref:`jsonrpc-node-errors`.
+
+Examples
+~~~~~~~~
+
+Request:
+
+.. code-block:: json
+   :linenos:
+
+   {
+      "id": "dc8b7f1e-2521-4bc0-b0ed-5e3ec751599d",
+      "jsonrpc": "2.0",
+      "method": "admin_hostdb_clear"
+   }
+
+Response:
+
+.. code-block:: json
+   :linenos:
+
+   {
+      "jsonrpc": "2.0",
+      "result": "success",
+      "id": "dc8b7f1e-2521-4bc0-b0ed-5e3ec751599d"
    }
 
 

--- a/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-api.en.rst
@@ -455,6 +455,8 @@ JSONRPC API
 
 * `admin_host_set_status`_
 
+* `admin_hostdb_clear`_
+
 * `admin_server_stop_drain`_
 
 * `admin_server_start_drain`_
@@ -1450,6 +1452,58 @@ Response:
          ]
          ,"errorList":[]
       }
+   }
+
+
+HostDB
+======
+
+.. _admin_hostdb_clear:
+
+admin_hostdb_clear
+------------------
+
+|method|
+
+Description
+~~~~~~~~~~~
+
+Remove all cached DNS resolution records from HostDB. Entries loaded from the host file remain. In-flight transactions retain their
+current resolution, while subsequent transactions resolve their upstream hosts again.
+
+Parameters
+~~~~~~~~~~
+
+* ``params``: Omitted
+
+Result
+~~~~~~
+
+The response will contain the default `success_response` or an error. :ref:`jsonrpc-node-errors`.
+
+Examples
+~~~~~~~~
+
+Request:
+
+.. code-block:: json
+   :linenos:
+
+   {
+      "id": "dc8b7f1e-2521-4bc0-b0ed-5e3ec751599d",
+      "jsonrpc": "2.0",
+      "method": "admin_hostdb_clear"
+   }
+
+Response:
+
+.. code-block:: json
+   :linenos:
+
+   {
+      "jsonrpc": "2.0",
+      "result": "success",
+      "id": "dc8b7f1e-2521-4bc0-b0ed-5e3ec751599d"
    }
 
 

--- a/include/iocore/hostdb/HostDBProcessor.h
+++ b/include/iocore/hostdb/HostDBProcessor.h
@@ -652,6 +652,9 @@ struct HostDBProcessor : public Processor {
    */
   int start(int no_of_additional_event_threads = 0, size_t stacksize = DEFAULT_STACKSIZE) override;
 
+  /// Remove all cached DNS resolution records.
+  void clear();
+
   // Private
   HostDBCache *cache();
 

--- a/include/mgmt/rpc/handlers/hostdb/HostDB.h
+++ b/include/mgmt/rpc/handlers/hostdb/HostDB.h
@@ -25,4 +25,5 @@
 namespace rpc::handlers::hostdb
 {
 swoc::Rv<YAML::Node> get_hostdb_status(std::string_view const &id, YAML::Node const &);
+swoc::Rv<YAML::Node> clear_hostdb(std::string_view const &id, YAML::Node const &);
 } // namespace rpc::handlers::hostdb

--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -254,6 +254,12 @@ HostDBProcessor::cache()
   return &hostDB;
 }
 
+void
+HostDBProcessor::clear()
+{
+  hostDB.refcountcache->clear();
+}
+
 int
 HostDBCache::start(int flags)
 {

--- a/src/iocore/hostdb/HostDB.cc
+++ b/src/iocore/hostdb/HostDB.cc
@@ -214,10 +214,10 @@ HostDBCache::HostDBCache() {}
 bool
 HostDBCache::is_pending_dns_for_hash(const CryptoHash &hash)
 {
-  ts::shared_mutex                  &bucket_lock = hostDB.refcountcache->lock_for_key(hash.fold());
-  std::shared_lock<ts::shared_mutex> lock{bucket_lock};
-  bool                               retval = false;
-  Queue<HostDBContinuation>         &q      = pending_dns_for_hash(hash);
+  ts::shared_mutex          &bucket_lock = hostDB.refcountcache->lock_for_key(hash.fold());
+  ts::read_guard             lock{bucket_lock};
+  bool                       retval = false;
+  Queue<HostDBContinuation> &q      = pending_dns_for_hash(hash);
   for (HostDBContinuation *c = q.head; c; c = static_cast<HostDBContinuation *>(c->link.next)) {
     if (hash == c->hash.hash) {
       retval = true;
@@ -230,10 +230,10 @@ HostDBCache::is_pending_dns_for_hash(const CryptoHash &hash)
 bool
 HostDBCache::remove_from_pending_dns_for_hash(const CryptoHash &hash, HostDBContinuation *c)
 {
-  bool                               retval      = false;
-  ts::shared_mutex                  &bucket_lock = hostDB.refcountcache->lock_for_key(hash.fold());
-  std::unique_lock<ts::shared_mutex> lock{bucket_lock};
-  Queue<HostDBContinuation>         &q = pending_dns_for_hash(hash);
+  bool                       retval      = false;
+  ts::shared_mutex          &bucket_lock = hostDB.refcountcache->lock_for_key(hash.fold());
+  ts::write_guard            lock{bucket_lock};
+  Queue<HostDBContinuation> &q = pending_dns_for_hash(hash);
   if (q.in(c)) {
     q.remove(c);
     retval = true;
@@ -253,6 +253,12 @@ HostDBCache *
 HostDBProcessor::cache()
 {
   return &hostDB;
+}
+
+void
+HostDBProcessor::clear()
+{
+  hostDB.refcountcache->clear();
 }
 
 int
@@ -469,32 +475,26 @@ probe(HostDBHash const &hash, bool ignore_timeout)
   }
 
   // Otherwise HostDB is enabled, so we'll do our thing
-  uint64_t          folded_hash = hash.hash.fold();
-  ts::shared_mutex &bucket_lock = hostDB.refcountcache->lock_for_key(folded_hash);
+  uint64_t folded_hash = hash.hash.fold();
 
-  Ptr<HostDBRecord> record;
-  {
-    std::shared_lock<ts::shared_mutex> lock{bucket_lock};
-
-    // get the record from cache
-    record = hostDB.refcountcache->get(folded_hash);
-    // If there was nothing in the cache-- this is a miss
-    if (record.get() == nullptr) {
-      record = probe_ip(hash);
-      if (!record) {
-        record = probe_hostfile(hash);
-      }
-      return record;
+  // get the record from cache
+  Ptr<HostDBRecord> record = hostDB.refcountcache->get(folded_hash);
+  // If there was nothing in the cache-- this is a miss
+  if (record.get() == nullptr) {
+    record = probe_ip(hash);
+    if (!record) {
+      record = probe_hostfile(hash);
     }
+    return record;
+  }
 
-    // If the dns response was failed, and we've hit the failed timeout, lets stop returning it
-    if (record->is_failed() && record->is_ip_fail_timeout()) {
-      return NO_RECORD;
-      // if we aren't ignoring timeouts, and we are past it-- then remove the record
-    } else if (!ignore_timeout && record->is_ip_timeout() && !record->serve_stale_but_revalidate()) {
-      Metrics::Counter::increment(hostdb_rsb.ttl_expires);
-      return NO_RECORD;
-    }
+  // If the dns response was failed, and we've hit the failed timeout, lets stop returning it
+  if (record->is_failed() && record->is_ip_fail_timeout()) {
+    return NO_RECORD;
+    // if we aren't ignoring timeouts, and we are past it-- then remove the record
+  } else if (!ignore_timeout && record->is_ip_timeout() && !record->serve_stale_but_revalidate()) {
+    Metrics::Counter::increment(hostdb_rsb.ttl_expires);
+    return NO_RECORD;
   }
 
   // If the record is stale, but we want to revalidate-- lets start that up
@@ -567,12 +567,8 @@ HostDBProcessor::getby(Continuation *cont, cb_process_result_pfn cb_process_resu
     bool loop = lock.is_locked();
     while (loop) {
       loop = false; // Only loop on explicit set for retry.
-      // find the partition lock
-      ts::shared_mutex &bucket_lock = hostDB.refcountcache->lock_for_key(hash.hash.fold());
-
-      // If we can get the lock and a level 1 probe succeeds, return
-      HostDBRecord::Handle               r = probe(hash, false);
-      std::shared_lock<ts::shared_mutex> lock{bucket_lock};
+      // If a level 1 probe succeeds, return
+      HostDBRecord::Handle r = probe(hash, false);
       if (r) {
         // fail, see if we should retry with alternate
         if (hash.db_mark != HOSTDB_MARK_SRV && r->is_failed() && hash.host_name) {
@@ -992,10 +988,9 @@ HostDBContinuation::dnsEvent(int event, HostEnt *e)
     }
 
     if (!serve_stale) { // implies r != old_r
-      ts::shared_mutex                  &bucket_lock = hostDB.refcountcache->lock_for_key(hash.hash.fold());
-      std::unique_lock<ts::shared_mutex> lock{bucket_lock};
-      auto const                         duration_till_revalidate = r->expiry_time().time_since_epoch();
-      auto const                         seconds_till_revalidate  = duration_cast<ts_seconds>(duration_till_revalidate).count();
+      auto const duration_till_revalidate = r->expiry_time().time_since_epoch();
+      auto const seconds_till_revalidate  = duration_cast<ts_seconds>(duration_till_revalidate).count();
+
       hostDB.refcountcache->put(r->key, r.get(), r->_record_size, seconds_till_revalidate);
     } else {
       Warning("Fallback to serving stale record, skip re-update of hostdb for %.*s", int(query_name.size()), query_name.data());
@@ -1121,9 +1116,9 @@ HostDBContinuation::probeEvent(int /* event ATS_UNUSED */, Event *e)
 int
 HostDBContinuation::set_check_pending_dns()
 {
-  ts::shared_mutex                  &bucket_lock = hostDB.refcountcache->lock_for_key(hash.hash.fold());
-  std::unique_lock<ts::shared_mutex> lock{bucket_lock};
-  Queue<HostDBContinuation>         &q = hostDB.pending_dns_for_hash(hash.hash);
+  ts::shared_mutex          &bucket_lock = hostDB.refcountcache->lock_for_key(hash.hash.fold());
+  ts::write_guard            lock{bucket_lock};
+  Queue<HostDBContinuation> &q = hostDB.pending_dns_for_hash(hash.hash);
   this->setThreadAffinity(this_ethread());
   if (q.in(this)) {
     Metrics::Counter::increment(hostdb_rsb.insert_duplicate_to_pending_dns);
@@ -1149,8 +1144,8 @@ HostDBContinuation::remove_and_trigger_pending_dns()
   HostDBContinuation       *c           = nullptr;
   ts::shared_mutex         &bucket_lock = hostDB.refcountcache->lock_for_key(hash.hash.fold());
   {
-    std::unique_lock<ts::shared_mutex> lock{bucket_lock};
-    Queue<HostDBContinuation>         &q = hostDB.pending_dns_for_hash(hash.hash);
+    ts::write_guard            lock{bucket_lock};
+    Queue<HostDBContinuation> &q = hostDB.pending_dns_for_hash(hash.hash);
     q.remove(this);
     c = q.head;
     while (c) {

--- a/src/iocore/hostdb/P_RefCountCache.h
+++ b/src/iocore/hostdb/P_RefCountCache.h
@@ -35,6 +35,7 @@
 
 #include "swoc/IntrusiveHashMap.h"
 #include <cstdint>
+#include <mutex>
 #include <unistd.h>
 
 using ts::Metrics;
@@ -507,6 +508,9 @@ void
 RefCountCache<C>::clear()
 {
   for (unsigned int i = 0; i < this->num_partitions; i++) {
-    this->partitions[i]->clear();
+    auto &partition = *this->partitions[i];
+
+    std::unique_lock<ts::shared_mutex> lock{partition.lock};
+    partition.clear();
   }
 }

--- a/src/iocore/hostdb/P_RefCountCache.h
+++ b/src/iocore/hostdb/P_RefCountCache.h
@@ -162,33 +162,32 @@ public:
   using hash_type = swoc::IntrusiveHashMap<RefCountCacheLinkage>;
 
   RefCountCachePartition(unsigned int part_num, uint64_t max_size, unsigned int max_items, RefCountCacheBlock *rsb = nullptr);
-  Ptr<C> get(uint64_t key);
-  void   put(uint64_t key, C *item, int size = 0, time_t expire_time = 0);
-  void   erase(uint64_t key, ink_time_t expiry_time = -1);
+  Ptr<C> get(uint64_t key) TS_REQUIRES_SHARED(lock);
+  void   put(uint64_t key, C *item, int size = 0, time_t expire_time = 0) TS_REQUIRES(lock);
+  void   erase(uint64_t key, ink_time_t expiry_time = -1) TS_REQUIRES(lock);
 
-  void clear();
-  bool is_full() const;
-  bool make_space_for(unsigned int);
-  void dealloc_entry(hash_type::iterator ptr);
+  void clear() TS_REQUIRES(lock);
+  bool is_full() const TS_REQUIRES_SHARED(lock);
+  bool make_space_for(unsigned int) TS_REQUIRES(lock);
+  void dealloc_entry(hash_type::iterator ptr) TS_REQUIRES(lock);
 
-  size_t count() const;
-  void   copy(std::vector<RefCountCacheHashEntry *> &items);
+  size_t count() const TS_REQUIRES_SHARED(lock);
 
-  hash_type &get_map();
+  hash_type &get_map() TS_REQUIRES_SHARED(lock);
 
   ts::shared_mutex lock;
 
 private:
-  unsigned int part_num;
-  uint64_t     max_size;
-  unsigned int max_items;
-  uint64_t     size;
-  unsigned int items;
+  unsigned int       part_num;
+  uint64_t           max_size;
+  unsigned int       max_items;
+  uint64_t size      TS_GUARDED_BY(lock);
+  unsigned int items TS_GUARDED_BY(lock);
 
-  hash_type item_map;
+  hash_type item_map TS_GUARDED_BY(lock);
 
-  PriorityQueue<RefCountCacheHashEntry *> expiry_queue;
-  RefCountCacheBlock                     *rsb;
+  PriorityQueue<RefCountCacheHashEntry *> expiry_queue TS_GUARDED_BY(lock);
+  RefCountCacheBlock                                  *rsb;
 };
 
 template <class C>
@@ -343,17 +342,6 @@ RefCountCachePartition<C>::count() const
 }
 
 template <class C>
-void
-RefCountCachePartition<C>::copy(std::vector<RefCountCacheHashEntry *> &items)
-{
-  for (auto &&it : this->item_map) {
-    RefCountCacheHashEntry *val = RefCountCacheHashEntry::alloc();
-    val->set(it.item.get(), it.meta.key, it.meta.size, it.meta.expiry_time);
-    items.push_back(val);
-  }
-}
-
-template <class C>
 swoc::IntrusiveHashMap<RefCountCacheLinkage> &
 RefCountCachePartition<C>::get_map()
 {
@@ -438,14 +426,20 @@ template <class C>
 Ptr<C>
 RefCountCache<C>::get(uint64_t key)
 {
-  return this->partitions[this->partition_for_key(key)]->get(key);
+  auto &partition = *this->partitions[this->partition_for_key(key)];
+
+  ts::read_guard lock{partition.lock};
+  return partition.get(key);
 }
 
 template <class C>
 void
 RefCountCache<C>::put(uint64_t key, C *item, int size, ink_time_t expiry_time)
 {
-  return this->partitions[this->partition_for_key(key)]->put(key, item, size, expiry_time);
+  auto &partition = *this->partitions[this->partition_for_key(key)];
+
+  ts::write_guard lock{partition.lock};
+  return partition.put(key, item, size, expiry_time);
 }
 
 // Pick a partition for a given item
@@ -476,7 +470,10 @@ RefCountCache<C>::count() const
 {
   size_t c = 0;
   for (unsigned int i = 0; i < this->num_partitions; i++) {
-    c += this->partitions[i]->count();
+    auto &partition = *this->partitions[i];
+
+    ts::read_guard lock{partition.lock};
+    c += partition.count();
   }
   return c;
 }
@@ -499,7 +496,10 @@ template <class C>
 void
 RefCountCache<C>::erase(uint64_t key)
 {
-  this->partitions[this->partition_for_key(key)]->erase(key);
+  auto &partition = *this->partitions[this->partition_for_key(key)];
+
+  ts::write_guard lock{partition.lock};
+  partition.erase(key);
 }
 
 template <class C>
@@ -507,6 +507,9 @@ void
 RefCountCache<C>::clear()
 {
   for (unsigned int i = 0; i < this->num_partitions; i++) {
-    this->partitions[i]->clear();
+    auto &partition = *this->partitions[i];
+
+    ts::write_guard lock{partition.lock};
+    partition.clear();
   }
 }

--- a/src/mgmt/rpc/handlers/hostdb/HostDB.cc
+++ b/src/mgmt/rpc/handlers/hostdb/HostDB.cc
@@ -84,24 +84,28 @@ template <> struct convert<HostDBCache> {
   {
     Node partitions;
     for (size_t i = 0; i < hostDB->refcountcache->partition_count(); i++) {
-      auto                                 &partition = hostDB->refcountcache->get_partition(i);
-      std::vector<RefCountCacheHashEntry *> partition_entries;
+      auto                             &partition = hostDB->refcountcache->get_partition(i);
+      std::vector<HostDBRecord::Handle> partition_records;
 
       {
         std::shared_lock<ts::shared_mutex> shared_lock{partition.lock};
-        partition_entries.reserve(partition.count());
-        partition.copy(partition_entries);
+
+        partition_records.reserve(partition.count());
+        for (auto &&entry : partition.get_map()) {
+          partition_records.emplace_back(make_ptr(static_cast<HostDBRecord *>(entry.item.get())));
+        }
       }
 
-      if (partition_entries.empty()) {
+      if (partition_records.empty()) {
         continue;
       }
 
       Node partition_node;
       partition_node["id"] = i;
 
-      for (RefCountCacheHashEntry *entry : partition_entries) {
-        HostDBRecord *record = static_cast<HostDBRecord *>(entry->item.get());
+      for (auto const &record_handle : partition_records) {
+        HostDBRecord *record = record_handle.get();
+
         if (!hostname.empty() && record->name_view().find(hostname) == std::string_view::npos) {
           continue;
         }
@@ -202,5 +206,12 @@ get_hostdb_status(std::string_view const & /* id ATS_UNUSED */, YAML::Node const
       .note("Error found when calling get_hostdb_status API: {}", ex.what());
   }
   return resp;
+}
+
+swoc::Rv<YAML::Node>
+clear_hostdb(std::string_view const & /* id ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
+{
+  hostDBProcessor.clear();
+  return {};
 }
 } // namespace rpc::handlers::hostdb

--- a/src/mgmt/rpc/handlers/hostdb/HostDB.cc
+++ b/src/mgmt/rpc/handlers/hostdb/HostDB.cc
@@ -27,7 +27,6 @@
 #include "swoc/TextView.h"
 #include "tsutil/TsSharedMutex.h"
 #include "yaml-cpp/node/node.h"
-#include <shared_mutex>
 #include <string>
 #include <string_view>
 
@@ -84,24 +83,28 @@ template <> struct convert<HostDBCache> {
   {
     Node partitions;
     for (size_t i = 0; i < hostDB->refcountcache->partition_count(); i++) {
-      auto                                 &partition = hostDB->refcountcache->get_partition(i);
-      std::vector<RefCountCacheHashEntry *> partition_entries;
+      auto                             &partition = hostDB->refcountcache->get_partition(i);
+      std::vector<HostDBRecord::Handle> partition_records;
 
       {
-        std::shared_lock<ts::shared_mutex> shared_lock{partition.lock};
-        partition_entries.reserve(partition.count());
-        partition.copy(partition_entries);
+        ts::read_guard lock{partition.lock};
+
+        partition_records.reserve(partition.count());
+        for (auto &&entry : partition.get_map()) {
+          partition_records.emplace_back(make_ptr(static_cast<HostDBRecord *>(entry.item.get())));
+        }
       }
 
-      if (partition_entries.empty()) {
+      if (partition_records.empty()) {
         continue;
       }
 
       Node partition_node;
       partition_node["id"] = i;
 
-      for (RefCountCacheHashEntry *entry : partition_entries) {
-        HostDBRecord *record = static_cast<HostDBRecord *>(entry->item.get());
+      for (auto const &record_handle : partition_records) {
+        HostDBRecord *record = record_handle.get();
+
         if (!hostname.empty() && record->name_view().find(hostname) == std::string_view::npos) {
           continue;
         }
@@ -190,10 +193,16 @@ swoc::Rv<YAML::Node>
 get_hostdb_status(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &params)
 {
   swoc::Rv<YAML::Node> resp;
+  HostDBCache         *cache = hostDBProcessor.cache();
+  if (cache->refcountcache == nullptr) {
+    resp.errata().assign(std::error_code{errors::Codes::SERVER}).note("HostDB is not initialized");
+    return resp;
+  }
+
   try {
     HostDBGetStatusCmdInfo cmd = params.as<HostDBGetStatusCmdInfo>();
 
-    YAML::Node data = YAML::convert<HostDBCache>::encode(hostDBProcessor.cache(), cmd.hostname);
+    YAML::Node data = YAML::convert<HostDBCache>::encode(cache, cmd.hostname);
 
     resp.result()["data"] = data;
   } catch (std::exception const &ex) {
@@ -201,6 +210,20 @@ get_hostdb_status(std::string_view const & /* id ATS_UNUSED */, YAML::Node const
       .assign(std::error_code{errors::Codes::SERVER})
       .note("Error found when calling get_hostdb_status API: {}", ex.what());
   }
+  return resp;
+}
+
+swoc::Rv<YAML::Node>
+clear_hostdb(std::string_view const & /* id ATS_UNUSED */, YAML::Node const & /* params ATS_UNUSED */)
+{
+  swoc::Rv<YAML::Node> resp;
+  if (hostDBProcessor.cache()->refcountcache == nullptr) {
+    resp.errata().assign(std::error_code{errors::Codes::SERVER}).note("HostDB is not initialized");
+    return resp;
+  }
+
+  hostDBProcessor.clear();
+  Note("HostDB cleared via JSONRPC");
   return resp;
 }
 } // namespace rpc::handlers::hostdb

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -927,6 +927,9 @@ HostDBCommand::HostDBCommand(ts::Arguments *args) : CtrlCommand(args)
   if (get_parsed_arguments()->get(STATUS_STR)) {
     _printer      = std::make_unique<HostDBStatusPrinter>(printOpts);
     _invoked_func = [&]() { status_get(); };
+  } else if (get_parsed_arguments()->get(CLEAR_STR)) {
+    _printer      = std::make_unique<GenericPrinter>(printOpts);
+    _invoked_func = [&]() { clear(); };
   }
 }
 
@@ -943,6 +946,16 @@ HostDBCommand::status_get()
   }
 
   HostDBGetStatusRequest request{params};
+
+  auto response = invoke_rpc(request);
+
+  _printer->write_output(response);
+}
+
+void
+HostDBCommand::clear()
+{
+  HostDBClearRequest request;
 
   auto response = invoke_rpc(request);
 

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -950,6 +950,9 @@ HostDBCommand::HostDBCommand(ts::Arguments *args) : CtrlCommand(args)
   if (get_parsed_arguments()->get(STATUS_STR)) {
     _printer      = std::make_unique<HostDBStatusPrinter>(printOpts);
     _invoked_func = [&]() { status_get(); };
+  } else if (get_parsed_arguments()->get(CLEAR_STR)) {
+    _printer      = std::make_unique<GenericPrinter>(printOpts);
+    _invoked_func = [&]() { clear(); };
   }
 }
 
@@ -966,6 +969,16 @@ HostDBCommand::status_get()
   }
 
   HostDBGetStatusRequest request{std::move(params)};
+
+  auto response = invoke_rpc(request);
+
+  _printer->write_output(response);
+}
+
+void
+HostDBCommand::clear()
+{
+  HostDBClearRequest request;
 
   auto response = invoke_rpc(request);
 

--- a/src/traffic_ctl/CtrlCommands.h
+++ b/src/traffic_ctl/CtrlCommands.h
@@ -196,8 +196,10 @@ public:
 
 private:
   static inline const std::string STATUS_STR{"status"};
+  static inline const std::string CLEAR_STR{"clear"};
 
   void status_get();
+  void clear();
 };
 // -----------------------------------------------------------------------------------------------------------------------------------
 class PluginCommand : public CtrlCommand

--- a/src/traffic_ctl/CtrlCommands.h
+++ b/src/traffic_ctl/CtrlCommands.h
@@ -210,8 +210,10 @@ public:
 
 private:
   static inline const std::string STATUS_STR{"status"};
+  static inline const std::string CLEAR_STR{"clear"};
 
   void status_get();
+  void clear();
 };
 // -----------------------------------------------------------------------------------------------------------------------------------
 class PluginCommand : public CtrlCommand

--- a/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
@@ -198,6 +198,14 @@ struct HostDBGetStatusRequest : shared::rpc::ClientRequest {
     return "get_hostdb_status";
   }
 };
+
+struct HostDBClearRequest : shared::rpc::ClientRequest {
+  std::string
+  get_method() const override
+  {
+    return "admin_hostdb_clear";
+  }
+};
 //------------------------------------------------------------------------------------------------------------------------------------
 struct GetPluginListRequest : shared::rpc::ClientRequest {
   using super = shared::rpc::ClientRequest;

--- a/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
+++ b/src/traffic_ctl/jsonrpc/CtrlRPCRequests.h
@@ -206,6 +206,14 @@ struct HostDBGetStatusRequest : shared::rpc::ClientRequest {
     return "get_hostdb_status";
   }
 };
+
+struct HostDBClearRequest : shared::rpc::ClientRequest {
+  std::string
+  get_method() const override
+  {
+    return "admin_hostdb_clear";
+  }
+};
 //------------------------------------------------------------------------------------------------------------------------------------
 struct GetPluginListRequest : shared::rpc::ClientRequest {
   using super = shared::rpc::ClientRequest;

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -259,6 +259,8 @@ main([[maybe_unused]] int argc, const char **argv)
   // hostdb commands
   hostdb_command.add_command("status", "Get HostDB info", "", MORE_THAN_ZERO_ARG_N, Command_Execute)
     .add_example_usage("traffic_ctl hostdb status");
+  hostdb_command.add_command("clear", "Clear all HostDB entries", "", 0, Command_Execute)
+    .add_example_usage("traffic_ctl hostdb clear");
 
   // plugin command
   plugin_command

--- a/src/traffic_ctl/traffic_ctl.cc
+++ b/src/traffic_ctl/traffic_ctl.cc
@@ -267,6 +267,8 @@ main([[maybe_unused]] int argc, const char **argv)
   // hostdb commands
   hostdb_command.add_command("status", "Get HostDB info", "", MORE_THAN_ZERO_ARG_N, Command_Execute)
     .add_example_usage("traffic_ctl hostdb status");
+  hostdb_command.add_command("clear", "Clear all HostDB entries", "", 0, Command_Execute)
+    .add_example_usage("traffic_ctl hostdb clear");
 
   // plugin command
   plugin_command

--- a/src/traffic_server/RpcAdminPubHandlers.cc
+++ b/src/traffic_server/RpcAdminPubHandlers.cc
@@ -46,6 +46,7 @@ register_admin_jsonrpc_handlers()
   // HostDB
   using namespace rpc::handlers::hostdb;
   rpc::add_method_handler("get_hostdb_status", &get_hostdb_status, &core_ats_rpc_service_provider_handle, {{rpc::RESTRICTED_API}});
+  rpc::add_method_handler("admin_hostdb_clear", &clear_hostdb, &core_ats_rpc_service_provider_handle, {{rpc::RESTRICTED_API}});
 
   // Records
   using namespace rpc::handlers::records;

--- a/src/traffic_server/RpcAdminPubHandlers.cc
+++ b/src/traffic_server/RpcAdminPubHandlers.cc
@@ -51,6 +51,7 @@ register_admin_jsonrpc_handlers()
   // HostDB
   using namespace rpc::handlers::hostdb;
   rpc::add_method_handler("get_hostdb_status", &get_hostdb_status, &core_ats_rpc_service_provider_handle, {{rpc::RESTRICTED_API}});
+  rpc::add_method_handler("admin_hostdb_clear", &clear_hostdb, &core_ats_rpc_service_provider_handle, {{rpc::RESTRICTED_API}});
 
   // Records
   using namespace rpc::handlers::records;

--- a/tests/gold_tests/dns/hostdb_clear.test.py
+++ b/tests/gold_tests/dns/hostdb_clear.test.py
@@ -1,0 +1,85 @@
+'''
+Verify HostDB can be cleared without restarting Traffic Server.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from ports import get_port
+
+Test.Summary = 'Verify HostDB can be cleared without restarting Traffic Server.'
+
+replay_file = 'replay/single_transaction.replay.yaml'
+hostname = 'resolve.this.com'
+
+server = Test.MakeVerifierServerProcess('server', replay_file)
+ts = Test.MakeATSProcess('ts', enable_cache=False)
+dns_port = get_port(ts, 'dns_port')
+dns = Test.MakeDNServer('dns', port=dns_port)
+dns.addRecords(records={hostname: ['127.0.0.1']})
+
+ts.Disk.records_config.update({
+    'proxy.config.dns.nameservers': f'127.0.0.1:{dns_port}',
+    'proxy.config.dns.resolv_conf': 'NULL',
+})
+ts.Disk.remap_config.AddLine(f'map / http://{hostname}:{server.Variables.http_port}/')
+
+tr = Test.AddTestRun('Populate HostDB')
+tr.AddVerifierClientProcess('client-before-clear', replay_file, http_ports=[ts.Variables.port])
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts)
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Verify HostDB is populated')
+tr.Processes.Default.Command = f'traffic_ctl hostdb status {hostname}'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(hostname, 'HostDB should contain the resolved host')
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Clear HostDB')
+tr.Processes.Default.Command = 'traffic_ctl hostdb clear'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Verify HostDB is empty')
+tr.Processes.Default.Command = f'traffic_ctl hostdb status {hostname}'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ExcludesExpression(hostname, 'HostDB should no longer contain the resolved host')
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Resolve the host again without restarting Traffic Server')
+tr.AddVerifierClientProcess('client-after-clear', replay_file, http_ports=[ts.Variables.port])
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Verify HostDB is repopulated')
+tr.Processes.Default.Command = f'traffic_ctl hostdb status {hostname}'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(hostname, 'HostDB should contain the resolved host again')
+tr.StillRunningAfter = ts

--- a/tests/gold_tests/dns/hostdb_clear.test.py
+++ b/tests/gold_tests/dns/hostdb_clear.test.py
@@ -1,0 +1,118 @@
+'''
+Verify HostDB can be cleared without restarting Traffic Server.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import re
+
+from ports import get_port
+
+Test.Summary = 'Verify HostDB can be cleared without restarting Traffic Server.'
+
+replay_file = 'replay/single_transaction.replay.yaml'
+hostname = 'resolve.this.com'
+hostdb_items_metric = 'proxy.process.hostdb.cache.current_items'
+
+server = Test.MakeVerifierServerProcess('server', replay_file)
+ts = Test.MakeATSProcess('ts', enable_cache=False)
+dns_port = get_port(ts, 'dns_port')
+dns = Test.MakeDNServer('dns', port=dns_port)
+dns.addRecords(records={hostname: ['127.0.0.1']})
+
+ts.Disk.records_config.update({
+    'proxy.config.dns.nameservers': f'127.0.0.1:{dns_port}',
+    'proxy.config.dns.resolv_conf': 'NULL',
+})
+ts.Disk.remap_config.AddLine(f'map / http://{hostname}:{server.Variables.http_port}/')
+
+tr = Test.AddTestRun('Populate HostDB')
+tr.AddVerifierClientProcess('client-before-clear', replay_file, http_ports=[ts.Variables.port])
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts)
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Verify HostDB is populated')
+tr.Processes.Default.Command = f'traffic_ctl hostdb status {hostname}'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(hostname, 'HostDB should contain the resolved host')
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Clear HostDB')
+tr.Processes.Default.Command = 'traffic_ctl hostdb clear'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Verify HostDB is empty')
+tr.Processes.Default.Command = f'traffic_ctl metric get {hostdb_items_metric}'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(
+    rf'{hostdb_items_metric} 0$', 'The HostDB current-items metric should be zero after clearing', reflags=re.MULTILINE)
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Clear HostDB while a transaction is in flight')
+tr.Processes.Default.Command = (
+    f'curl --fail --silent --show-error --output /dev/null '
+    f'--header "Host: {hostname}" --header "X-Request: request" --header "uuid: 1" '
+    f'http://127.0.0.1:{ts.Variables.port}/some/path & '
+    'client_pid=$$!; '
+    f'for attempt in $$(seq 1 100); do traffic_ctl hostdb status {hostname} | grep -q {hostname} && break; sleep 0.05; done; '
+    f'traffic_ctl hostdb status {hostname} | grep -q {hostname}; status_result=$$?; '
+    'traffic_ctl hostdb clear; clear_result=$$?; '
+    'wait "$$client_pid"; client_result=$$?; '
+    'test "$$status_result" -eq 0 -a "$$clear_result" -eq 0 -a "$$client_result" -eq 0')
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Reject arguments to HostDB clear')
+tr.Processes.Default.Command = 'traffic_ctl hostdb clear extra_arg'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 64
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Resolve the host again without restarting Traffic Server')
+tr.AddVerifierClientProcess('client-after-clear', replay_file, http_ports=[ts.Variables.port])
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+tr = Test.AddTestRun('Verify HostDB is repopulated')
+tr.Processes.Default.Command = f'traffic_ctl hostdb status {hostname}'
+tr.Processes.Default.Env = ts.Env
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.All = Testers.ContainsExpression(hostname, 'HostDB should contain the resolved host again')
+tr.StillRunningAfter = dns
+tr.StillRunningAfter = server
+tr.StillRunningAfter = ts
+
+ts.Disk.diags_log.Content += Testers.ContainsExpression('HostDB cleared via JSONRPC', 'HostDB clears should be logged')

--- a/tests/gold_tests/dns/replay/single_transaction.replay.yaml
+++ b/tests/gold_tests/dns/replay/single_transaction.replay.yaml
@@ -35,6 +35,7 @@ sessions:
         - [ X-Request, { value: request, as: equal } ]
 
     server-response:
+      delay: 3s
       status: 200
       reason: OK
       headers:


### PR DESCRIPTION
Operators cannot discard stale HostDB entries without restarting Traffic
Server. A restart interrupts service and delays recovery from incorrect
DNS data.

This adds a traffic_ctl command and restricted JSON-RPC method to clear
HostDB safely under partition locks while preserving in-flight records.
This also uses scoped status snapshots and verifies clearing and
repopulation without a restart.

Fixes: #9022