### PR TITLE
Add APIs to set a firewall mark with a mask

### DIFF
--- a/doc/developer-guide/api/functions/TSHttpTxnClientPacketMarkSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnClientPacketMarkSet.en.rst
@@ -28,13 +28,25 @@ Synopsis
     #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark)
+.. function:: TSReturnCode TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark, int mask)
 
 Description
 ===========
 
 Change the packet firewall :arg:`mark` for the client side connection. The
-entire firewall mark is replaced with :arg:`mark`, which is interpreted as a
-32-bit unsigned bit pattern.
+two-argument overload replaces the entire firewall mark with :arg:`mark`, which
+is interpreted as a 32-bit unsigned bit pattern.
+
+The three-argument overload changes only the bits selected by :arg:`mask`: bits
+set in :arg:`mask` are taken from the corresponding bits of :arg:`mark`, and bits
+clear in :arg:`mask` retain their previous value. Equivalently, the resulting
+mark is::
+
+    result = (current_mark & ~mask) | (mark & mask);
+
+Both :arg:`mark` and :arg:`mask` are interpreted as 32-bit unsigned bit patterns.
+A :arg:`mask` of ``0xFFFFFFFF`` replaces the entire mark and is equivalent to the
+two-argument overload; a :arg:`mask` of ``0`` leaves the mark unchanged.
 
 Returns :const:`TS_SUCCESS` when the client connection was modified, and
 :const:`TS_ERROR` when there is no client connection to modify.

--- a/doc/developer-guide/api/functions/TSHttpTxnServerPacketMarkSet.en.rst
+++ b/doc/developer-guide/api/functions/TSHttpTxnServerPacketMarkSet.en.rst
@@ -28,13 +28,27 @@ Synopsis
     #include <ts/ts.h>
 
 .. function:: TSReturnCode TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark)
+.. function:: TSReturnCode TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark, int mask)
 
 Description
 ===========
 
 Change the packet firewall :arg:`mark` for the server side (origin) connection.
-The entire firewall mark is replaced with :arg:`mark`, which is interpreted as a
-32-bit unsigned bit pattern.
+The two-argument overload replaces the entire firewall mark with :arg:`mark`, which
+is interpreted as a 32-bit unsigned bit pattern.
+
+The three-argument overload changes only the bits selected by :arg:`mask`: bits
+set in :arg:`mask` are taken from the corresponding bits of :arg:`mark`, and bits
+clear in :arg:`mask` retain their previous value. Equivalently, the resulting
+mark is::
+
+    result = (current_mark & ~mask) | (mark & mask);
+
+Both :arg:`mark` and :arg:`mask` are interpreted as 32-bit unsigned bit patterns.
+A :arg:`mask` of ``0xFFFFFFFF`` replaces the entire mark and is equivalent to the
+two-argument overload; a :arg:`mask` of ``0`` leaves the mark unchanged. The
+current mark in this formula is taken from the transaction's recorded config value,
+not from socket state.
 
 Always returns :const:`TS_SUCCESS`, including when no server connection has been
 established yet.

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1643,6 +1643,32 @@ TSReturnCode TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark, int mask);
 */
 TSReturnCode TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark);
 
+/** Change selected bits of the packet firewall mark for the server side connection
+
+    Only the bits selected by @a mask are modified. Bits set in @a mask are updated from the
+    corresponding bits of @a mark; bits clear in @a mask retain their previous value. Equivalently,
+    the resulting mark is computed as:
+
+    @code
+    result = (current_mark & ~mask) | (mark & mask);
+    @endcode
+
+    @a mark and @a mask are interpreted as 32-bit unsigned bit patterns. A @a mask of 0xFFFFFFFF
+    replaces the entire mark and is equivalent to the two-argument overload. A @a mask of 0 leaves
+    the mark unchanged. The current mark in this formula is the value recorded on @a txnp, not
+    socket state.
+
+    @note The firewall mark is only honored on platforms whose OS supports it, specifically Linux via
+    @c SO_MARK. On platforms without @c SO_MARK support the call still returns TS_SUCCESS, but setting
+    the mark has no effect at the OS layer (it is a safe no-op).
+
+    @note If a live server connection exists, the mark is applied to it immediately; the mark is also
+    recorded on the transaction so that any subsequent server connection for this transaction uses it.
+
+    @return TS_SUCCESS always, including when no server connection has been established yet.
+*/
+TSReturnCode TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark, int mask);
+
 /** Change packet DSCP for the client side connection
  *
     @note The change takes effect immediately

--- a/include/ts/ts.h
+++ b/include/ts/ts.h
@@ -1601,6 +1601,32 @@ TSReturnCode           TSHttpSsnClientFdGet(TSHttpSsn ssnp, int *fdp);
 */
 TSReturnCode TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark);
 
