### PR TITLE
header_rewrite: add POST_REMAP_HOOK support

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1738,14 +1738,17 @@ POST_REMAP_HOOK
 ~~~~~~~~~~~~~~~
 
 Forces evaluation of the ruleset immediately after remapping has completed, but
-before |TS| contacts the origin server (or fetches the object from cache). There
-is no response data yet, so context-adapting conditions and operators match
-against the request.
+before |TS| looks the request up in the cache. There is no response data yet, so
+context-adapting conditions and operators match against the request, which at
+this point is the remapped request.
 
-This hook is available to both global (:file:`plugin.config`) and per-remap
-(:file:`remap.config`) configurations, and is primarily useful for
-globally-configured ``header_rewrite`` instances that need to act on the request
-after remapping.
+For rulesets in :file:`remap.config`, `REMAP_PSEUDO_HOOK`_ already covers this
+window. This hook exists for globally-configured rulesets, which otherwise have
+no hook that sees the remapped request before the cache lookup:
+`READ_REQUEST_HDR_HOOK`_ and `READ_REQUEST_PRE_REMAP_HOOK`_ run before
+remapping, and `SEND_REQUEST_HDR_HOOK`_ runs after the lookup, only when the
+request is forwarded to an origin. Anything that has to influence the lookup
+itself belongs at this hook.
 
 SEND_REQUEST_HDR_HOOK
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1734,6 +1734,19 @@ files shared by both the global :file:`plugin.config` and individual remapping
 entries in :file:`remap.config`, this hook condition will force the subsequent
 ruleset(s) to be valid only for remapped transactions.
 
+POST_REMAP_HOOK
+~~~~~~~~~~~~~~~
+
+Forces evaluation of the ruleset immediately after remapping has completed, but
+before |TS| contacts the origin server (or fetches the object from cache). There
+is no response data yet, so context-adapting conditions and operators match
+against the request.
+
+This hook is available to both global (:file:`plugin.config`) and per-remap
+(:file:`remap.config`) configurations, and is primarily useful for
+globally-configured ``header_rewrite`` instances that need to act on the request
+after remapping.
+
 SEND_REQUEST_HDR_HOOK
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/plugins/header_rewrite/header_rewrite.cc
+++ b/plugins/header_rewrite/header_rewrite.cc
@@ -494,6 +494,9 @@ cont_rewrite_headers(TSCont contp, TSEvent event, void *edata)
   case TS_EVENT_HTTP_READ_REQUEST_PRE_REMAP:
     hook = TS_HTTP_PRE_REMAP_HOOK;
     break;
+  case TS_EVENT_HTTP_POST_REMAP:
+    hook = TS_HTTP_POST_REMAP_HOOK;
+    break;
   case TS_EVENT_HTTP_SEND_REQUEST_HDR:
     hook = TS_HTTP_SEND_REQUEST_HDR_HOOK;
     break;

--- a/plugins/header_rewrite/header_rewrite_test.cc
+++ b/plugins/header_rewrite/header_rewrite_test.cc
@@ -127,6 +127,19 @@ test_parsing()
   }
 
   {
+    ParserTest   p("cond %{POST_REMAP_HOOK}");
+    TSHttpHookID hook = TS_HTTP_LAST_HOOK;
+
+    CHECK_EQ(p.getTokens().size(), 2U);
+    CHECK_EQ(p.getTokens()[0], "cond");
+    CHECK_EQ(p.getTokens()[1], "%{POST_REMAP_HOOK}");
+    CHECK_EQ(p.cond_is_hook(hook), true);
+    CHECK_EQ(hook, TS_HTTP_POST_REMAP_HOOK);
+
+    END_TEST();
+  }
+
+  {
     ParserTest p("cond %{CLIENT-HEADER:Host}    =a");
 
     CHECK_EQ(p.getTokens().size(), 4UL);

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -296,6 +296,10 @@ Parser::cond_is_hook(TSHttpHookID &hook) const
     hook = TS_REMAP_PSEUDO_HOOK;
     return true;
   }
