### PR TITLE
Release logging thread continuations

### DIFF
--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -277,6 +277,7 @@ struct LoggingPreprocContinuation : public Continuation {
   mainEvent(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
   {
     Log::preproc_thread_main((void *)&m_idx);
+    delete this;
     return 0;
   }
 
@@ -293,6 +294,7 @@ struct LoggingFlushContinuation : public Continuation {
   mainEvent(int /* event ATS_UNUSED */, void * /* data ATS_UNUSED */)
   {
     Log::flush_thread_main((void *)&m_idx);
+    delete this;
     return 0;
   }
 


### PR DESCRIPTION
Dedicated logging continuations remain allocated after their worker loops return during shutdown. Once shutdown reliably completes, LeakSanitizer can report the flush continuation as an 80-byte leak.

Release both continuations after their loops finish. This matches the ownership model used by other dedicated event threads.