### PR TITLE
Resolve OpenSSL 4.0 build issues

### DIFF
--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -367,12 +367,18 @@ mkcrt(const std::string &commonName, int serial)
   X509_gmtime_adj(X509_get_notAfter(cert.get()), static_cast<long>(3650) * 24 * 3600);
 
   // Get handle to subject name
-  X509_NAME *n = X509_get_subject_name(cert.get());
+  X509_NAME *n = X509_NAME_dup(X509_get_subject_name(cert.get()));
   // Set common name field
   if (X509_NAME_add_entry_by_txt(n, "CN", MBSTRING_ASC, (unsigned char *)commonName.c_str(), -1, -1, 0) != 1) {
     TSError("[%s] %s: failed to add certificate subject CN", PLUGIN_NAME, __func__);
     return nullptr;
   }
+  if (X509_set_subject_name(cert.get(), n) != 1) {
+    TSError("[%s] %s: failed to set certificate subject", PLUGIN_NAME, __func__);
+    X509_NAME_free(n);
+    return nullptr;
+  }
+  X509_NAME_free(n);
 
   // Set Traffic Server public key
   if (X509_set_pubkey(cert.get(), ca_pkey_scoped.get()) == 0) {

--- a/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
+++ b/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
@@ -65,7 +65,7 @@ dump_context(const char *ca_path, const char *ck_path)
         // expiration date, serial number, common name, and subject alternative names
         const ASN1_TIME    *not_after    = X509_get_notAfter(cert);
         const ASN1_INTEGER *serial       = X509_get_serialNumber(cert);
-        X509_NAME          *subject_name = X509_get_subject_name(cert);
+        const X509_NAME    *subject_name = X509_get_subject_name(cert);
 
         // Subject name
         BIO *subject_bio = BIO_new(BIO_s_mem());

--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -49,14 +49,14 @@ x509_expand_certificate(X509 *x509, BIO *bio)
 static void
 x509_expand_subject(X509 *x509, BIO *bio)
 {
-  X509_NAME *name = X509_get_subject_name(x509);
+  const X509_NAME *name = X509_get_subject_name(x509);
   X509_NAME_print_ex(bio, name, 0 /* indent */, XN_FLAG_ONELINE);
 }
 
 static void
 x509_expand_issuer(X509 *x509, BIO *bio)
 {
-  X509_NAME *name = X509_get_issuer_name(x509);
+  const X509_NAME *name = X509_get_issuer_name(x509);
   X509_NAME_print_ex(bio, name, 0 /* indent */, XN_FLAG_ONELINE);
 }
 
@@ -72,8 +72,8 @@ x509_expand_signature(X509 *x509, BIO *bio)
 {
   const ASN1_BIT_STRING *sig;
   X509_get0_signature(&sig, nullptr, x509);
-  const char *ptr = reinterpret_cast<const char *>(sig->data);
-  const char *end = ptr + sig->length;
+  const char *ptr = reinterpret_cast<const char *>(ASN1_STRING_get0_data(sig));
+  const char *end = ptr + ASN1_STRING_length(sig);
 
   // The canonical OpenSSL way to format the signature seems to be
   // X509_signature_dump(). However that separates each byte with a ':', which is

--- a/plugins/experimental/txn_box/plugin/src/ts_util.cc
+++ b/plugins/experimental/txn_box/plugin/src/ts_util.cc
@@ -1106,7 +1106,7 @@ ssl_nid(swoc::TextView const &name)
 namespace
 {
   TextView
-  ssl_value_for(X509_NAME *name, int nid)
+  ssl_value_for(const X509_NAME *name, int nid)
   {
     if (int loc = X509_NAME_get_index_by_NID(name, nid, -1); loc >= 0) {
       if (auto entry = X509_NAME_get_entry(name, loc); entry != nullptr) {

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -8305,9 +8305,9 @@ TSSslServerCertUpdate(const char *cert_path, const char *key_path)
     }
 
     // Extract common name
-    int              pos              = X509_NAME_get_index_by_NID(X509_get_subject_name(cert.get()), NID_commonName, -1);
-    X509_NAME_ENTRY *common_name      = X509_NAME_get_entry(X509_get_subject_name(cert.get()), pos);
-    ASN1_STRING     *common_name_asn1 = X509_NAME_ENTRY_get_data(common_name);
+    const int              pos              = X509_NAME_get_index_by_NID(X509_get_subject_name(cert.get()), NID_commonName, -1);
+    const X509_NAME_ENTRY *common_name      = X509_NAME_get_entry(X509_get_subject_name(cert.get()), pos);
+    const ASN1_STRING     *common_name_asn1 = X509_NAME_ENTRY_get_data(common_name);
     char *common_name_str = reinterpret_cast<char *>(const_cast<unsigned char *>(ASN1_STRING_get0_data(common_name_asn1)));
     if (ASN1_STRING_length(common_name_asn1) != static_cast<int>(strlen(common_name_str))) {
       // Embedded null char

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -490,7 +490,7 @@ TS_OCSP_cert_id_new(const EVP_MD *dgst, const X509_NAME *issuerName, const ASN1_
   }
 
   /* Calculate the issuerKey hash, excluding tag and length */
-  if (!EVP_Digest(issuerKey->data, issuerKey->length, md, &i, dgst, nullptr)) {
+  if (!EVP_Digest(ASN1_STRING_get0_data(issuerKey), ASN1_STRING_length(issuerKey), md, &i, dgst, nullptr)) {
     goto err;
   }
 
@@ -516,7 +516,7 @@ TS_OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject, const X509 *issuer)
 {
   const X509_NAME    *iname;
   const ASN1_INTEGER *serial;
-  ASN1_BIT_STRING    *ikey;
+  const ASN1_BIT_STRING    *ikey;
 
   if (!dgst) {
     dgst = EVP_sha1();

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -514,9 +514,9 @@ err:
 TS_OCSP_CERTID *
 TS_OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject, const X509 *issuer)
 {
-  const X509_NAME    *iname;
-  const ASN1_INTEGER *serial;
-  const ASN1_BIT_STRING    *ikey;
+  const X509_NAME       *iname;
+  const ASN1_INTEGER    *serial;
+  const ASN1_BIT_STRING *ikey;
 
   if (!dgst) {
     dgst = EVP_sha1();

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -167,7 +167,7 @@ SSLNetVConnection::_unbindSSLObject()
 }
 
 static void
-debug_certificate_name(const char *msg, X509_NAME *name)
+debug_certificate_name(const char *msg, const X509_NAME *name)
 {
   BIO *bio;
 

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -2231,7 +2231,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
         const X509_NAME_ENTRY *e  = X509_NAME_get_entry(subject, pos);
         const ASN1_STRING     *cn = X509_NAME_ENTRY_get_data(e);
-        subj_name           = asn1_strdup(cn);
+        subj_name                 = asn1_strdup(cn);
 
         Dbg(dbg_ctl_ssl_load, "subj '%s' in certificate %s %p", subj_name.get(), data.cert_names_list[i].c_str(), cert);
         name_set.insert(subj_name.get());

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1008,7 +1008,7 @@ SSLMultiCertConfigLoader::check_server_cert_now(X509 *cert, const char *certname
 } /* CheckServerCertNow() */
 
 static char *
-asn1_strdup(ASN1_STRING *s)
+asn1_strdup(const ASN1_STRING *s)
 {
   // Make sure we have an 8-bit encoding.
   ink_assert(ASN1_STRING_type(s) == V_ASN1_IA5STRING || ASN1_STRING_type(s) == V_ASN1_UTF8STRING ||
@@ -2216,7 +2216,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
     std::set<std::string> name_set;
     // Grub through the names in the certs
-    X509_NAME *subject = nullptr;
+    const X509_NAME *subject = nullptr;
 
     // Insert a key for the subject CN.
     subject = X509_get_subject_name(cert);
@@ -2229,8 +2229,8 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
           break;
         }
 
-        X509_NAME_ENTRY *e  = X509_NAME_get_entry(subject, pos);
-        ASN1_STRING     *cn = X509_NAME_ENTRY_get_data(e);
+        const X509_NAME_ENTRY *e  = X509_NAME_get_entry(subject, pos);
+        const ASN1_STRING     *cn = X509_NAME_ENTRY_get_data(e);
         subj_name           = asn1_strdup(cn);
 
         Dbg(dbg_ctl_ssl_load, "subj '%s' in certificate %s %p", subj_name.get(), data.cert_names_list[i].c_str(), cert);

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -205,12 +205,12 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
 {
   bool retval = false;
 
-  if (!a->data || !a->length || cmp_type != a->type) {
+  if (!ASN1_STRING_get0_data(a) || !ASN1_STRING_length(a) || cmp_type != ASN1_STRING_type(a)) {
     return false;
   }
-  retval = equal(a->data, a->length, b, blen);
+  retval = equal(ASN1_STRING_get0_data(a), ASN1_STRING_length(a), b, blen);
   if (retval && peername) {
-    *peername = ats_strndup((char *)a->data, a->length);
+    *peername = ats_strndup((char *)ASN1_STRING_get0_data(a), ASN1_STRING_length(a));
   }
   return retval;
 }
@@ -218,11 +218,11 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
 bool
 validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **peername)
 {
-  GENERAL_NAMES *gens = nullptr;
-  X509_NAME     *name = nullptr;
-  int            i;
-  int            alt_type;
-  bool           retval = false;
+  GENERAL_NAMES   *gens = nullptr;
+  const X509_NAME *name = nullptr;
+  int             i;
+  int             alt_type;
+  bool            retval = false;
   ;
   equal_fn equal;
   size_t   hostname_len = strlen((char *)hostname);
@@ -267,9 +267,9 @@ validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **pee
   name = X509_get_subject_name(x);
 
   while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
-    ASN1_STRING   *str;
-    int            astrlen;
-    unsigned char *astr;
+    const ASN1_STRING   *str;
+    int                 astrlen;
+    unsigned char       *astr;
     str = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     // Convert to UTF-8
     astrlen = ASN1_STRING_to_UTF8(&astr, str);

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -220,9 +220,9 @@ validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **pee
 {
   GENERAL_NAMES   *gens = nullptr;
   const X509_NAME *name = nullptr;
-  int             i;
-  int             alt_type;
-  bool            retval = false;
+  int              i;
+  int              alt_type;
+  bool             retval = false;
   ;
   equal_fn equal;
   size_t   hostname_len = strlen((char *)hostname);
@@ -267,9 +267,9 @@ validate_hostname(X509 *x, const unsigned char *hostname, bool is_ip, char **pee
   name = X509_get_subject_name(x);
 
   while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
-    const ASN1_STRING   *str;
-    int                 astrlen;
-    unsigned char       *astr;
+    const ASN1_STRING *str;
+    int                astrlen;
+    unsigned char     *astr;
     str = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     // Convert to UTF-8
     astrlen = ASN1_STRING_to_UTF8(&astr, str);


### PR DESCRIPTION
Fedora 45 updates to OpenSSL 4.0, which removes several long-deprecated capabilities and breaks ATS build.   Specific issues fixed are lack of const tagging of pointers to immutable structures, and disallowed introspection of ASN1_STRING. Resolves #13427 