+/** Change selected bits of the packet firewall mark for the client side connection
+
+    Only the bits selected by @a mask are modified. Bits set in @a mask are updated from the
+    corresponding bits of @a mark; bits clear in @a mask retain their previous value. Equivalently,
+    the resulting mark is computed as:
+
+    @code
+    result = (current_mark & ~mask) | (mark & mask);
+    @endcode
+
+    @a mark and @a mask are interpreted as 32-bit unsigned bit patterns. A @a mask of 0xFFFFFFFF
+    replaces the entire mark and is equivalent to the two-argument overload. A @a mask of 0 leaves
+    the mark unchanged.
+
+    @note The firewall mark is only honored on platforms whose OS supports it, specifically Linux via
+    @c SO_MARK. On platforms without @c SO_MARK support the call still returns TS_SUCCESS when a
+    client connection is present, but setting the mark has no effect at the OS layer (it is a safe
+    no-op).
+
+    @note The change takes effect immediately on the live client connection
+
+    @return TS_SUCCESS if the client connection was modified, TS_ERROR if there is no client
+    connection to modify
+*/
+TSReturnCode TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark, int mask);
+
 /** Change packet firewall mark for the server side connection
 
     Sets the entire server-side packet firewall mark to @a mark; the whole mark is replaced. @a mark

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -4942,6 +4942,21 @@ TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark)
 }
 
 TSReturnCode
+TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark, int mask)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+
+  // The current mark lives on the transaction config so the masked update composes
+  // correctly even before an origin connection exists.
+  TSMgmtInt current = 0;
+  TSHttpTxnConfigIntGet(txnp, TS_CONFIG_NET_SOCK_PACKET_MARK_OUT, &current);
+  uint32_t new_mark =
+    (static_cast<uint32_t>(current) & ~static_cast<uint32_t>(mask)) | (static_cast<uint32_t>(mark) & static_cast<uint32_t>(mask));
+
+  return TSHttpTxnServerPacketMarkSet(txnp, static_cast<int>(new_mark));
+}
+
+TSReturnCode
 TSHttpTxnClientPacketDscpSet(TSHttpTxn txnp, int dscp)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -4901,6 +4901,26 @@ TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark)
 }
 
 TSReturnCode
+TSHttpTxnClientPacketMarkSet(TSHttpTxn txnp, int mark, int mask)
+{
+  sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);
+  HttpSM *sm = reinterpret_cast<HttpSM *>(txnp);
+  if (nullptr == sm->get_ua_txn()) {
+    return TS_ERROR;
+  }
+
+  NetVConnection *vc = sm->get_ua_txn()->get_netvc();
+  if (nullptr == vc) {
+    return TS_ERROR;
+  }
+
+  vc->options.packet_mark =
+    (vc->options.packet_mark & ~static_cast<uint32_t>(mask)) | (static_cast<uint32_t>(mark) & static_cast<uint32_t>(mask));
+  vc->apply_options();
+  return TS_SUCCESS;
+}
+
+TSReturnCode
 TSHttpTxnServerPacketMarkSet(TSHttpTxn txnp, int mark)
 {
   sdk_assert(sdk_sanity_check_txn(txnp) == TS_SUCCESS);

--- a/tests/gold_tests/pluginTest/packet_mark/packet_mark.test.py
+++ b/tests/gold_tests/pluginTest/packet_mark/packet_mark.test.py
@@ -59,10 +59,14 @@ class PacketMarkTest:
     """Drive a TSHttpTxn*PacketMarkSet API through a test plugin and assert on the
     firewall mark read back off the relevant socket.
 
-    This base holds the shared skeleton -- process setup, the common records, the
-    curl-and-assert case runner. Each subclass supplies its plugin and echo
-    header and extends _configure() (via super()) with the side-specific mark and
-    flag records.
+    This base holds the shared skeleton -- per-run process setup, the common
+    records, and the curl-and-assert case runners. Each subclass supplies its
+    plugin and echo header and extends _configure() (via super()) with the
+    side-specific mark and flag records.
+
+    Every test run gets its own freshly-started origin server and ATS instance,
+    each serving exactly one request. Runs are therefore fully isolated: process
+    teardown or a crash in one run cannot disturb any other run.
     """
 
     # Value the plugin sets; the mark is expected to become exactly this.
@@ -70,29 +74,31 @@ class PacketMarkTest:
     # Seeded starting mark, distinct from SET_MARK so a no-op would be visible.
     SEED_MARK = 0x0000FF00
 
-    # Bumped per instance so each side gets uniquely-numbered processes.
+    # Bumped per created process so each run gets uniquely-numbered processes.
     _counter = 0
 
-    def __init__(self):
-        self._num = PacketMarkTest._counter
-        PacketMarkTest._counter += 1
-        self._server = self._make_server()
-        self._ts = self._make_ats()
-        self._configure(self._ts)
-        self._started = False
+    def __init__(self, seed_mark: int = None):
+        # Instance-level override of the seeded starting mark; falls back to the
+        # class default. Lets a masked case start from a distinct value (e.g. 0)
+        # without disturbing the other runs.
+        if seed_mark is not None:
+            self.SEED_MARK = seed_mark
 
-    def _make_server(self):
-        server = Test.MakeOriginServer(f"server{self._num}")
+    def _make_instance(self):
+        # Build a fresh origin server and ATS process for a single test run. Each
+        # run owns its processes and serves exactly one request, so runs are fully
+        # isolated from one another.
+        num = PacketMarkTest._counter
+        PacketMarkTest._counter += 1
+        server = Test.MakeOriginServer(f"server{num}")
         request_header = {"headers": "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
         response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
-        for _ in range(2):
-            server.addResponse("sessionlog.json", request_header, response_header)
-        return server
+        server.addResponse("sessionlog.json", request_header, response_header)
+        ts = Test.MakeATSProcess(f"ts{num}", enable_cache=False)
+        self._configure(ts, server)
+        return server, ts
 
-    def _make_ats(self):
-        return Test.MakeATSProcess(f"ts{self._num}", enable_cache=False)
-
-    def _configure(self, ts):
+    def _configure(self, ts, server):
         # Records and remap shared by both sides. Subclasses override to add the
         # side-specific mark/flag records and load their plugin, calling super()
         # for these.
@@ -102,27 +108,44 @@ class PacketMarkTest:
                 # Keep ATS running as the invoking user inside sudo (no privilege drop).
                 'proxy.config.admin.user_id': '#-1',
             })
-        ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{self._server.Variables.Port}")
+        ts.Disk.remap_config.AddLine(f"map / http://127.0.0.1:{server.Variables.Port}")
 
     def _add_case(self, echo_header: str, description: str, set_header: str):
-        # The mark is set to the supplied value, regardless of the seeded
-        # starting mark. The set is driven by whichever request header the plugin
-        # keys on; the observed mark is echoed into echo_header. The origin server
-        # and ATS are started before the first case, independent of the order in
-        # which cases are added.
+        # The mark is set to the supplied value, regardless of the seeded starting
+        # mark. The set is driven by whichever request header the plugin keys on;
+        # the observed mark is echoed into echo_header. This case runs against its
+        # own freshly-started origin server and ATS instance.
+        server, ts = self._make_instance()
         tr = Test.AddTestRun(description)
-        tr.Processes.Default.StartBefore(self._server)
-        tr.Processes.Default.StartBefore(self._ts)
-        if not self._started:
-            tr.StillRunningAfter = self._server
-            tr.StillRunningAfter = self._ts
-            self._started = True
+        tr.Processes.Default.StartBefore(server)
+        tr.Processes.Default.StartBefore(ts)
         tr.MakeCurlCommand(
-            f'--verbose --ipv4 --header "{set_header}: 0x{self.SET_MARK:08x}" http://localhost:{self._ts.Variables.port}/',
-            ts=self._ts)
+            f'--verbose --ipv4 --header "{set_header}: 0x{self.SET_MARK:08x}" http://localhost:{ts.Variables.port}/', ts=ts)
         tr.Processes.Default.ReturnCode = 0
         tr.Processes.Default.Streams.All += Testers.ContainsExpression(
             f"{echo_header}: 0x{self.SET_MARK:08x}", f"Observed packet mark should be 0x{self.SET_MARK:08x}")
+        tr.StillRunningAfter = server
+        tr.StillRunningAfter = ts
+
+    def _add_masked_case(self, echo_header: str, description: str, mark: int, mask: int, expected: int):
+        # Drives the three-argument (masked) overload: only the bits selected by
+        # `mask` are taken from `mark`; the rest retain the seeded starting mark.
+        # `expected` is the full value the mark should read back as. The set is
+        # keyed on X-Set-Mark + X-Set-Mask; the observed mark is echoed into
+        # echo_header. This case runs against its own freshly-started instance.
+        server, ts = self._make_instance()
+        tr = Test.AddTestRun(description)
+        tr.Processes.Default.StartBefore(server)
+        tr.Processes.Default.StartBefore(ts)
+        tr.MakeCurlCommand(
+            f'--verbose --ipv4 --header "X-Set-Mark: 0x{mark:08x}" --header "X-Set-Mask: 0x{mask:08x}" '
+            f'http://localhost:{ts.Variables.port}/',
+            ts=ts)
+        tr.Processes.Default.ReturnCode = 0
+        tr.Processes.Default.Streams.All += Testers.ContainsExpression(
+            f"{echo_header}: 0x{expected:08x}", f"Observed packet mark should be 0x{expected:08x}")
+        tr.StillRunningAfter = server
+        tr.StillRunningAfter = ts
 
 
 class ClientPacketMarkTest(PacketMarkTest):
@@ -132,8 +155,43 @@ class ClientPacketMarkTest(PacketMarkTest):
 
     ECHO_HEADER = "X-Client-Packet-Mark"
 
-    def _configure(self, ts):
-        super()._configure(ts)
+    def _configure(self, ts, server):
+        super()._configure(ts, server)
+        ts.Disk.records_config.update(
+            {
+                'proxy.config.net.sock_packet_mark_in': self.SEED_MARK,
+                'proxy.config.net.sock_option_flag_in': SOCK_OPT_FLAG_PACKET_MARK,
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|client_packet_mark|plugin',
+            })
+        Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, f'client_packet_mark.so'), ts)
+
+    def run(self):
+        self._add_case(self.ECHO_HEADER, "client_packet_mark sets the client-side mark on the live connection", "X-Set-Mark")
+        # Masked overload: only the bits selected by the mask change; the rest keep
+        # the seeded starting mark (SEED_MARK = 0x0000FF00).
+        self._add_masked_case(
+            self.ECHO_HEADER, "client_packet_mark masked set updates only selected bits", 0x0000000A, 0x0000000F, 0x0000FF0A)
+        self._add_masked_case(
+            self.ECHO_HEADER, "client_packet_mark masked set with all-bits mask replaces the whole mark", self.SET_MARK, 0xFFFFFFFF,
+            self.SET_MARK)
+        self._add_masked_case(
+            self.ECHO_HEADER, "client_packet_mark masked set with no-bits mask leaves the mark unchanged", self.SET_MARK,
+            0x00000000, self.SEED_MARK)
+
+
+class ClientPacketMarkZeroSeedTest(PacketMarkTest):
+    """Exercise the masked overload from a zero starting mark, so the selected bits
+    are the only bits set afterward.
+    """
+
+    ECHO_HEADER = "X-Client-Packet-Mark"
+
+    def __init__(self):
+        super().__init__(seed_mark=0x00000000)
+
+    def _configure(self, ts, server):
+        super()._configure(ts, server)
         ts.Disk.records_config.update(
             {
                 'proxy.config.net.sock_packet_mark_in': self.SEED_MARK,
@@ -144,7 +202,9 @@ class ClientPacketMarkTest(PacketMarkTest):
         Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, f'client_packet_mark.so'), ts)
 
     def run(self):
-        self._add_case(self.ECHO_HEADER, "client_packet_mark sets the client-side mark on the live connection", "X-Set-Mark")
+        self._add_masked_case(
+            self.ECHO_HEADER, "client_packet_mark masked set from a zero starting mark sets only the selected bits", 0x0000000A,
+            0x0000000F, 0x0000000A)
 
 
 class ServerPacketMarkTest(PacketMarkTest):
@@ -160,8 +220,8 @@ class ServerPacketMarkTest(PacketMarkTest):
 
     ECHO_HEADER = "X-Server-Packet-Mark"
 
-    def _configure(self, ts):
-        super()._configure(ts)
+    def _configure(self, ts, server):
+        super()._configure(ts, server)
         ts.Disk.records_config.update(
             {
                 'proxy.config.net.sock_packet_mark_out': self.SEED_MARK,
@@ -178,4 +238,5 @@ class ServerPacketMarkTest(PacketMarkTest):
 
 
 ClientPacketMarkTest().run()
+ClientPacketMarkZeroSeedTest().run()
 ServerPacketMarkTest().run()

--- a/tests/gold_tests/pluginTest/packet_mark/packet_mark.test.py
+++ b/tests/gold_tests/pluginTest/packet_mark/packet_mark.test.py
@@ -235,8 +235,46 @@ class ServerPacketMarkTest(PacketMarkTest):
         self._add_case(self.ECHO_HEADER, "server_packet_mark sets the server-side mark on the live connection", "X-Set-Mark")
         self._add_case(
             self.ECHO_HEADER, "server_packet_mark seeds the mark for a future origin connection", "X-Set-Mark-Preconnect")
+        # Masked overload: only the bits selected by the mask change; the rest keep
+        # the seeded starting mark (SEED_MARK = 0x0000FF00).
+        self._add_masked_case(
+            self.ECHO_HEADER, "server_packet_mark masked set updates only selected bits", 0x0000000A, 0x0000000F, 0x0000FF0A)
+        self._add_masked_case(
+            self.ECHO_HEADER, "server_packet_mark masked set with all-bits mask replaces the whole mark", self.SET_MARK, 0xFFFFFFFF,
+            self.SET_MARK)
+        self._add_masked_case(
+            self.ECHO_HEADER, "server_packet_mark masked set with no-bits mask leaves the mark unchanged", self.SET_MARK,
+            0x00000000, self.SEED_MARK)
+
+
+class ServerPacketMarkZeroSeedTest(PacketMarkTest):
+    """Exercise the server masked overload from a zero starting mark, so the
+    selected bits are the only bits set afterward.
+    """
+
+    ECHO_HEADER = "X-Server-Packet-Mark"
+
+    def __init__(self):
+        super().__init__(seed_mark=0x00000000)
+
+    def _configure(self, ts, server):
+        super()._configure(ts, server)
+        ts.Disk.records_config.update(
+            {
+                'proxy.config.net.sock_packet_mark_out': self.SEED_MARK,
+                'proxy.config.net.sock_option_flag_out': SOCK_OPT_FLAG_PACKET_MARK,
+                'proxy.config.diags.debug.enabled': 1,
+                'proxy.config.diags.debug.tags': 'http|server_packet_mark',
+            })
+        Test.PrepareTestPlugin(os.path.join(Test.Variables.AtsTestPluginsDir, f'server_packet_mark.so'), ts)
+
+    def run(self):
+        self._add_masked_case(
+            self.ECHO_HEADER, "server_packet_mark masked set from a zero starting mark sets only the selected bits", 0x0000000A,
+            0x0000000F, 0x0000000A)
 
 
 ClientPacketMarkTest().run()
 ClientPacketMarkZeroSeedTest().run()
 ServerPacketMarkTest().run()
+ServerPacketMarkZeroSeedTest().run()

--- a/tests/tools/plugins/client_packet_mark.cc
+++ b/tests/tools/plugins/client_packet_mark.cc
@@ -37,6 +37,7 @@ namespace
 {
 constexpr char PLUGIN_NAME[] = "client_packet_mark";
 constexpr char MARK_HEADER[] = "X-Set-Mark";
+constexpr char MASK_HEADER[] = "X-Set-Mask";
 constexpr char ECHO_HEADER[] = "X-Client-Packet-Mark";
 
 DbgCtl dbg_ctl{PLUGIN_NAME};
@@ -50,7 +51,13 @@ handle_send_response(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
     // The client connection is live here; this applies the mark to it and reads
     // it back off the client socket.
     packet_mark::LogContext log{PLUGIN_NAME, dbg_ctl};
-    packet_mark::apply_client_mark(log, txnp, MARK_HEADER);
+    // Prefer the masked (three-argument) overload when a mask header is present;
+    // otherwise fall back to the whole-mark (two-argument) overload. Only one of
+    // them runs, so the masked read-modify-write is not clobbered by a preceding
+    // whole-mark set.
+    if (!packet_mark::apply_client_mark_masked(log, txnp, MARK_HEADER, MASK_HEADER)) {
+      packet_mark::apply_client_mark(log, txnp, MARK_HEADER);
+    }
     packet_mark::echo_client_mark(log, txnp, ECHO_HEADER);
   }
 

--- a/tests/tools/plugins/packet_mark_common.cc
+++ b/tests/tools/plugins/packet_mark_common.cc
@@ -147,8 +147,8 @@ namespace
 
   // Masked variant: reads both a mark and a mask header and calls the
   // three-argument overload so only the selected bits change. Parameterized on the
-  // masked setter for symmetry with apply_mark_from_header, though only the client
-  // side has a masked overload today.
+  // masked setter for symmetry with apply_mark_from_header; both the client and
+  // server sides have a masked overload.
   template <MaskedMarkSetter MaskedSetter>
   bool
   apply_masked_mark_from_header(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header)
@@ -230,6 +230,22 @@ void
 apply_server_mark(const LogContext &log, TSHttpTxn txnp, std::string_view header)
 {
   apply_mark_from_header<TSHttpTxnServerPacketMarkSet>(log, txnp, header);
+}
+
+namespace
+{
+  // Wrapper to explicitly select the three-argument overload of TSHttpTxnServerPacketMarkSet
+  TSReturnCode
+  server_mark_setter_masked(TSHttpTxn txnp, int mark, int mask)
+  {
+    return TSHttpTxnServerPacketMarkSet(txnp, mark, mask);
+  }
+} // anonymous namespace
+
+bool
+apply_server_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header)
+{
+  return apply_masked_mark_from_header<server_mark_setter_masked>(log, txnp, mark_header, mask_header);
 }
 
 void

--- a/tests/tools/plugins/packet_mark_common.cc
+++ b/tests/tools/plugins/packet_mark_common.cc
@@ -43,9 +43,10 @@ namespace
   // function-pointer types, not std::function: a non-type template parameter has
   // to be a structural type, and std::function is a runtime type-erasure wrapper,
   // so template <std::function<...> Setter> is ill-formed.
-  using MarkSetter = TSReturnCode (*)(TSHttpTxn, int);
-  using FdGetter   = TSReturnCode (*)(TSHttpTxn, int *);
-  using RespGetter = TSReturnCode (*)(TSHttpTxn, TSMBuffer *, TSMLoc *);
+  using MarkSetter       = TSReturnCode (*)(TSHttpTxn, int);
+  using MaskedMarkSetter = TSReturnCode (*)(TSHttpTxn, int, int);
+  using FdGetter         = TSReturnCode (*)(TSHttpTxn, int *);
+  using RespGetter       = TSReturnCode (*)(TSHttpTxn, TSMBuffer *, TSMLoc *);
 
   std::optional<uint32_t>
   get_uint_header(TSMBuffer bufp, TSMLoc hdr_loc, std::string_view header)
@@ -144,6 +145,37 @@ namespace
     }
   }
 
+  // Masked variant: reads both a mark and a mask header and calls the
+  // three-argument overload so only the selected bits change. Parameterized on the
+  // masked setter for symmetry with apply_mark_from_header, though only the client
+  // side has a masked overload today.
+  template <MaskedMarkSetter MaskedSetter>
+  bool
+  apply_masked_mark_from_header(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header)
+  {
+    TSMBuffer req_bufp{nullptr};
+    TSMLoc    req_loc{TS_NULL_MLOC};
+    if (TSHttpTxnClientReqGet(txnp, &req_bufp, &req_loc) != TS_SUCCESS) {
+      TSError("[%.*s] Failed to get client request headers", static_cast<int>(log.plugin_name.length()), log.plugin_name.data());
+      return false;
+    }
+
+    std::optional<uint32_t> const mark{get_uint_header(req_bufp, req_loc, mark_header)};
+    std::optional<uint32_t> const mask{get_uint_header(req_bufp, req_loc, mask_header)};
+    TSHandleMLocRelease(req_bufp, TS_NULL_MLOC, req_loc);
+
+    if (!mark.has_value() || !mask.has_value()) {
+      return false;
+    }
+
+    Dbg(log.dbg_ctl, "Setting packet mark to 0x%08x mask 0x%08x", *mark, *mask);
+    if (MaskedSetter(txnp, static_cast<int>(*mark), static_cast<int>(*mask)) != TS_SUCCESS) {
+      TSError("[%.*s] Failed to set packet mark 0x%08x mask 0x%08x", static_cast<int>(log.plugin_name.length()),
+              log.plugin_name.data(), *mark, *mask);
+    }
+    return true;
+  }
+
   template <FdGetter FdGet, RespGetter RespGet>
   void
   echo_observed_mark(const LogContext &log, TSHttpTxn txnp, std::string_view echo_header)
@@ -176,6 +208,22 @@ void
 apply_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view header)
 {
   apply_mark_from_header<TSHttpTxnClientPacketMarkSet>(log, txnp, header);
+}
+
+namespace
+{
+  // Wrapper to explicitly select the three-argument overload of TSHttpTxnClientPacketMarkSet
+  TSReturnCode
+  client_mark_setter_masked(TSHttpTxn txnp, int mark, int mask)
+  {
+    return TSHttpTxnClientPacketMarkSet(txnp, mark, mask);
+  }
+} // anonymous namespace
+
+bool
+apply_client_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header)
+{
+  return apply_masked_mark_from_header<client_mark_setter_masked>(log, txnp, mark_header, mask_header);
 }
 
 void

--- a/tests/tools/plugins/packet_mark_common.h
+++ b/tests/tools/plugins/packet_mark_common.h
@@ -44,17 +44,8 @@ void apply_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view h
 
 void apply_server_mark(const LogContext &log, TSHttpTxn txnp, std::string_view header);
 
-// Masked client variant: sets only the bits selected by @a mask_header using the
-// three-argument TSHttpTxnClientPacketMarkSet overload. Kept separate from
-// apply_client_mark so the existing whole-mark path is unchanged. Returns true when
-// a masked set was performed (both headers present), so the caller can skip the
-// whole-mark path and avoid clobbering the value the masked read-modify-write is
-// supposed to preserve.
 bool apply_client_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header);
 
-// Masked server variant: the server-side mirror of apply_client_mark_masked, using
-// the three-argument TSHttpTxnServerPacketMarkSet overload. Same true/false
-// contract so the caller can skip the whole-mark path when a masked set ran.
 bool apply_server_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header);
 
 void echo_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view echo_header);

--- a/tests/tools/plugins/packet_mark_common.h
+++ b/tests/tools/plugins/packet_mark_common.h
@@ -45,12 +45,17 @@ void apply_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view h
 void apply_server_mark(const LogContext &log, TSHttpTxn txnp, std::string_view header);
 
 // Masked client variant: sets only the bits selected by @a mask_header using the
-// three-argument TSHttpTxnClientPacketMarkSet overload. Client-only, matching the
-// tsapi. Kept separate from apply_client_mark so the existing whole-mark path is
-// unchanged. Returns true when a masked set was performed (both headers present),
-// so the caller can skip the whole-mark path and avoid clobbering the value the
-// masked read-modify-write is supposed to preserve.
+// three-argument TSHttpTxnClientPacketMarkSet overload. Kept separate from
+// apply_client_mark so the existing whole-mark path is unchanged. Returns true when
+// a masked set was performed (both headers present), so the caller can skip the
+// whole-mark path and avoid clobbering the value the masked read-modify-write is
+// supposed to preserve.
 bool apply_client_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header);
+
+// Masked server variant: the server-side mirror of apply_client_mark_masked, using
+// the three-argument TSHttpTxnServerPacketMarkSet overload. Same true/false
+// contract so the caller can skip the whole-mark path when a masked set ran.
+bool apply_server_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header);
 
 void echo_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view echo_header);
 

--- a/tests/tools/plugins/packet_mark_common.h
+++ b/tests/tools/plugins/packet_mark_common.h
@@ -44,6 +44,14 @@ void apply_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view h
 
 void apply_server_mark(const LogContext &log, TSHttpTxn txnp, std::string_view header);
 
+// Masked client variant: sets only the bits selected by @a mask_header using the
+// three-argument TSHttpTxnClientPacketMarkSet overload. Client-only, matching the
+// tsapi. Kept separate from apply_client_mark so the existing whole-mark path is
+// unchanged. Returns true when a masked set was performed (both headers present),
+// so the caller can skip the whole-mark path and avoid clobbering the value the
+// masked read-modify-write is supposed to preserve.
+bool apply_client_mark_masked(const LogContext &log, TSHttpTxn txnp, std::string_view mark_header, std::string_view mask_header);
+
 void echo_client_mark(const LogContext &log, TSHttpTxn txnp, std::string_view echo_header);
 
 void echo_server_mark(const LogContext &log, TSHttpTxn txnp, std::string_view echo_header);

--- a/tests/tools/plugins/server_packet_mark.cc
+++ b/tests/tools/plugins/server_packet_mark.cc
@@ -15,6 +15,10 @@
       apply to at that point, so the mark reaches the socket only via the
       transaction config seed.
 
+  When X-Set-Mask accompanies either mark header, the three-argument (masked)
+  overload runs instead of the whole-mark overload, updating only the selected
+  bits via a read-modify-write of the recorded transaction mark.
+
   Regardless of which header drove the set, the readback happens at
   TS_HTTP_READ_RESPONSE_HDR_HOOK: the origin fd is valid there and the server
   response headers -- which propagate to the client response -- carry the
@@ -49,6 +53,7 @@ namespace
 {
 constexpr char PLUGIN_NAME[]            = "server_packet_mark";
 constexpr char MARK_HEADER[]            = "X-Set-Mark";
+constexpr char MASK_HEADER[]            = "X-Set-Mask";
 constexpr char PRECONNECT_MARK_HEADER[] = "X-Set-Mark-Preconnect";
 constexpr char ECHO_HEADER[]            = "X-Server-Packet-Mark";
 
@@ -61,9 +66,12 @@ handle_read_request(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
 
   if (event == TS_EVENT_HTTP_READ_REQUEST_HDR) {
     // No origin connection exists yet; this exercises the "seed the mark for a
-    // future server connection" half of the contract.
+    // future server connection" half of the contract. The masked overload composes
+    // against the recorded transaction config here, with no live vc to apply to.
     packet_mark::LogContext log{PLUGIN_NAME, dbg_ctl};
-    packet_mark::apply_server_mark(log, txnp, PRECONNECT_MARK_HEADER);
+    if (!packet_mark::apply_server_mark_masked(log, txnp, PRECONNECT_MARK_HEADER, MASK_HEADER)) {
+      packet_mark::apply_server_mark(log, txnp, PRECONNECT_MARK_HEADER);
+    }
   }
 
   TSHttpTxnReenable(txnp, TS_EVENT_HTTP_CONTINUE);
@@ -79,7 +87,13 @@ handle_read_response(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
     // The origin connection is live here; this applies the mark to it and reads
     // it back off the server socket.
     packet_mark::LogContext log{PLUGIN_NAME, dbg_ctl};
-    packet_mark::apply_server_mark(log, txnp, MARK_HEADER);
+    // Prefer the masked (three-argument) overload when a mask header is present;
+    // otherwise fall back to the whole-mark (two-argument) overload. Only one of
+    // them runs, so the masked read-modify-write is not clobbered by a preceding
+    // whole-mark set.
+    if (!packet_mark::apply_server_mark_masked(log, txnp, MARK_HEADER, MASK_HEADER)) {
+      packet_mark::apply_server_mark(log, txnp, MARK_HEADER);
+    }
     packet_mark::echo_server_mark(log, txnp, ECHO_HEADER);
   }
 


### PR DESCRIPTION
This adds two new overloads to the existing firewall mark APIs, per the proposal I sent to the dev mailing list:

- `TSHttpTxnClientPacketMarkSet(TsHttpTxn, int, int)`
- `TSHttpTxnServerPacketMarkSet(TsHttpTxn, int, int)`