### PR TITLE
header_rewrite: inherit default hook support

### DIFF
--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1242,20 +1242,6 @@ OperatorSetPluginCntl::initialize(Parser &p)
   }
 }
 
-// This operator should be allowed everywhere
-void
-OperatorSetPluginCntl::initialize_hooks()
-{
-  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
-  add_allowed_hook(TS_HTTP_PRE_REMAP_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_START_HOOK);
-}
-
 bool
 OperatorSetPluginCntl::exec(const Resources &res) const
 {
@@ -1431,20 +1417,6 @@ OperatorSetStateFlag::initialize(Parser &p)
   }
 }
 
-// This operator should be allowed everywhere
-void
-OperatorSetStateFlag::initialize_hooks()
-{
-  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
-  add_allowed_hook(TS_HTTP_PRE_REMAP_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_START_HOOK);
-}
-
 bool
 OperatorSetStateFlag::exec(const Resources &res) const
 {
@@ -1483,20 +1455,6 @@ OperatorSetStateInt8::initialize(Parser &p)
       return;
     }
   }
-}
-
-// This operator should be allowed everywhere
-void
-OperatorSetStateInt8::initialize_hooks()
-{
-  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
-  add_allowed_hook(TS_HTTP_PRE_REMAP_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_START_HOOK);
 }
 
 bool
@@ -1553,20 +1511,6 @@ OperatorSetStateInt16::initialize(Parser &p)
       return;
     }
   }
-}
-
-// This operator should be allowed everywhere
-void
-OperatorSetStateInt16::initialize_hooks()
-{
-  add_allowed_hook(TS_HTTP_READ_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_READ_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_RESPONSE_HDR_HOOK);
-  add_allowed_hook(TS_REMAP_PSEUDO_HOOK);
-  add_allowed_hook(TS_HTTP_PRE_REMAP_HOOK);
-  add_allowed_hook(TS_HTTP_SEND_REQUEST_HDR_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_CLOSE_HOOK);
-  add_allowed_hook(TS_HTTP_TXN_START_HOOK);
 }
 
 bool

--- a/plugins/header_rewrite/operators.h
+++ b/plugins/header_rewrite/operators.h
@@ -477,7 +477,6 @@ public:
   };
 
 protected:
-  void initialize_hooks() override;
   bool exec(const Resources &res) const override;
 
   bool
@@ -560,7 +559,6 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void initialize_hooks() override;
   bool exec(const Resources &res) const override;
 
   bool
@@ -598,7 +596,6 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void initialize_hooks() override;
   bool exec(const Resources &res) const override;
 
   bool
@@ -635,7 +632,6 @@ public:
   void initialize(Parser &p) override;
 
 protected:
-  void initialize_hooks() override;
   bool exec(const Resources &res) const override;
 
   bool

--- a/tests/gold_tests/pluginTest/header_rewrite/post_remap.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/post_remap.conf
@@ -17,11 +17,16 @@
 
 # Global header_rewrite ruleset that fires after remapping, on the remapped
 # request, before the cache lookup. The value is the remapped host, so an
-# earlier hook would record the pristine host instead.
+# earlier hook would record the pristine host instead. Setting a state flag
+# also verifies that operators which inherit the default hook list are valid
+# at POST_REMAP_HOOK.
 cond %{POST_REMAP_HOOK}
+  set-state-flag 0 true
   set-header X-Post-Remap-Host "%{URL:HOST}"
 
 # Echo the post-remap header into the client response so the rule above can be
-# observed on a cache hit, where no request is forwarded to the origin.
+# observed on a cache hit, where no request is forwarded to the origin. The
+# state condition proves that the state operator also ran at POST_REMAP_HOOK.
 cond %{SEND_RESPONSE_HDR_HOOK}
+cond %{STATE-FLAG:0} =TRUE
   set-header X-Post-Remap-Echo "%{CLIENT-HEADER:X-Post-Remap-Host}"


### PR DESCRIPTION
Operators intended for every hook maintained private copies of the
default allowlist. New hooks added to Statement could therefore remain
unavailable for plugin controls and transaction or session state,
causing otherwise valid configurations to be rejected.

This patch lets those operators inherit Statement's default allowlist
and extends the POST_REMAP AuTest to exercise a state operator. Future
default hooks will now be available without updating duplicate lists.