### PR TITLE
Resolve OpenSSL 4.0 build issues

### DIFF
--- a/example/plugins/c-api/client_context_dump/client_context_dump.cc
+++ b/example/plugins/c-api/client_context_dump/client_context_dump.cc
@@ -65,7 +65,7 @@ dump_context(const char *ca_path, const char *ck_path)
         // expiration date, serial number, common name, and subject alternative names
         const ASN1_TIME    *not_after    = X509_get_notAfter(cert);
         const ASN1_INTEGER *serial       = X509_get_serialNumber(cert);
-        X509_NAME          *subject_name = X509_get_subject_name(cert);
+        auto               *subject_name = X509_get_subject_name(cert);
 
         // Subject name
         BIO *subject_bio = BIO_new(BIO_s_mem());

--- a/example/plugins/c-api/verify_cert/verify_cert.cc
+++ b/example/plugins/c-api/verify_cert/verify_cert.cc
@@ -37,7 +37,7 @@ namespace
 DbgCtl dbg_ctl{PLUGIN_NAME};
 
 static void
-debug_certificate(const char *msg, X509_NAME *name)
+debug_certificate(const char *msg, const X509_NAME *name)
 {
   BIO *bio;
 

--- a/include/cripts/Certs.hpp
+++ b/include/cripts/Certs.hpp
@@ -107,10 +107,10 @@ public:
       }
     }
 
-    void _load_name(X509_NAME *(*getter)(const X509 *)) const;
-    void _load_integer(ASN1_INTEGER *(*getter)(X509 *)) const;
-    void _load_long(long (*getter)(const X509 *)) const;
-    void _load_time(ASN1_TIME *(*getter)(const X509 *)) const;
+    void _load_name(decltype(&X509_get_subject_name) getter) const;
+    void _load_integer(decltype(&X509_get_serialNumber) getter) const;
+    void _load_long(decltype(&X509_get_version) getter) const;
+    void _load_time(decltype(&X509_get_notBefore) getter) const;
 
     CertBase                                         *_owner = nullptr;
     mutable std::unique_ptr<BIO, decltype(&BIO_free)> _bio{nullptr, BIO_free};

--- a/include/cripts/Certs.hpp
+++ b/include/cripts/Certs.hpp
@@ -107,10 +107,15 @@ public:
       }
     }
 
-    void _load_name(decltype(&X509_get_subject_name) getter) const;
-    void _load_integer(decltype(&X509_get_serialNumber) getter) const;
-    void _load_long(decltype(&X509_get_version) getter) const;
-    void _load_time(decltype(&X509_get_notBefore) getter) const;
+    using NameGetter    = decltype(&X509_get_subject_name);
+    using IntegerGetter = decltype(&X509_get_serialNumber);
+    using LongGetter    = decltype(&X509_get_version);
+    using TimeGetter    = decltype(&X509_get_notBefore);
+
+    void _load_name(NameGetter getter) const;
+    void _load_integer(IntegerGetter getter) const;
+    void _load_long(LongGetter getter) const;
+    void _load_time(TimeGetter getter) const;
 
     CertBase                                         *_owner = nullptr;
     mutable std::unique_ptr<BIO, decltype(&BIO_free)> _bio{nullptr, BIO_free};

--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -401,12 +401,18 @@ mkcrt(const std::string &commonName, int serial)
   X509_gmtime_adj(X509_get_notAfter(cert.get()), static_cast<long>(3650) * 24 * 3600);
 
   // Get handle to subject name
-  X509_NAME *n = X509_get_subject_name(cert.get());
+  X509_NAME *n = X509_NAME_dup(X509_get_subject_name(cert.get()));
   // Set common name field
   if (X509_NAME_add_entry_by_txt(n, "CN", MBSTRING_ASC, (unsigned char *)commonName.c_str(), -1, -1, 0) != 1) {
     TSError("[%s] %s: failed to add certificate subject CN", PLUGIN_NAME, __func__);
     return nullptr;
   }
