### PR TITLE
Return an empty view for a non-participating capture group

### DIFF
--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -205,6 +205,13 @@ RegexMatches::operator[](size_t index) const
   }
 
   PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(_MatchData::get(_match_data));
+
+  // A group that did not participate in the match has an unset offset. This happens for an optional
+  // group that precedes a participating one, so a valid index is not enough to guarantee an offset.
+  if (PCRE2_UNSET == ovector[2 * index]) {
+    return std::string_view();
+  }
+
   return std::string_view(_subject.data() + ovector[2 * index], ovector[2 * index + 1] - ovector[2 * index]);
 }
 

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -460,6 +460,23 @@ TEST_CASE("RegexMatches edge cases", "[libts][Regex][RegexMatches]")
     CHECK(count >= 2); // At least whole match + first group
     CHECK(matches[1] == "foo");
   }
+
+  SECTION("RegexMatches with a non-participating group before a participating one")
+  {
+    // pcre2_match() returns one past the highest participating group, so an earlier optional group
+    // that did not participate is still within that count. Its offsets are unset.
+    Regex r;
+    REQUIRE(r.compile("(a)?(b)") == true);
+
+    RegexMatches matches;
+    int          count = r.exec("b", matches);
+
+    CHECK(count == 3);
+    CHECK(matches[0] == "b");
+    CHECK(matches[1] == "");
+    CHECK(matches[2] == "b");
+    CHECK(matches[1].data() == nullptr);
+  }
 }
 
 TEST_CASE("Regex with special characters", "[libts][Regex][special]")


### PR DESCRIPTION
A capture group that does not participate in a match has unset offsets. `RegexMatches::operator[]` only compared the index against the ovector count, which is not sufficient: `pcre2_match()` returns one past the highest *participating* group, so an optional group that precedes a participating one is inside that count with its offsets unset.

For pattern `(a)?(b)` on subject `b`, the match count is 3 and group 1 is `PCRE2_UNSET`. The index check passes and the subject pointer is advanced by `PCRE2_UNSET`.

The resulting view has length zero, because the length is computed as `end - start` and both are unset, so callers see an empty string and nothing observably breaks today. The pointer itself is invalid, which is what this fixes. `operator[]` now returns a default `std::string_view` for a group that did not participate.

Found while reviewing #13352, which works around the same underlying behavior in the prefetch plugin. That plugin guards the trailing-optional-group case; this is the general fix, and other callers index the ovector the same way (`plugins/regex_remap/regex_remap.cc`, `plugins/cachekey/pattern.cc`, `plugins/regex_revalidate/regex_revalidate.cc`).

### Tests

New section in `test_Regex.cc` covering a non-participating group before a participating one. It fails on master (the returned pointer is non-null) and passes with this change. Full `test_tsutil` suite passes: 458 assertions, 28 cases.