### PR TITLE
Fix JSON-RPC request size check

### DIFF
--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -419,7 +419,7 @@ IPCSocketServer::Client::read_all(Buffer &bw) const
       return {false, swoc::bwprint(buff, "Peer disconnected. EOF")};
     }
     bw.save(ret);
-    if (_max_req_size - bw.stored() > 0) { // we can still read more.
+    if (bw.stored() < _max_req_size) { // we can still read more.
       using namespace std::chrono_literals;
       if (!this->poll_for_data(1ms)) {
         return {true, buff};

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -519,6 +519,15 @@ TEST_CASE("Sending a message bigger than the internal server's buffer. 32000", "
       auto              resp = rpc_client.query(json);
       REQUIRE(resp == R"({"jsonrpc": "2.0", "result": {"size": "32000"}, "id": "32k_1"})");
     }());
+
+    const int oversized_message_size{64000};
+    auto      oversized_json{R"({"jsonrpc": "2.0", "method": "do_nothing32000", "params": {"msg":")" +
+                        random_string(oversized_message_size) + R"("}, "id":"over-limit"})"};
+    REQUIRE_NOTHROW([&]() {
+      ScopedLocalSocket rpc_client;
+      auto              resp = rpc_client.query(oversized_json);
+      REQUIRE(resp.empty());
+    }());
   }
   REQUIRE(rpc::test_remove_handler("do_nothing32000"));
 }


### PR DESCRIPTION
Unsigned subtraction can wrap after the JSON-RPC request buffer grows
past its configured maximum. This allows oversized requests to be
accepted.

This compares stored bytes directly with the limit and adds regression
coverage for an oversized request.

Fixes: #12312