### PR TITLE
Fix PluginVC server connection cast

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -6916,7 +6916,7 @@ HttpSM::attach_server_session()
   server_entry->vc_type          = HttpVC_t::SERVER_VC;
   server_entry->vc_write_handler = &HttpSM::state_send_server_request_header;
 
-  UnixNetVConnection *server_vc = static_cast<UnixNetVConnection *>(server_txn->get_netvc());
+  NetVConnection *server_vc = server_txn->get_netvc();
 
   // set flag for server session is SSL
   if (server_vc->get_service<TLSBasicSupport>()) {


### PR DESCRIPTION
Plugin intercepts provide a PluginVC for the server connection, but
HttpSM treats it as a UnixNetVConnection. This invalid downcast can
trigger libc++ RTTI diagnostics and is undefined behavior.

This keeps the connection at its NetVConnection base type, which
provides both TLS service lookups needed at that point.

Fixes: #8105