### PR TITLE
Rename `OPENSSL_IS_X` -> `OPENSSL_IS_AT_LEAST_X`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,8 +313,8 @@ if(NOT SSLLIB_IS_BORINGSSL
    AND NOT SSLLIB_IS_AWSLC
    AND OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0"
 )
-  set(SSLLIB_IS_OPENSSL3 TRUE)
-  add_compile_definitions(OPENSSL_API_COMPAT=10002 OPENSSL_IS_OPENSSL3)
+  set(SSLLIB_IS_AT_LEAST_OPENSSL3 TRUE)
+  add_compile_definitions(OPENSSL_API_COMPAT=10002 OPENSSL_IS_AT_LEAST_OPENSSL3)
 endif()
 
 check_openssl_has_quic_tls_cbs(SSLLIB_HAS_QUIC_TLS_CBS "${OPENSSL_INCLUDE_DIR}")
@@ -630,7 +630,7 @@ check_symbol_exists(ENGINE_get_default_RSA "openssl/engine.h" HAVE_ENGINE_GET_DE
 check_symbol_exists(ENGINE_load_private_key "openssl/engine.h" HAVE_ENGINE_LOAD_PRIVATE_KEY)
 check_symbol_exists(sysctlbyname "sys/sysctl.h" HAVE_SYSCTLBYNAME)
 
-if(SSLLIB_IS_OPENSSL3)
+if(SSLLIB_IS_AT_LEAST_OPENSSL3)
   check_symbol_exists(SSL_CTX_set_tlsext_ticket_key_evp_cb "openssl/ssl.h" TS_HAS_TLS_SESSION_TICKET)
 else()
   check_symbol_exists(SSL_CTX_set_tlsext_ticket_key_cb "openssl/ssl.h" TS_HAS_TLS_SESSION_TICKET)

--- a/example/plugins/c-api/verify_cert/verify_cert.cc
+++ b/example/plugins/c-api/verify_cert/verify_cert.cc
@@ -66,7 +66,7 @@ CB_clientcert(TSCont /* contp */, TSEvent /* event */, void *edata)
   TSVConn         ssl_vc = reinterpret_cast<TSVConn>(edata);
   TSSslConnection sslobj = TSVConnSslConnectionGet(ssl_vc);
   SSL            *ssl    = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
   X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
   X509 *cert = SSL_get_peer_certificate(ssl);

--- a/include/cripts/Connections.hpp
+++ b/include/cripts/Connections.hpp
@@ -365,7 +365,7 @@ class ConnBase
       auto conn = Connection();
 
       if (mTLS) {
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
         return SSL_get1_peer_certificate(reinterpret_cast<::SSL *>(conn));
 #else
         return SSL_get_peer_certificate(reinterpret_cast<::SSL *>(conn));

--- a/plugins/experimental/access_control/unit_tests/test_utils.cc
+++ b/plugins/experimental/access_control/unit_tests/test_utils.cc
@@ -252,7 +252,7 @@ TEST_CASE("HMAC Digest: test various supported/unsupported types", "[MAC][access
   digests.push_back("ccf3230972bcf229fb3b16741495c74a72bbdd14");
 #endif
 
-#ifdef OPENSSL_IS_OPENSSL3 // MD4, RIPEMD160 are deprecated in OpenSSL 3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3 // MD4, RIPEMD160 are deprecated in OpenSSL 3
   types.pop_front();
   digests.pop_front();
   types.pop_back();

--- a/plugins/experimental/sslheaders/sslheaders.cc
+++ b/plugins/experimental/sslheaders/sslheaders.cc
@@ -159,7 +159,7 @@ private:
   void
   _set()
   {
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     _x509 = (IsClient ? SSL_get1_peer_certificate : SSL_get_certificate)(_ssl);
 #else
     _x509 = (IsClient ? SSL_get_peer_certificate : SSL_get_certificate)(_ssl);

--- a/plugins/experimental/wasm/ats_context.cc
+++ b/plugins/experimental/wasm/ats_context.cc
@@ -719,7 +719,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);
@@ -787,7 +787,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);
@@ -825,7 +825,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);
@@ -863,7 +863,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnClientVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);
@@ -952,7 +952,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnServerVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);
@@ -990,7 +990,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnServerVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1028,7 +1028,7 @@ Context::getProperty(std::string_view path, std::string *result)
     TSVConn         client_conn = TSHttpSsnServerVConnGet(ssnp);
     TSSslConnection sslobj      = TSVConnSslConnectionGet(client_conn);
     SSL            *ssl         = reinterpret_cast<SSL *>(sslobj);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(ssl);

