### PR TITLE
header_rewrite: add sort-destination operator

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1421,6 +1421,17 @@ the operator will effectively be a no-op.
     This operator is deprecated, use the `set-http-cntl`_ operator instead,
     with the ``SKIP_REMAP`` control.
 
+sort-destination
+~~~~~~~~~~~~~~~~
+::
+
+  sort-destination QUERY
+
+Sorts the query parameters of the remapped destination's URL by parameter
+name. Sorting is stable, so parameters that share the same name keep their
+relative order. Currently ``QUERY`` is the only valid part for
+sort-destination.
+
 set-cookie
 ~~~~~~~~~~
 ::

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1137,7 +1137,8 @@ rm-destination
 Removes individual components of the remapped destination's address. When
 changing the remapped destination, ``<part>`` should be used to indicate the
 component that is being modified (see `URL Parts`_). Currently the only valid
-parts for rm-destination are QUERY, PATH, and PORT.
+parts for rm-destination are QUERY, PATH, and PORT; any other part is ignored,
+leaving the destination unchanged.
 
 For the query parameter, this operator takes an optional second argument,
 which is a list of query parameters to remove (or keep with ``[INV]`` modifier).

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1431,7 +1431,7 @@ sort-destination
 Sorts the query parameters of the remapped destination's URL by parameter
 name. Sorting is stable, so parameters that share the same name keep their
 relative order. Currently ``QUERY`` is the only valid part for
-sort-destination.
+sort-destination; any other part is ignored, leaving the destination unchanged.
 
 set-cookie
 ~~~~~~~~~~

--- a/plugins/header_rewrite/CMakeLists.txt
+++ b/plugins/header_rewrite/CMakeLists.txt
@@ -30,6 +30,7 @@ add_atsplugin(
   resources.cc
   ruleset.cc
   statement.cc
+  url_query.cc
   value.cc
 )
 
@@ -98,6 +99,11 @@ if(BUILD_TESTING)
       endif()
     endif()
   endif()
+
+  add_executable(test_url_query unit_tests/test_url_query.cc url_query.cc)
+  target_include_directories(test_url_query PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  add_catch2_test(NAME test_url_query COMMAND test_url_query)
+  target_link_libraries(test_url_query PRIVATE Catch2::Catch2WithMain libswoc::libswoc)
 
   # add_executable(test_matcher matcher_tests.cc matcher.cc lulu.cc regex_helper.cc)
   # add_catch2_test(NAME test_matcher COMMAND $<TARGET_FILE:test_matcher>)

--- a/plugins/header_rewrite/factory.cc
+++ b/plugins/header_rewrite/factory.cc
@@ -49,6 +49,8 @@ operator_factory(const std::string &op)
     o = new OperatorSetDestination();
   } else if (op == "rm-destination") {
     o = new OperatorRMDestination();
+  } else if (op == "sort-destination") {
+    o = new OperatorSortDestination();
   } else if (op == "set-redirect") {
     o = new OperatorSetRedirect();
   } else if (op == "timeout-out") {

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -420,6 +420,16 @@ test_parsing()
     END_TEST();
   }
 
+  {
+    ParserTest p("sort-destination QUERY");
+
+    CHECK_EQ(p.getTokens().size(), 2UL);
+    CHECK_EQ(p.getTokens()[0], "sort-destination");
+    CHECK_EQ(p.getTokens()[1], "QUERY");
+
+    END_TEST();
+  }
+
   return errors;
 }
 

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -29,6 +29,7 @@
 #include "swoc/swoc_file.h"
 
 #include "operators.h"
+#include "url_query.h"
 #include "ts/apidefs.h"
 #include "conditions.h"
 #include "factory.h"