+  if ("POST_REMAP_HOOK" == _op) {
+    hook = TS_HTTP_POST_REMAP_HOOK;
+    return true;
+  }
   if ("TXN_START_HOOK" == _op) {
     hook = TS_HTTP_TXN_START_HOOK;
     return true;

--- a/plugins/header_rewrite/resources.cc
+++ b/plugins/header_rewrite/resources.cc
@@ -87,7 +87,8 @@ Resources::gather(const ResourceIDs ids, TSHttpHookID hook)
 
   case TS_HTTP_READ_REQUEST_HDR_HOOK:
   case TS_HTTP_PRE_REMAP_HOOK:
-    // Read request from client
+  case TS_HTTP_POST_REMAP_HOOK:
+    // Read request from client (post-remap this is the remapped request)
     if (ids & RSRC_CLIENT_REQUEST_HEADERS) {
       bufp    = client_bufp;
       hdr_loc = client_hdr_loc;

--- a/plugins/header_rewrite/statement.cc
+++ b/plugins/header_rewrite/statement.cc
@@ -81,6 +81,7 @@ Statement::initialize_hooks()
   add_allowed_hook(TS_HTTP_SEND_REQUEST_HDR_HOOK);
   add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
   add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
+  add_allowed_hook(TS_HTTP_POST_REMAP_HOOK);
   add_allowed_hook(TS_HTTP_TXN_START_HOOK);
   add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
 }

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_post_remap.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_post_remap.replay.yaml
@@ -32,6 +32,9 @@ autest:
   ats:
     name: 'ts'
 
+    process_config:
+      enable_cache: true
+
     copy_to_config_dir:
       - 'post_remap.conf'
 
@@ -43,6 +46,7 @@ autest:
     # the ATS config dir, where copy_to_config_dir places it.
     plugin_config:
       - 'header_rewrite.so post_remap.conf'
+      - 'xdebug.so --enable=x-cache'
 
     remap_config:
       - from: "http://www.example.com/"
@@ -50,6 +54,11 @@ autest:
 
 sessions:
 - transactions:
+
+  #############################################################################
+  # Cache miss: the header set at POST_REMAP reaches the origin, and the echo
+  # rule reports it on the response.
+  #############################################################################
   - client-request:
       method: "GET"
       version: "1.1"
@@ -57,20 +66,58 @@ sessions:
       headers:
         fields:
         - [ Host, www.example.com ]
-        - [ uuid, 1 ]
+        - [ x-debug, "x-cache" ]
+        - [ uuid, post-remap-miss ]
 
-    # The header set at POST_REMAP must be present on the request ATS forwards.
     proxy-request:
       headers:
         fields:
-        - [ X-Post-Remap-Applied, { value: "yes", as: equal } ]
+        - [ X-Post-Remap-Host, { value: "backend.ex", as: equal } ]
 
     server-response:
       status: 200
       reason: OK
       headers:
         fields:
-        - [ Connection, close ]
+        - [ Content-Type, text/plain ]
+        - [ Content-Length, "3" ]
+        - [ Cache-Control, "max-age=300" ]
+      content:
+        encoding: plain
+        data: xxx
 
     proxy-response:
       status: 200
+      headers:
+        fields:
+        - [ X-Cache, { value: "miss", as: equal } ]
+        - [ X-Post-Remap-Echo, { value: "backend.ex", as: equal } ]
+
+  #############################################################################
+  # Cache hit: nothing is forwarded to the origin, so SEND_REQUEST_HDR_HOOK
+  # never runs. The rule still fires, because POST_REMAP is before the lookup.
+  #############################################################################
+  - client-request:
+      delay: 100ms
+      method: "GET"
+      version: "1.1"
+      url: /post_remap/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ x-debug, "x-cache" ]
+        - [ uuid, post-remap-hit ]
+
+    proxy-request:
+      expect: absent
+
+    server-response:
+      status: 404
+      reason: Not Found
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Cache, { value: "hit-fresh", as: equal } ]
+        - [ X-Post-Remap-Echo, { value: "backend.ex", as: equal } ]

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_post_remap.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_post_remap.replay.yaml
@@ -1,0 +1,76 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+autest:
+  description: 'Test header_rewrite POST_REMAP_HOOK support (global plugin)'
+
+  dns:
+    name: 'dns'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+
+    copy_to_config_dir:
+      - 'post_remap.conf'
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'header_rewrite'
+
+    # header_rewrite loaded as a GLOBAL plugin. The conf resolves relative to
+    # the ATS config dir, where copy_to_config_dir places it.
+    plugin_config:
+      - 'header_rewrite.so post_remap.conf'
+
+    remap_config:
+      - from: "http://www.example.com/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /post_remap/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, 1 ]
+
+    # The header set at POST_REMAP must be present on the request ATS forwards.
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Post-Remap-Applied, { value: "yes", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_post_remap.test.py
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_post_remap.test.py
@@ -1,0 +1,24 @@
+'''
+Test header_rewrite POST_REMAP_HOOK support.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test header_rewrite attaching a ruleset to the POST_REMAP_HOOK.
+'''
+
+Test.ATSReplayTest(replay_file="header_rewrite_post_remap.replay.yaml",)

--- a/tests/gold_tests/pluginTest/header_rewrite/post_remap.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/post_remap.conf
@@ -15,8 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Global header_rewrite ruleset that fires after remapping. It sets a request
-# header on the post-remap request, which must then appear on the request ATS
-# forwards to the origin (proxy-request).
+# Global header_rewrite ruleset that fires after remapping, on the remapped
+# request, before the cache lookup. The value is the remapped host, so an
+# earlier hook would record the pristine host instead.
 cond %{POST_REMAP_HOOK}
-  set-header X-Post-Remap-Applied "yes"
+  set-header X-Post-Remap-Host "%{URL:HOST}"
+
+# Echo the post-remap header into the client response so the rule above can be
+# observed on a cache hit, where no request is forwarded to the origin.
+cond %{SEND_RESPONSE_HDR_HOOK}
+  set-header X-Post-Remap-Echo "%{CLIENT-HEADER:X-Post-Remap-Host}"

--- a/tests/gold_tests/pluginTest/header_rewrite/post_remap.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/post_remap.conf
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Global header_rewrite ruleset that fires after remapping. It sets a request
+# header on the post-remap request, which must then appear on the request ATS
+# forwards to the origin (proxy-request).
+cond %{POST_REMAP_HOOK}
+  set-header X-Post-Remap-Applied "yes"


### PR DESCRIPTION
`header_rewrite` can attach rulesets to most transaction hooks, but not to
`TS_HTTP_POST_REMAP_HOOK`. For a global (`plugin.config`) configuration, that
leaves no hook that sees the *remapped* request *before the cache lookup*:

- `READ_REQUEST_HDR_HOOK` / `READ_REQUEST_PRE_REMAP_HOOK` run before remapping,
  so they only ever see the pristine request.
- `REMAP_PSEUDO_HOOK` sees the remapped request before the lookup, but is valid
  only in a remap context.
- `SEND_REQUEST_HDR_HOOK` sees the remapped request, but fires after the lookup
  and only when the request is forwarded to an origin. It cannot influence the
  lookup, and it never runs on a cache hit.

That window is where anything feeding the cache lookup has to run. The `cachekey`
plugin registers `TS_HTTP_POST_REMAP_HOOK` for exactly this reason
(`plugins/cachekey/plugin.cc:114`): its remap-time path (`TSRemapDoRemap`)
covers the per-remap case, and a global instance needs the remapped request
before `TSCacheUrlSet` is consumed by the lookup.

This is the hook a planned `header_rewrite` cache-key operator needs, for the
same reason: setting the cache key is only meaningful between remapping and the
cache lookup, and `SEND_REQUEST_HDR_HOOK` is already too late.

This PR adds a `POST_REMAP_HOOK` hook condition and wires it end to end:

- Recognize the `POST_REMAP_HOOK` keyword in the parser.
- Handle the POST_REMAP event so rulesets run at that hook.
- Gather the post-remap request headers for the hook.
- Allow operators and conditions on the hook.

Covered by a parser unit test and an end-to-end autest.