+  if (X509_set_subject_name(cert.get(), n) != 1) {
+    TSError("[%s] %s: failed to set certificate subject", PLUGIN_NAME, __func__);
+    X509_NAME_free(n);
+    return nullptr;
+  }
+  X509_NAME_free(n);
 
   // Set Traffic Server public key
   if (X509_set_pubkey(cert.get(), ca_pkey_scoped.get()) == 0) {

--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -402,9 +402,14 @@ mkcrt(const std::string &commonName, int serial)
 
   // Get handle to subject name
   X509_NAME *n = X509_NAME_dup(X509_get_subject_name(cert.get()));
+  if (n == nullptr) {
+    TSError("[%s] %s: failed to duplicate certificate subject", PLUGIN_NAME, __func__);
+    return nullptr;
+  }
   // Set common name field
   if (X509_NAME_add_entry_by_txt(n, "CN", MBSTRING_ASC, (unsigned char *)commonName.c_str(), -1, -1, 0) != 1) {
     TSError("[%s] %s: failed to add certificate subject CN", PLUGIN_NAME, __func__);
+    X509_NAME_free(n);
     return nullptr;
   }
   if (X509_set_subject_name(cert.get(), n) != 1) {

--- a/plugins/certifier/certifier.cc
+++ b/plugins/certifier/certifier.cc
@@ -88,10 +88,11 @@ template <> struct default_delete<SSL_CTX> {
 } // namespace std
 
 /// Name aliases for unique pts to openSSL objects
-using scoped_X509     = std::unique_ptr<X509>;
-using scoped_X509_REQ = std::unique_ptr<X509_REQ>;
-using scoped_EVP_PKEY = std::unique_ptr<EVP_PKEY>;
-using scoped_SSL_CTX  = std::unique_ptr<SSL_CTX>;
+using scoped_X509      = std::unique_ptr<X509>;
+using scoped_X509_REQ  = std::unique_ptr<X509_REQ>;
+using scoped_EVP_PKEY  = std::unique_ptr<EVP_PKEY>;
+using scoped_SSL_CTX   = std::unique_ptr<SSL_CTX>;
+using scoped_X509_NAME = std::unique_ptr<X509_NAME, decltype(&X509_NAME_free)>;
 
 class SslLRUList
 {
@@ -401,23 +402,20 @@ mkcrt(const std::string &commonName, int serial)
   X509_gmtime_adj(X509_get_notAfter(cert.get()), static_cast<long>(3650) * 24 * 3600);
 
   // Get handle to subject name
-  X509_NAME *n = X509_NAME_dup(X509_get_subject_name(cert.get()));
+  scoped_X509_NAME n{X509_NAME_dup(X509_get_subject_name(cert.get())), X509_NAME_free};
   if (n == nullptr) {
     TSError("[%s] %s: failed to duplicate certificate subject", PLUGIN_NAME, __func__);
     return nullptr;
   }
   // Set common name field
-  if (X509_NAME_add_entry_by_txt(n, "CN", MBSTRING_ASC, (unsigned char *)commonName.c_str(), -1, -1, 0) != 1) {
+  if (X509_NAME_add_entry_by_txt(n.get(), "CN", MBSTRING_ASC, (unsigned char *)commonName.c_str(), -1, -1, 0) != 1) {
     TSError("[%s] %s: failed to add certificate subject CN", PLUGIN_NAME, __func__);
-    X509_NAME_free(n);
     return nullptr;
   }
-  if (X509_set_subject_name(cert.get(), n) != 1) {
+  if (X509_set_subject_name(cert.get(), n.get()) != 1) {
     TSError("[%s] %s: failed to set certificate subject", PLUGIN_NAME, __func__);
-    X509_NAME_free(n);
     return nullptr;
   }
-  X509_NAME_free(n);
 
   // Set Traffic Server public key
   if (X509_set_pubkey(cert.get(), ca_pkey_scoped.get()) == 0) {

--- a/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
+++ b/plugins/experimental/cert_reporting_tool/cert_reporting_tool.cc
@@ -65,7 +65,7 @@ dump_context(const char *ca_path, const char *ck_path)
         // expiration date, serial number, common name, and subject alternative names
         const ASN1_TIME    *not_after    = X509_get_notAfter(cert);
         const ASN1_INTEGER *serial       = X509_get_serialNumber(cert);
-        X509_NAME          *subject_name = X509_get_subject_name(cert);
+        const X509_NAME    *subject_name = X509_get_subject_name(cert);
 
         // Subject name
         BIO *subject_bio = BIO_new(BIO_s_mem());

--- a/plugins/experimental/sslheaders/expand.cc
+++ b/plugins/experimental/sslheaders/expand.cc
@@ -49,14 +49,14 @@ x509_expand_certificate(X509 *x509, BIO *bio)
 static void
 x509_expand_subject(X509 *x509, BIO *bio)
 {
-  X509_NAME *name = X509_get_subject_name(x509);
+  const X509_NAME *name = X509_get_subject_name(x509);
   X509_NAME_print_ex(bio, name, 0 /* indent */, XN_FLAG_ONELINE);
 }
 
 static void
 x509_expand_issuer(X509 *x509, BIO *bio)
 {
-  X509_NAME *name = X509_get_issuer_name(x509);
+  const X509_NAME *name = X509_get_issuer_name(x509);
   X509_NAME_print_ex(bio, name, 0 /* indent */, XN_FLAG_ONELINE);
 }
 
@@ -72,8 +72,8 @@ x509_expand_signature(X509 *x509, BIO *bio)
 {
   const ASN1_BIT_STRING *sig;
   X509_get0_signature(&sig, nullptr, x509);
-  const char *ptr = reinterpret_cast<const char *>(sig->data);
-  const char *end = ptr + sig->length;
+  const char *ptr = reinterpret_cast<const char *>(ASN1_STRING_get0_data(sig));
+  const char *end = ptr + ASN1_STRING_length(sig);
 
   // The canonical OpenSSL way to format the signature seems to be
   // X509_signature_dump(). However that separates each byte with a ':', which is

--- a/plugins/experimental/txn_box/plugin/src/ts_util.cc
+++ b/plugins/experimental/txn_box/plugin/src/ts_util.cc
@@ -1112,7 +1112,7 @@ ssl_nid(swoc::TextView const &name)
 namespace
 {
   TextView
-  ssl_value_for(X509_NAME *name, int nid)
+  ssl_value_for(const X509_NAME *name, int nid)
   {
     if (int loc = X509_NAME_get_index_by_NID(name, nid, -1); loc >= 0) {
       if (auto entry = X509_NAME_get_entry(name, loc); entry != nullptr) {

--- a/plugins/experimental/txn_box/plugin/src/ts_util.cc
+++ b/plugins/experimental/txn_box/plugin/src/ts_util.cc
@@ -1111,11 +1111,11 @@ ssl_nid(swoc::TextView const &name)
 
 namespace
 {
+  template <typename T>
   TextView
-  ssl_value_for(const X509_NAME *name, int nid)
+  ssl_value_for(T *name, int nid)
   {
-    // const_cast is needed for OpenSSL 1.1.1
-    if (int loc = X509_NAME_get_index_by_NID(const_cast<X509_NAME *>(name), nid, -1); loc >= 0) {
+    if (int loc = X509_NAME_get_index_by_NID(name, nid, -1); loc >= 0) {
       if (auto entry = X509_NAME_get_entry(name, loc); entry != nullptr) {
         if (auto value = X509_NAME_ENTRY_get_data(entry); value != nullptr) {
           return {reinterpret_cast<char const *>(ASN1_STRING_get0_data(value)), size_t(ASN1_STRING_length(value))};

--- a/plugins/experimental/txn_box/plugin/src/ts_util.cc
+++ b/plugins/experimental/txn_box/plugin/src/ts_util.cc
@@ -1111,9 +1111,10 @@ ssl_nid(swoc::TextView const &name)
 
 namespace
 {
-  template <typename T>
+  using X509_NAME_ptr = decltype(X509_get_subject_name(nullptr));
+
   TextView
-  ssl_value_for(T *name, int nid)
+  ssl_value_for(X509_NAME_ptr name, int nid)
   {
     if (int loc = X509_NAME_get_index_by_NID(name, nid, -1); loc >= 0) {
       if (auto entry = X509_NAME_get_entry(name, loc); entry != nullptr) {

--- a/plugins/experimental/txn_box/plugin/src/ts_util.cc
+++ b/plugins/experimental/txn_box/plugin/src/ts_util.cc
@@ -1114,7 +1114,8 @@ namespace
   TextView
   ssl_value_for(const X509_NAME *name, int nid)
   {
-    if (int loc = X509_NAME_get_index_by_NID(name, nid, -1); loc >= 0) {
+    // const_cast is needed for OpenSSL 1.1.1
+    if (int loc = X509_NAME_get_index_by_NID(const_cast<X509_NAME *>(name), nid, -1); loc >= 0) {
       if (auto entry = X509_NAME_get_entry(name, loc); entry != nullptr) {
         if (auto value = X509_NAME_ENTRY_get_data(entry); value != nullptr) {
           return {reinterpret_cast<char const *>(ASN1_STRING_get0_data(value)), size_t(ASN1_STRING_length(value))};

--- a/plugins/lua/ts_lua_client_cert_helpers.h
+++ b/plugins/lua/ts_lua_client_cert_helpers.h
@@ -18,7 +18,7 @@
 
 // Helper functions for certificate data extraction
 static std::string
-get_x509_name_string(X509_NAME *name)
+get_x509_name_string(const X509_NAME *name)
 {
   if (!name) {
     return "";
@@ -157,12 +157,15 @@ get_x509_signature_string(X509 *cert)
     return "";
   }
 
-  for (int i = 0; i < sig->length; i++) {
-    if (BIO_printf(bio, "%02x", sig->data[i]) <= 0) {
+  const unsigned char *sig_data = ASN1_STRING_get0_data(sig);
+  int                  sig_len  = ASN1_STRING_length(sig);
+
+  for (int i = 0; i < sig_len; i++) {
+    if (BIO_printf(bio, "%02x", sig_data[i]) <= 0) {
       BIO_free(bio);
       return "";
     }
-    if (i < sig->length - 1) {
+    if (i < sig_len - 1) {
       if (BIO_printf(bio, ":") <= 0) {
         BIO_free(bio);
         return "";

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -8316,9 +8316,9 @@ TSSslServerCertUpdate(const char *cert_path, const char *key_path)
     }
 
     // Extract common name
-    int              pos              = X509_NAME_get_index_by_NID(X509_get_subject_name(cert.get()), NID_commonName, -1);
-    X509_NAME_ENTRY *common_name      = X509_NAME_get_entry(X509_get_subject_name(cert.get()), pos);
-    ASN1_STRING     *common_name_asn1 = X509_NAME_ENTRY_get_data(common_name);
+    const int              pos              = X509_NAME_get_index_by_NID(X509_get_subject_name(cert.get()), NID_commonName, -1);
+    const X509_NAME_ENTRY *common_name      = X509_NAME_get_entry(X509_get_subject_name(cert.get()), pos);
+    const ASN1_STRING     *common_name_asn1 = X509_NAME_ENTRY_get_data(common_name);
     char *common_name_str = reinterpret_cast<char *>(const_cast<unsigned char *>(ASN1_STRING_get0_data(common_name_asn1)));
     if (ASN1_STRING_length(common_name_asn1) != static_cast<int>(strlen(common_name_str))) {
       // Embedded null char

--- a/src/cripts/Certs.cc
+++ b/src/cripts/Certs.cc
@@ -78,7 +78,7 @@ CertBase::X509Value::_update_value() const
 }
 
 void
-CertBase::X509Value::_load_name(decltype(&X509_get_subject_name) getter) const
+CertBase::X509Value::_load_name(NameGetter getter) const
 {
   if (!_ready && _owner->_x509) {
     auto *name = getter(_owner->_x509);
@@ -95,7 +95,7 @@ CertBase::X509Value::_load_name(decltype(&X509_get_subject_name) getter) const
 }
 
 void
-CertBase::X509Value::_load_integer(decltype(&X509_get_serialNumber) getter) const
+CertBase::X509Value::_load_integer(IntegerGetter getter) const
 {
   if (!_ready && _owner->_x509) {
     auto *value = getter(_owner->_x509);
@@ -107,7 +107,7 @@ CertBase::X509Value::_load_integer(decltype(&X509_get_serialNumber) getter) cons
 }
 
 void
-CertBase::X509Value::_load_long(decltype(&X509_get_version) getter) const
+CertBase::X509Value::_load_long(LongGetter getter) const
 {
   if (!_ready && _owner->_x509) {
     auto value = getter(_owner->_x509);
@@ -119,7 +119,7 @@ CertBase::X509Value::_load_long(decltype(&X509_get_version) getter) const
 }
 
 void
-CertBase::X509Value::_load_time(decltype(&X509_get_notBefore) getter) const
+CertBase::X509Value::_load_time(TimeGetter getter) const
 {
   if (!_ready && _owner->_x509) {
     auto *time = getter(_owner->_x509);

--- a/src/cripts/Certs.cc
+++ b/src/cripts/Certs.cc
@@ -54,8 +54,8 @@ CertBase::Signature::_load() const
   if (!_ready && _owner->_x509) {
     const ASN1_BIT_STRING *sig;
     X509_get0_signature(&sig, nullptr, _owner->_x509);
-    const char *ptr = reinterpret_cast<const char *>(sig->data);
-    const char *end = ptr + sig->length;
+    const char *ptr = reinterpret_cast<const char *>(ASN1_STRING_get0_data(sig));
+    const char *end = ptr + ASN1_STRING_length(sig);
 
     super_type::_load();
     for (; ptr < end; ++ptr) {
@@ -78,7 +78,7 @@ CertBase::X509Value::_update_value() const
 }
 
 void
-CertBase::X509Value::_load_name(X509_NAME *(*getter)(const X509 *)) const
+CertBase::X509Value::_load_name(decltype(&X509_get_subject_name) getter) const
 {
   if (!_ready && _owner->_x509) {
     auto *name = getter(_owner->_x509);
@@ -95,7 +95,7 @@ CertBase::X509Value::_load_name(X509_NAME *(*getter)(const X509 *)) const
 }
 
 void
-CertBase::X509Value::_load_integer(ASN1_INTEGER *(*getter)(X509 *)) const
+CertBase::X509Value::_load_integer(decltype(&X509_get_serialNumber) getter) const
 {
   if (!_ready && _owner->_x509) {
     auto *value = getter(_owner->_x509);
@@ -107,7 +107,7 @@ CertBase::X509Value::_load_integer(ASN1_INTEGER *(*getter)(X509 *)) const
 }
 
 void
-CertBase::X509Value::_load_long(long (*getter)(const X509 *)) const
+CertBase::X509Value::_load_long(decltype(&X509_get_version) getter) const
 {
   if (!_ready && _owner->_x509) {
     auto value = getter(_owner->_x509);
@@ -119,7 +119,7 @@ CertBase::X509Value::_load_long(long (*getter)(const X509 *)) const
 }
 
 void
-CertBase::X509Value::_load_time(ASN1_TIME *(*getter)(const X509 *)) const
+CertBase::X509Value::_load_time(decltype(&X509_get_notBefore) getter) const
 {
   if (!_ready && _owner->_x509) {
     auto *time = getter(_owner->_x509);
@@ -153,8 +153,8 @@ namespace
   _write_ip_address(const ASN1_OCTET_STRING *ip, BIO *_bio)
   {
     char                 buffer[INET6_ADDRSTRLEN];
-    const unsigned char *raw = ip->data;
-    int                  len = ip->length;
+    const unsigned char *raw = ASN1_STRING_get0_data(ip);
+    int                  len = ASN1_STRING_length(ip);
 
     if (inet_ntop(len == 4 ? AF_INET : AF_INET6, raw, buffer, sizeof(buffer))) {
       BIO_printf(_bio, "%s", buffer);

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -490,7 +490,7 @@ TS_OCSP_cert_id_new(const EVP_MD *dgst, const X509_NAME *issuerName, const ASN1_
   }
 
   /* Calculate the issuerKey hash, excluding tag and length */
-  if (!EVP_Digest(issuerKey->data, issuerKey->length, md, &i, dgst, nullptr)) {
+  if (!EVP_Digest(ASN1_STRING_get0_data(issuerKey), ASN1_STRING_length(issuerKey), md, &i, dgst, nullptr)) {
     goto err;
   }
 
@@ -516,7 +516,7 @@ TS_OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject, const X509 *issuer)
 {
   const X509_NAME    *iname;
   const ASN1_INTEGER *serial;
-  ASN1_BIT_STRING    *ikey;
+  const ASN1_BIT_STRING    *ikey;
 
   if (!dgst) {
     dgst = EVP_sha1();

--- a/src/iocore/net/OCSPStapling.cc
+++ b/src/iocore/net/OCSPStapling.cc
@@ -514,9 +514,9 @@ err:
 TS_OCSP_CERTID *
 TS_OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject, const X509 *issuer)
 {
-  const X509_NAME    *iname;
-  const ASN1_INTEGER *serial;
-  const ASN1_BIT_STRING    *ikey;
+  const X509_NAME       *iname;
+  const ASN1_INTEGER    *serial;
+  const ASN1_BIT_STRING *ikey;
 
   if (!dgst) {
     dgst = EVP_sha1();

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -167,7 +167,7 @@ SSLNetVConnection::_unbindSSLObject()
 }
 
 static void
-debug_certificate_name(const char *msg, X509_NAME *name)
+debug_certificate_name(const char *msg, const X509_NAME *name)
 {
   BIO *bio;
 

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -2220,7 +2220,8 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
     if (subject) {
       int pos = -1;
       for (;;) {
-        pos = X509_NAME_get_index_by_NID(subject, NID_commonName, pos);
+        // const_cast is needed for OpenSSL 1.1.1
+        pos = X509_NAME_get_index_by_NID(const_cast<X509_NAME *>(subject), NID_commonName, pos);
         if (pos == -1) {
           break;
         }

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -1004,7 +1004,7 @@ SSLMultiCertConfigLoader::check_server_cert_now(X509 *cert, const char *certname
 } /* CheckServerCertNow() */
 
 static char *
-asn1_strdup(ASN1_STRING *s)
+asn1_strdup(const ASN1_STRING *s)
 {
   // Make sure we have an 8-bit encoding.
   ink_assert(ASN1_STRING_type(s) == V_ASN1_IA5STRING || ASN1_STRING_type(s) == V_ASN1_UTF8STRING ||
@@ -2212,7 +2212,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
     std::set<std::string> name_set;
     // Grub through the names in the certs
-    X509_NAME *subject = nullptr;
+    const X509_NAME *subject = nullptr;
 
     // Insert a key for the subject CN.
     subject = X509_get_subject_name(cert);
@@ -2225,8 +2225,8 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
           break;
         }
 
-        X509_NAME_ENTRY *e  = X509_NAME_get_entry(subject, pos);
-        ASN1_STRING     *cn = X509_NAME_ENTRY_get_data(e);
+        const X509_NAME_ENTRY *e  = X509_NAME_get_entry(subject, pos);
+        const ASN1_STRING     *cn = X509_NAME_ENTRY_get_data(e);
         subj_name           = asn1_strdup(cn);
 
         Dbg(dbg_ctl_ssl_load, "subj '%s' in certificate %s %p", subj_name.get(), data.cert_names_list[i].c_str(), cert);

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -2212,16 +2212,14 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
     std::set<std::string> name_set;
     // Grub through the names in the certs
-    const X509_NAME *subject = nullptr;
 
     // Insert a key for the subject CN.
-    subject = X509_get_subject_name(cert);
+    auto          *subject = X509_get_subject_name(cert);
     ats_scoped_str subj_name;
     if (subject) {
       int pos = -1;
       for (;;) {
-        // const_cast is needed for OpenSSL 1.1.1
-        pos = X509_NAME_get_index_by_NID(const_cast<X509_NAME *>(subject), NID_commonName, pos);
+        pos = X509_NAME_get_index_by_NID(subject, NID_commonName, pos);
         if (pos == -1) {
           break;
         }

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -2227,7 +2227,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
         const X509_NAME_ENTRY *e  = X509_NAME_get_entry(subject, pos);
         const ASN1_STRING     *cn = X509_NAME_ENTRY_get_data(e);
-        subj_name           = asn1_strdup(cn);
+        subj_name                 = asn1_strdup(cn);
 
         Dbg(dbg_ctl_ssl_load, "subj '%s' in certificate %s %p", subj_name.get(), data.cert_names_list[i].c_str(), cert);
         name_set.insert(subj_name.get());

--- a/src/iocore/net/unit_tests/test_SSLDHParams.cc
+++ b/src/iocore/net/unit_tests/test_SSLDHParams.cc
@@ -132,9 +132,12 @@ make_cert_and_key(EVP_CIPHER const *cipher = nullptr, char *pass = nullptr)
   X509_gmtime_adj(X509_getm_notAfter(x509), 60L * 60L * 24L * 365L);
   REQUIRE(X509_set_pubkey(x509, pkey) == 1);
 
-  X509_NAME *name = X509_get_subject_name(x509);
+  X509_NAME *name = X509_NAME_dup(X509_get_subject_name(x509));
+  REQUIRE(name != nullptr);
   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<unsigned char const *>("ats-test"), -1, -1, 0);
+  REQUIRE(X509_set_subject_name(x509, name) == 1);
   REQUIRE(X509_set_issuer_name(x509, name) == 1);
+  X509_NAME_free(name);
   REQUIRE(X509_sign(x509, pkey, EVP_sha256()) > 0);
 
   BIO *cert_bio = BIO_new(BIO_s_mem());

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -272,7 +272,8 @@ validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peernam
   i    = -1;
   name = X509_get_subject_name(x);
 
-  while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
+  // const_cast is needed for OpenSSL 1.1.1
+  while ((i = X509_NAME_get_index_by_NID(const_cast<X509_NAME *>(name), NID_commonName, i)) >= 0) {
     const ASN1_STRING *str;
     int                astrlen;
     unsigned char     *astr;

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -211,7 +211,7 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
   }
   retval = equal(ASN1_STRING_get0_data(a), ASN1_STRING_length(a), b, blen);
   if (retval && peername) {
-    *peername = ats_strndup((char *)ASN1_STRING_get0_data(a), ASN1_STRING_length(a));
+    *peername = ats_strndup((const char *)ASN1_STRING_get0_data(a), ASN1_STRING_length(a));
   }
   return retval;
 }

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -219,11 +219,10 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
 bool
 validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peername)
 {
-  GENERAL_NAMES   *gens = nullptr;
-  const X509_NAME *name = nullptr;
-  int              i;
-  int              alt_type;
-  bool             retval = false;
+  GENERAL_NAMES *gens = nullptr;
+  int            i;
+  int            alt_type;
+  bool           retval = false;
   ;
   equal_fn    equal;
   auto const *hostname_data = reinterpret_cast<const unsigned char *>(hostname.data());
@@ -269,11 +268,10 @@ validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peernam
     }
   }
   // No SAN match -- check the subject
-  i    = -1;
-  name = X509_get_subject_name(x);
+  i          = -1;
+  auto *name = X509_get_subject_name(x);
 
-  // const_cast is needed for OpenSSL 1.1.1
-  while ((i = X509_NAME_get_index_by_NID(const_cast<X509_NAME *>(name), NID_commonName, i)) >= 0) {
+  while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
     const ASN1_STRING *str;
     int                astrlen;
     unsigned char     *astr;

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -211,7 +211,7 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
   }
   retval = equal(ASN1_STRING_get0_data(a), ASN1_STRING_length(a), b, blen);
   if (retval && peername) {
-    *peername = ats_strndup((const char *)ASN1_STRING_get0_data(a), ASN1_STRING_length(a));
+    *peername = ats_strndup(reinterpret_cast<const char *>(ASN1_STRING_get0_data(a)), ASN1_STRING_length(a));
   }
   return retval;
 }

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -221,9 +221,9 @@ validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peernam
 {
   GENERAL_NAMES   *gens = nullptr;
   const X509_NAME *name = nullptr;
-  int             i;
-  int             alt_type;
-  bool            retval = false;
+  int              i;
+  int              alt_type;
+  bool             retval = false;
   ;
   equal_fn    equal;
   auto const *hostname_data = reinterpret_cast<const unsigned char *>(hostname.data());
@@ -273,9 +273,9 @@ validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peernam
   name = X509_get_subject_name(x);
 
   while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
-    const ASN1_STRING   *str;
-    int                 astrlen;
-    unsigned char       *astr;
+    const ASN1_STRING *str;
+    int                astrlen;
+    unsigned char     *astr;
     str = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     // Convert to UTF-8
     astrlen = ASN1_STRING_to_UTF8(&astr, str);

--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -206,12 +206,12 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
 {
   bool retval = false;
 
-  if (!a->data || !a->length || cmp_type != a->type) {
+  if (!ASN1_STRING_get0_data(a) || !ASN1_STRING_length(a) || cmp_type != ASN1_STRING_type(a)) {
     return false;
   }
-  retval = equal(a->data, a->length, b, blen);
+  retval = equal(ASN1_STRING_get0_data(a), ASN1_STRING_length(a), b, blen);
   if (retval && peername) {
-    *peername = ats_strndup((char *)a->data, a->length);
+    *peername = ats_strndup((char *)ASN1_STRING_get0_data(a), ASN1_STRING_length(a));
   }
   return retval;
 }
@@ -219,11 +219,11 @@ do_check_string(ASN1_STRING *a, int cmp_type, equal_fn equal, const unsigned cha
 bool
 validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peername)
 {
-  GENERAL_NAMES *gens = nullptr;
-  X509_NAME     *name = nullptr;
-  int            i;
-  int            alt_type;
-  bool           retval = false;
+  GENERAL_NAMES   *gens = nullptr;
+  const X509_NAME *name = nullptr;
+  int             i;
+  int             alt_type;
+  bool            retval = false;
   ;
   equal_fn    equal;
   auto const *hostname_data = reinterpret_cast<const unsigned char *>(hostname.data());
@@ -273,9 +273,9 @@ validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peernam
   name = X509_get_subject_name(x);
 
   while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0) {
-    ASN1_STRING   *str;
-    int            astrlen;
-    unsigned char *astr;
+    const ASN1_STRING   *str;
+    int                 astrlen;
+    unsigned char       *astr;
     str = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name, i));
     // Convert to UTF-8
     astrlen = ASN1_STRING_to_UTF8(&astr, str);

--- a/tests/tools/plugins/ssl_client_verify_test.cc
+++ b/tests/tools/plugins/ssl_client_verify_test.cc
@@ -58,7 +58,7 @@ check_names(X509 *cert)
   bool retval = false;
 
   // Check the common name
-  X509_NAME *subject = X509_get_subject_name(cert);
+  auto *subject = X509_get_subject_name(cert);
   if (subject) {
     int pos = -1;
     for (; !retval;) {
@@ -67,10 +67,10 @@ check_names(X509 *cert)
         break;
       }
 
-      X509_NAME_ENTRY *e         = X509_NAME_get_entry(subject, pos);
-      ASN1_STRING     *cn        = X509_NAME_ENTRY_get_data(e);
-      char            *subj_name = strndup(reinterpret_cast<const char *>(ASN1_STRING_get0_data(cn)), ASN1_STRING_length(cn));
-      retval                     = check_name(subj_name);
+      auto *e         = X509_NAME_get_entry(subject, pos);
+      auto *cn        = X509_NAME_ENTRY_get_data(e);
+      char *subj_name = strndup(reinterpret_cast<const char *>(ASN1_STRING_get0_data(cn)), ASN1_STRING_length(cn));
+      retval          = check_name(subj_name);
       free(subj_name);
     }
   }


### PR DESCRIPTION
## Summary

Continues #13440 ("Resolve OpenSSL 4.0 build issues"), fixing the remaining CI failures on Ubuntu 20.04 and FreeBSD 13.1 (OpenSSL 1.1.1) flagged in review.

`X509_NAME_get_index_by_NID()` takes a non-const `X509_NAME *` on OpenSSL 1.1.1 but a `const X509_NAME *` on OpenSSL 3.0+ and post-constify OpenSSL/BoringSSL. The original PR widened several `X509_NAME`-typed variables to `const` to build against the newer, constified signature, which broke the older signature at three call sites:

- `src/tscore/X509HostnameValidator.cc` — `validate_hostname()`
- `src/iocore/net/SSLUtils.cc` — `SSLMultiCertConfigLoader::load_certs_and_cross_reference_names()`
- `plugins/experimental/txn_box/plugin/src/ts_util.cc` — `ssl_value_for()`

Each call site now does `const_cast<X509_NAME *>(...)`, matching the existing precedent in `OCSPStapling.cc` for the same kind of OpenSSL-version const mismatch.

## Test plan

- [x] Built `tscore`, `inknet`, and `txn_box` targets locally against BoringSSL — all compile clean
- [x] Ran `cmake --build build -t format` — no additional changes
- [ ] CI to confirm the Ubuntu 20.04 / FreeBSD 13.1 (OpenSSL 1.1.1) jobs that failed on #13440 now pass
```