@@ -477,6 +478,60 @@ OperatorRMDestination::exec(const Resources &res) const
     }
   } else {
     Dbg(pi_dbg_ctl, "OperatorRMDestination::exec() unable to continue due to missing bufp=%p or hdr_loc=%p, rri=%p!", res.bufp,
+        res.hdr_loc, res._rri);
+  }
+  return true;
+}
+
+// OperatorSortDestination
+void
+OperatorSortDestination::initialize(Parser &p)
+{
+  Operator::initialize(p);
+
+  _url_qual = parse_url_qualifier(p.get_arg());
+
+  require_resources(RSRC_CLIENT_REQUEST_HEADERS);
+  require_resources(RSRC_SERVER_REQUEST_HEADERS);
+}
+
+bool
+OperatorSortDestination::exec(const Resources &res) const
+{
+  if (res._rri || (res.bufp && res.hdr_loc)) {
+    TSMBuffer bufp;
+    TSMLoc    url_m_loc;
+
+    // Determine which TSMBuffer and TSMLoc to use
+    if (res._rri) {
+      bufp      = res._rri->requestBufp;
+      url_m_loc = res._rri->requestUrl;
+    } else {
+      bufp = res.bufp;
+      if (TSHttpHdrUrlGet(res.bufp, res.hdr_loc, &url_m_loc) != TS_SUCCESS) {
+        Dbg(pi_dbg_ctl, "TSHttpHdrUrlGet was unable to return the url m_loc");
+        return true;
+      }
+    }
+
+    switch (_url_qual) {
+    case URL_QUAL_QUERY: {
+      int         q_len  = 0;
+      const char *query  = TSUrlHttpQueryGet(bufp, url_m_loc, &q_len);
+      std::string sorted = sort_query(q_len > 0 ? std::string_view(query, static_cast<size_t>(q_len)) : std::string_view());
+
+      const_cast<Resources &>(res).changed_url = true;
+      TSUrlHttpQuerySet(bufp, url_m_loc, sorted.c_str(), sorted.size());
+      res.reset_query_cache();
+      Dbg(pi_dbg_ctl, "OperatorSortDestination::exec() rewrote QUERY to \"%s\"", sorted.c_str());
+      break;
+    }
+    default:
+      Dbg(pi_dbg_ctl, "Sort destination %i has no handler", _url_qual);
+      break;
+    }
+  } else {
+    Dbg(pi_dbg_ctl, "OperatorSortDestination::exec() unable to continue due to missing bufp=%p or hdr_loc=%p, rri=%p!", res.bufp,
         res.hdr_loc, res._rri);
   }
   return true;

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -142,6 +142,24 @@ private:
   std::vector<std::string_view> _stop_list;
 };
 
+class OperatorSortDestination : public Operator
+{
+public:
+  OperatorSortDestination() { Dbg(dbg_ctl, "Calling CTOR for OperatorSortDestination"); }
+
+  // noncopyable
+  OperatorSortDestination(const OperatorSortDestination &) = delete;
+  void operator=(const OperatorSortDestination &)          = delete;
+
+  void initialize(Parser &p) override;
+
+protected:
+  bool exec(const Resources &res) const override;
+
+private:
+  UrlQualifiers _url_qual = URL_QUAL_NONE;
+};
+
 class OperatorSetRedirect : public Operator
 {
 public:

--- a/plugins/header_rewrite/unit_tests/test_url_query.cc
+++ b/plugins/header_rewrite/unit_tests/test_url_query.cc
@@ -55,4 +55,14 @@ TEST_CASE("sort_query orders params by name", "[header_rewrite][url_query]")
   {
     CHECK(sort_query("a=1=2") == "a=1=2");
   }
+
+  SECTION("leading '&' produces a clean drop, not an empty leading token")
+  {
+    CHECK(sort_query("&a=1") == "a=1");
+  }
+
+  SECTION("consecutive '&'s produce a clean drop, not empty middle tokens")
+  {
+    CHECK(sort_query("b=2&&a=1&&c=3") == "a=1&b=2&c=3");
+  }
 }

--- a/plugins/header_rewrite/unit_tests/test_url_query.cc
+++ b/plugins/header_rewrite/unit_tests/test_url_query.cc
@@ -1,0 +1,48 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#include <catch2/catch_test_macros.hpp>
+
+#include "url_query.h"
+
+TEST_CASE("sort_query orders params by name", "[header_rewrite][url_query]")
+{
+  SECTION("out-of-order params are sorted")
+  {
+    CHECK(sort_query("b=2&a=1") == "a=1&b=2");
+  }
+
+  SECTION("valueless params sort by their own name")
+  {
+    CHECK(sort_query("b&a=1") == "a=1&b");
+  }
+
+  SECTION("params with duplicate names keep their relative order")
+  {
+    CHECK(sort_query("x=1&a=2&x=3") == "a=2&x=1&x=3");
+  }
+
+  SECTION("empty query stays empty")
+  {
+    CHECK(sort_query("") == "");
+  }
+
+  SECTION("single param is unaffected")
+  {
+    CHECK(sort_query("a=1") == "a=1");
+  }
+}

--- a/plugins/header_rewrite/unit_tests/test_url_query.cc
+++ b/plugins/header_rewrite/unit_tests/test_url_query.cc
@@ -45,4 +45,14 @@ TEST_CASE("sort_query orders params by name", "[header_rewrite][url_query]")
   {
     CHECK(sort_query("a=1") == "a=1");
   }
+
+  SECTION("trailing '&' produces a clean drop, not an empty trailing token")
+  {
+    CHECK(sort_query("a=1&") == "a=1");
+  }
+
+  SECTION("param value containing '=' is preserved and sorts by its name only")
+  {
+    CHECK(sort_query("a=1=2") == "a=1=2");
+  }
 }

