### PR TITLE
Fix ssl_multicert.yaml usage in two 10.2.x autests

### DIFF
--- a/tests/gold_tests/h2/http2_max_active_streams.test.py
+++ b/tests/gold_tests/h2/http2_max_active_streams.test.py
@@ -53,13 +53,7 @@ class Http2MaxActiveStreamsTest:
                 'proxy.config.http2.max_concurrent_streams_in': 100,
             })
         ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{server.Variables.http_port}')
-        ts.Disk.ssl_multicert_yaml.AddLines(
-            """
-ssl_multicert:
-  - dest_ip: "*"
-    ssl_cert_name: server.pem
-    ssl_key_name: server.key
-""".split('\n'))
+        ts.Disk.ssl_multicert_config.AddLine('dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key')
 
         tr.Processes.Default.StartBefore(server)
         tr.Processes.Default.StartBefore(ts)

--- a/tests/gold_tests/tls/tls_secret_update_default.test.py
+++ b/tests/gold_tests/tls/tls_secret_update_default.test.py
@@ -87,15 +87,10 @@ class TestDefaultSecretUpdate:
                 'proxy.config.url_remap.pristine_host_hdr': 1,
             })
 
-        ts.Disk.ssl_multicert_yaml.AddLines(
+        ts.Disk.ssl_multicert_config.AddLines(
             [
-                'ssl_multicert:',
-                '  - dest_ip: "*"',
-                f'    ssl_cert_name: {self.initial_cert}',
-                f'    ssl_key_name: {self.key_file}',
-                '  - dest_ip: "*"',
-                f'    ssl_cert_name: {self.shadowed_cert}',
-                f'    ssl_key_name: {self.shadowed_key_file}',
+                f'dest_ip=* ssl_cert_name={self.initial_cert} ssl_key_name={self.key_file}',
+                f'dest_ip=* ssl_cert_name={self.shadowed_cert} ssl_key_name={self.shadowed_key_file}',
             ])
         ts.Disk.remap_config.AddLine(f'map / http://127.0.0.1:{self._server.Variables.Port}')
         return ts
@@ -122,7 +117,7 @@ class TestDefaultSecretUpdate:
     def _add_config_touch_run(self) -> 'TestRun':
         '''Mark the multicert configuration for reload.'''
         tr = Test.AddTestRun('Mark the multicert configuration for reload')
-        tr.Processes.Default.Command = f'touch {self._ts.Disk.ssl_multicert_yaml.AbsPath}'
+        tr.Processes.Default.Command = f'touch {self._ts.Disk.ssl_multicert_config.AbsPath}'
         tr.Processes.Default.ReturnCode = 0
         self._keep_processes_running(tr)
         return tr
@@ -134,7 +129,7 @@ class TestDefaultSecretUpdate:
         tr.Processes.Default.Env = self._ts.Env
         tr.Processes.Default.ReturnCode = 0
         await_reload = tr.Processes.Process('await_reload', 'sleep 30')
-        await_reload.Ready = When.FileContains(self._ts.Disk.diags_log.Name, 'ssl_multicert.yaml finished loading', 2)
+        await_reload.Ready = When.FileContains(self._ts.Disk.diags_log.Name, 'ssl_multicert.config finished loading', 2)
         tr.Processes.Default.StartBefore(await_reload)
         self._keep_processes_running(tr)
         return tr


### PR DESCRIPTION
Two autests fail at load time on `10.2.x` because they use the
`ssl_multicert.yaml` Disk API, which the release-branch autest harness
does not provide (it registers `ssl_multicert.config`):

- `gold_tests/h2/http2_max_active_streams.test.py`
- `gold_tests/tls/tls_secret_update_default.test.py`

Both raise `AttributeError: 'Disk' object has no attribute
'ssl_multicert_yaml'` before running. They were backported (via #13386
and #13342) without adapting the config-file format to `10.2.x`.

This converts both to the flat `ssl_multicert.config` form already used
throughout the branch (e.g. `h2origin.test.py`,
`tls_check_dual_cert_selection2.test.py`), including the reload `touch`
in the TLS test. No product-code changes.
