### PR TITLE
CMake: use new policies for Highway

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,6 +654,9 @@ else()
       CACHE INTERNAL "GENERAL_NAME lives in the bssl namespace" FORCE
   )
 endif()
+# Prevent unrelated feature probes from inheriting the OpenSSL dependencies.
+list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 set(CMAKE_EXTRA_INCLUDE_FILES netinet/in.h netinet/tcp.h)
 check_type_size("struct tcp_info" STRUCT_TCP_INFO)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -111,6 +111,8 @@ if(NOT EXTERNAL_HWY)
       OFF
       CACHE BOOL "Enable HWY tests" FORCE
   )
+  set(CMAKE_POLICY_DEFAULT_CMP0075 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
   add_subdirectory(highway)
   add_library(hwy::hwy ALIAS hwy)
   add_library(hwy::hwy_contrib ALIAS hwy_contrib)

--- a/lib/highway/CMakeLists.txt
+++ b/lib/highway/CMakeLists.txt
@@ -22,10 +22,9 @@ if(POLICY CMP0083)
   cmake_policy(SET CMP0083 NEW)
 endif()
 
-# Workaround for 3.19 raising error 'IMPORTED_LOCATION not set for imported
-# target "GTest::gtest_main"'.
+# Reject imported targets without a usable location during generation.
 if(POLICY CMP0111)
-  cmake_policy(SET CMP0111 OLD)
+  cmake_policy(SET CMP0111 NEW)
 endif()
 
 # Starting with GCC-13, we want to make sure to remove gnu extension (ie.


### PR DESCRIPTION
CMake 4.3 reports three policy warnings while configuring bundled
Highway. Each exposes compatibility behavior that makes configuration
less deterministic or defers failures.

The warnings and fixes are:

* `CMP0111 OLD behavior is deprecated`: Highway’s GTest workaround
  allows an imported target without a location to produce unusable
  build rules. ATS disables Highway tests, so this selects NEW and
  makes any incomplete imported target fail during generation.

* `CMP0075 is not set`: Highway’s header checks ignore inherited
  CMAKE_REQUIRED_LIBRARIES under OLD behavior. ATS also leaves OpenSSL
  libraries and includes in the probe state after TLS checks. This
  selects NEW and removes those OpenSSL values before generic checks,
  so required libraries are honored without leaking TLS dependencies.

* `CMP0077 is not set`: Highway’s option(BUILD_SHARED_LIBS) discards
  the normal value supplied by ATS under OLD behavior. This selects
  NEW to preserve the parent setting while HWY_FORCE_STATIC_LIBS keeps
  bundled Highway static.