### PR TITLE
9.2.x: INKVConnInternal::do_io_*: handle null buffer

### DIFF
--- a/src/traffic_server/InkAPI.cc
+++ b/src/traffic_server/InkAPI.cc
@@ -1197,17 +1197,21 @@ INKVConnInternal::destroy()
 VIO *
 INKVConnInternal::do_io_read(Continuation *c, int64_t nbytes, MIOBuffer *buf)
 {
-  m_read_vio.buffer.writer_for(buf);
   m_read_vio.op = VIO::READ;
   m_read_vio.set_continuation(c);
   m_read_vio.nbytes    = nbytes;
   m_read_vio.ndone     = 0;
   m_read_vio.vc_server = this;
 
-  if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
-    ink_assert(!"not reached");
+  if (buf) {
+    m_read_vio.buffer.writer_for(buf);
+    if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
+      ink_assert(!"not reached");
+    }
+    eventProcessor.schedule_imm(this, ET_NET);
+  } else {
+    m_read_vio.buffer.clear();
   }
-  eventProcessor.schedule_imm(this, ET_NET);
 
   return &m_read_vio;
 }
@@ -1216,18 +1220,22 @@ VIO *
 INKVConnInternal::do_io_write(Continuation *c, int64_t nbytes, IOBufferReader *buf, bool owner)
 {
   ink_assert(!owner);
-  m_write_vio.buffer.reader_for(buf);
   m_write_vio.op = VIO::WRITE;
   m_write_vio.set_continuation(c);
   m_write_vio.nbytes    = nbytes;
   m_write_vio.ndone     = 0;
   m_write_vio.vc_server = this;
 
-  if (m_write_vio.buffer.reader()->read_avail() > 0) {
-    if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
-      ink_assert(!"not reached");
+  if (buf) {
+    m_write_vio.buffer.reader_for(buf);
+    if (m_write_vio.buffer.reader()->read_avail() > 0) {
+      if (ink_atomic_increment((int *)&m_event_count, 1) < 0) {
+        ink_assert(!"not reached");
+      }
+      eventProcessor.schedule_imm(this, ET_NET);
     }
-    eventProcessor.schedule_imm(this, ET_NET);
+  } else {
+    m_write_vio.buffer.clear();
   }
 
   return &m_write_vio;


### PR DESCRIPTION
It's common for users of VC's to cancel io via a 0 byte, nullptr read or
write on the VC. INKVConnInternal::do_io_read and
INKVConnInternal::do_io_write were not prepared to handle such
cancellations. This updates them to handle this gracefully rather than
crashing on a nullptr dereference. This change is was found to be needed
for the multiplexer plugin for handling HttpTunnel aborts.

For reference, see, for example, UnixNetVConnection::do_io_read which
handles a nullptr MIOBuffer. This basically copies that logic into
INKVConnInternal so it handles cancellation gracefully.

(cherry picked from commit 7afd9e3dc81229f15d6e9ed1abbb06fc5788182a)
