### PR TITLE
Enable OpenSSL QUIC when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,6 @@ set(ENABLE_TPROXY
         'X' where X is a number to use as the IP_TRANSPARENT sockopt,
         anything else to enable."
 )
-option(ENABLE_OPENSSL_QUIC "Use OpenSSL native QUIC (default OFF)")
 option(ENABLE_QUICHE "Use quiche (default OFF)")
 
 option(ENABLE_EXAMPLE "Build example directory (default OFF)")
@@ -330,6 +329,42 @@ endif()
 
 check_openssl_has_native_quic(SSLLIB_HAS_NATIVE_QUIC "${OPENSSL_INCLUDE_DIR}")
 
+if(DEFINED ENABLE_OPENSSL_QUIC
+   AND NOT ENABLE_OPENSSL_QUIC STREQUAL "AUTO"
+   AND ENABLE_OPENSSL_QUIC
+)
+  if(ENABLE_QUICHE)
+    message(FATAL_ERROR "ENABLE_OPENSSL_QUIC and ENABLE_QUICHE are mutually exclusive QUIC backends")
+  endif()
+  if(NOT SSLLIB_HAS_NATIVE_QUIC)
+    message(FATAL_ERROR "OpenSSL native QUIC support requires OpenSSL 3.5 or newer with OSSL_QUIC_server_method")
+  endif()
+  if(SSLLIB_IS_BORINGSSL
+     OR SSLLIB_IS_AWSLC
+     OR SSLLIB_IS_QUICTLS
+  )
+    message(FATAL_ERROR "OpenSSL native QUIC support requires upstream OpenSSL 3.5 or newer")
+  endif()
+endif()
+
+set(OPENSSL_QUIC_AVAILABLE ${SSLLIB_HAS_NATIVE_QUIC})
+if(SSLLIB_IS_BORINGSSL
+   OR SSLLIB_IS_AWSLC
+   OR SSLLIB_IS_QUICTLS
+   OR ENABLE_QUICHE
+)
+  set(OPENSSL_QUIC_AVAILABLE FALSE)
+endif()
+auto_option(
+  OPENSSL_QUIC
+  FEATURE_VAR
+  TS_HAS_OPENSSL_QUIC
+  DESCRIPTION
+  "Use OpenSSL native QUIC"
+  VAR_DEPENDS
+  OPENSSL_QUIC_AVAILABLE
+)
+
 if(ENABLE_PROFILER)
   find_package(profiler REQUIRED)
   set(TS_HAS_PROFILER ${profiler_FOUND})
@@ -345,21 +380,7 @@ elseif(TS_HAS_MIMALLOC)
   link_libraries(mimalloc)
 endif()
 
-if(ENABLE_OPENSSL_QUIC AND ENABLE_QUICHE)
-  message(FATAL_ERROR "ENABLE_OPENSSL_QUIC and ENABLE_QUICHE are mutually exclusive QUIC backends")
-endif()
-
-if(ENABLE_OPENSSL_QUIC)
-  if(NOT SSLLIB_HAS_NATIVE_QUIC)
-    message(FATAL_ERROR "OpenSSL native QUIC support requires OpenSSL 3.5 or newer with OSSL_QUIC_server_method")
-  endif()
-  if(SSLLIB_IS_BORINGSSL
-     OR SSLLIB_IS_AWSLC
-     OR SSLLIB_IS_QUICTLS
-  )
-    message(FATAL_ERROR "OpenSSL native QUIC support requires upstream OpenSSL 3.5 or newer")
-  endif()
-  set(TS_HAS_OPENSSL_QUIC TRUE)
+if(TS_HAS_OPENSSL_QUIC)
   set(TS_USE_QUIC TRUE)
   message(STATUS "Using OpenSSL native QUIC")
 endif()

--- a/src/iocore/net/SSLClientCoordinator.cc
+++ b/src/iocore/net/SSLClientCoordinator.cc
@@ -25,6 +25,7 @@
 #include "P_SSLConfig.h"
 #include "iocore/net/SSLSNIConfig.h"
 #include "mgmt/config/ConfigRegistry.h"
+#include "records/RecHttp.h"
 #include "tscore/Filenames.h"
 #if TS_USE_QUIC == 1
 #include "iocore/net/QUICMultiCertConfigLoader.h"
@@ -40,7 +41,9 @@ SSLClientCoordinator::reconfigure(ConfigContext reconf_ctx)
   SNIConfig::reconfigure(reconf_ctx.add_dependent_ctx("SNIConfig", ts::filename::SNI));
   SSLCertificateConfig::reconfigure(reconf_ctx.add_dependent_ctx("SSLCertificateConfig", ts::filename::SSL_MULTICERT));
 #if TS_USE_QUIC == 1
-  QUICCertConfig::reconfigure(reconf_ctx.add_dependent_ctx("QUICCertConfig", ts::filename::SSL_MULTICERT));
+  if (HttpProxyPort::hasQUIC()) {
+    QUICCertConfig::reconfigure(reconf_ctx.add_dependent_ctx("QUICCertConfig", ts::filename::SSL_MULTICERT));
+  }
 #endif
   reconf_ctx.complete("SSL configs reloaded");
 }

--- a/src/traffic_server/traffic_server.cc
+++ b/src/traffic_server/traffic_server.cc
@@ -2403,7 +2403,9 @@ main(int /* argc ATS_UNUSED */, const char **argv)
     SSLConfigParams::load_ssl_file_cb = load_ssl_file_callback;
     sslNetProcessor.start(-1, stacksize);
 #if TS_USE_QUIC == 1
-    quic_NetProcessor.start(-1, stacksize);
+    if (HttpProxyPort::hasQUIC()) {
+      quic_NetProcessor.start(-1, stacksize);
+    }
 #endif
     FileManager::instance().registerConfigPluginCallbacks([&]() { global_config_cbs->invoke(); });
     cacheProcessor.afterInitCallbackSet(&CB_After_Cache_Init);

--- a/tests/gold_tests/tls/ssl_multicert_loader.test.py
+++ b/tests/gold_tests/tls/ssl_multicert_loader.test.py
@@ -92,6 +92,8 @@ tr3.MakeCurlCommand(
 tr3.Processes.Default.ReturnCode = 0
 tr3.Processes.Default.Streams.stdout = Testers.ExcludesExpression("Could Not Connect", "Check response")
 tr3.Processes.Default.Streams.stderr = Testers.IncludesExpression(f"CN={sni_domain}", "Check response")
+ts.Disk.diags_log.Content = Testers.ExcludesExpression(
+    r'\(quic\).*ssl_multicert', 'QUIC certificates should not load without a configured QUIC listener')
 
 ##########################################################################
 # Ensure ATS fails/exits when non-existent cert is specified


### PR DESCRIPTION
OpenSSL 3.5 provides the QUIC implementation ATS needs to accept
HTTP/3 connections from downstream clients. This affects client-to-ATS
traffic, not ATS-to-origin traffic. Requiring an extra opt-in leaves
capable builds without client-facing HTTP/3, but merely compiling QUIC
should not make deployments without QUIC listeners load every TLS
certificate twice.

This makes native OpenSSL QUIC an automatic CMake option. It activates
only with upstream OpenSSL's native server API, remains disabled when
quiche is selected, and preserves explicit ON and OFF overrides.

This also starts the QUIC processor and maintains its certificate
table only when a QUIC listener is configured, avoiding the duplicate
load when HTTP/3 is unused.