--- a/plugins/lua/ts_lua_client_request.cc
+++ b/plugins/lua/ts_lua_client_request.cc
@@ -1299,7 +1299,7 @@ ts_lua_client_request_client_cert_get_pem(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1335,7 +1335,7 @@ ts_lua_client_request_client_cert_get_subject(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1371,7 +1371,7 @@ ts_lua_client_request_client_cert_get_issuer(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1407,7 +1407,7 @@ ts_lua_client_request_client_cert_get_serial(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1443,7 +1443,7 @@ ts_lua_client_request_client_cert_get_signature(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1479,7 +1479,7 @@ ts_lua_client_request_client_cert_get_not_before(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1515,7 +1515,7 @@ ts_lua_client_request_client_cert_get_not_after(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1551,7 +1551,7 @@ ts_lua_client_request_client_cert_get_version(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1585,7 +1585,7 @@ ts_lua_client_request_client_cert_get_san_dns(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1626,7 +1626,7 @@ ts_lua_client_request_client_cert_get_san_ip(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1667,7 +1667,7 @@ ts_lua_client_request_client_cert_get_san_email(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1708,7 +1708,7 @@ ts_lua_client_request_client_cert_get_san_uri(lua_State *L)
     TSSslConnection ssl_conn = TSVConnSslConnectionGet(client_conn);
     if (ssl_conn) {
       SSL *ssl = reinterpret_cast<SSL *>(ssl_conn);
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -146,7 +146,7 @@ if(BUILD_TESTING)
     unit_tests/test_OCSPStapling.cc
     unit_tests/unit_test_main.cc
   )
-  if(SSLLIB_IS_OPENSSL3)
+  if(SSLLIB_IS_AT_LEAST_OPENSSL3)
     target_sources(test_net PRIVATE unit_tests/test_SSLDHParams.cc)
   endif()
   # Use link groups to solve circular dependency

--- a/src/iocore/net/P_SSLNetVConnection.h
+++ b/src/iocore/net/P_SSLNetVConnection.h
@@ -258,7 +258,7 @@ public:
   bool
   peer_provided_cert() const override
   {
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
     X509 *cert = SSL_get1_peer_certificate(this->ssl);
 #else
     X509 *cert = SSL_get_peer_certificate(this->ssl);

--- a/src/iocore/net/P_SSLUtils.h
+++ b/src/iocore/net/P_SSLUtils.h
@@ -25,7 +25,7 @@
 #include "iocore/net/SSLTypes.h"
 #include "tscore/Diags.h"
 
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 #include <openssl/decoder.h>
 #include <openssl/evp.h>
 #endif
@@ -114,7 +114,7 @@ namespace detail
     }
   };
 
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
   struct PKEYCTXDeleter {
     void
     operator()(EVP_PKEY_CTX *pctx)
@@ -156,7 +156,7 @@ private:
 
 using scoped_X509 = std::unique_ptr<X509, ssl::detail::X509Deleter>;
 using scoped_BIO  = std::unique_ptr<BIO, ssl::detail::BIODeleter>;
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 using scoped_PKEY_CTX    = std::unique_ptr<EVP_PKEY_CTX, ssl::detail::PKEYCTXDeleter>;
 using scoped_Decoder_CTX = std::unique_ptr<OSSL_DECODER_CTX, ssl::detail::DecoderCTXDeleter>;
 #endif

--- a/src/iocore/net/SSLClientUtils.cc
+++ b/src/iocore/net/SSLClientUtils.cc
@@ -177,7 +177,7 @@ validate_server_certificate_hostname(NetVConnection *netvc, std::string_view hos
   char      *matched_name = nullptr;
   bool const enforce_mode = netvc->options.verifyServerPolicy == YamlSNIConfig::Policy::ENFORCED;
   bool       verified     = false;
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
   X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
   X509 *cert = SSL_get_peer_certificate(ssl);

--- a/src/iocore/net/SSLKeyUtils.cc
+++ b/src/iocore/net/SSLKeyUtils.cc
@@ -23,13 +23,13 @@
 #include "P_SSLUtils.h"
 
 #include <tscore/Diags.h>
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 #include <tscore/ink_assert.h>
 #else
 #include <tscore/ink_config.h>
 #endif
 
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 #include <openssl/evp.h>
 #include <openssl/decoder.h>
 #include <openssl/params.h>
@@ -41,7 +41,7 @@
 #include <openssl/ssl.h>
 #endif
 
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 
 EVP_PKEY *
 gen_dh_2048_256_pkey()
@@ -187,4 +187,4 @@ set_ctx_dh(SSL_CTX *ctx, dh_key_t *pkey)
   return result;
 }
 
-#endif // OPENSSL_IS_OPENSSL3
+#endif // OPENSSL_IS_AT_LEAST_OPENSSL3

--- a/src/iocore/net/SSLKeyUtils.h
+++ b/src/iocore/net/SSLKeyUtils.h
@@ -21,14 +21,14 @@
 
 #pragma once
 
-#if OPENSSL_IS_OPENSSL3
+#if OPENSSL_IS_AT_LEAST_OPENSSL3
 #include <openssl/evp.h>
 #else
 #include <openssl/dh.h>
 #endif
 #include <openssl/ssl.h>
 
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 using dh_key_t = EVP_PKEY;
 #else
 using dh_key_t = DH;

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -1429,7 +1429,7 @@ SSLNetVConnection::sslServerHandShakeEvent(int &err)
   switch (ssl_error) {
   case SSL_ERROR_NONE:
     if (dbg_ctl_ssl.on()) {
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);
@@ -1611,7 +1611,7 @@ SSLNetVConnection::sslClientHandShakeEvent(int &err)
   switch (ssl_error) {
   case SSL_ERROR_NONE:
     if (dbg_ctl_ssl.on()) {
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
       X509 *cert = SSL_get1_peer_certificate(ssl);
 #else
       X509 *cert = SSL_get_peer_certificate(ssl);

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -57,7 +57,7 @@
 #include <openssl/asn1.h>
 #include <openssl/bio.h>
 #include <openssl/conf.h>
-#ifdef OPENSSL_IS_OPENSSL3
+#ifdef OPENSSL_IS_AT_LEAST_OPENSSL3
 #include <openssl/evp.h>
 #endif
 #include <openssl/dh.h>

--- a/src/tscore/CMakeLists.txt
+++ b/src/tscore/CMakeLists.txt
@@ -100,7 +100,7 @@ set_target_properties(tscore PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 if(SSLLIB_IS_BORINGSSL OR SSLLIB_IS_AWSLC)
   target_sources(tscore PRIVATE HKDF_boringssl.cc)
-elseif(SSLLIB_IS_OPENSSL3)
+elseif(SSLLIB_IS_AT_LEAST_OPENSSL3)
   target_sources(tscore PRIVATE HKDF_openssl3.cc)
 else()
   target_sources(tscore PRIVATE HKDF_openssl.cc)


### PR DESCRIPTION
This is for consistency since there is now OpenSSL 4, and we need to add a macro definition for OpenSSL 4 as well.