--- a/plugins/header_rewrite/url_query.cc
+++ b/plugins/header_rewrite/url_query.cc
@@ -59,6 +59,8 @@ sort_query(std::string_view query)
                    [](std::string_view a, std::string_view b) { return param_name(a) < param_name(b); });
 
   std::string result;
+  result.reserve(query.size()); // same length as query, capped at 64KB by request_line_max_size
+
   for (const auto &param : params) {
     if (!result.empty()) {
       result += '&';

--- a/plugins/header_rewrite/url_query.cc
+++ b/plugins/header_rewrite/url_query.cc
@@ -1,0 +1,70 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#include "url_query.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "swoc/TextView.h"
+
+namespace
+{
+
+std::vector<std::string_view>
+tokenize(std::string_view text, char delimiter)
+{
+  std::vector<std::string_view> tokens;
+  swoc::TextView                view(text);
+
+  while (view) {
+    tokens.push_back(view.take_prefix_at(delimiter));
+  }
+
+  return tokens;
+}
+
+std::string_view
+param_name(std::string_view param)
+{
+  return param.substr(0, param.find('='));
+}
+
+} // namespace
+
+std::string
+sort_query(std::string_view query)
+{
+  if (query.empty()) {
+    return {};
+  }
+
+  std::vector<std::string_view> params = tokenize(query, '&');
+
+  std::stable_sort(params.begin(), params.end(),
+                   [](std::string_view a, std::string_view b) { return param_name(a) < param_name(b); });
+
+  std::string result;
+  for (const auto &param : params) {
+    if (!result.empty()) {
+      result += '&';
+    }
+    result.append(param);
+  }
+
+  return result;
+}

--- a/plugins/header_rewrite/url_query.cc
+++ b/plugins/header_rewrite/url_query.cc
@@ -26,7 +26,7 @@ namespace
 {
 
 std::vector<std::string_view>
-tokenize(std::string_view text, char delimiter)
+split(std::string_view text, char delimiter)
 {
   std::vector<std::string_view> tokens;
   swoc::TextView                view(text);
@@ -53,7 +53,7 @@ sort_query(std::string_view query)
     return {};
   }
 
-  std::vector<std::string_view> params = tokenize(query, '&');
+  std::vector<std::string_view> params = split(query, '&');
 
   std::stable_sort(params.begin(), params.end(),
                    [](std::string_view a, std::string_view b) { return param_name(a) < param_name(b); });

--- a/plugins/header_rewrite/url_query.h
+++ b/plugins/header_rewrite/url_query.h
@@ -1,0 +1,26 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#pragma once
+
+#include <string>
+#include <string_view>
+
+// Sort the '&'-separated parameters of a URL query string by parameter
+// name. Sorting is stable: parameters that share the same name keep their
+// relative order. An empty input returns an empty string.
+std::string sort_query(std::string_view query);

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
@@ -183,6 +183,13 @@ autest:
             args:
               - "rules/set_status_in_if.conf"
 
+      - from: "http://www.example.com/from_19/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/to_19/"
+        plugins:
+          - name: "header_rewrite.so"
+            args:
+              - "rules/rule_sort_destination.conf"
+
     metric_checks:
       - metric: "proxy.process.plugin.header_rewrite.operators"
         min: 1
@@ -1973,3 +1980,28 @@ sessions:
 
     proxy-response:
       status: 403
+
+# Test 68: sort-destination QUERY sorts the request-URL query before the
+# request reaches the origin.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /from_19/?b=2&a=1&c=3
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, 68 ]
+
+    proxy-request:
+      url: /to_19/?a=1&b=2&c=3
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/rule_sort_destination.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/rule_sort_destination.conf
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sort-destination QUERY


### PR DESCRIPTION
Add a `sort-destination QUERY` operator to header_rewrite that stably
sorts the request URL's query parameters by name. Normalizing parameter
order lets varied client query strings map to one origin request, which
helps origin-side caching and dedup.

The sort logic lives in a new pure, TS-API-free `sort_query()` helper
with its own unit test, kept separate from the operator so the
cache-key and parent-key operators can reuse it in a later PR.

- `sort_query()` uses a stable sort, so duplicate-named parameters keep
  their relative order.
- Empty tokens from leading, trailing, or consecutive `&` are dropped.
- Docs note that `QUERY` is the only supported part; any other part is a
  no-op, matching the sibling `rm-destination` wording.

Covered by a Catch2 unit test for the helper and an end-to-end Proxy
Verifier test that checks an unsorted client query reaches the origin
sorted.
