### PR TITLE
Fix wrong variable in eventloop events max metric

### DIFF
--- a/include/iocore/eventsystem/EThread.h
+++ b/include/iocore/eventsystem/EThread.h
@@ -613,7 +613,7 @@ EThread::Metrics::Slice::record_event_count(int count) -> self_type &
     _events._min = count;
   }
   if (count > _events._max) {
-    _events._max = _count;
+    _events._max = count;
   }
   _events._total += count;
   return *this;


### PR DESCRIPTION
The code for counting eventloop events max used the incorrect `_count` variable, which stores the number of _iterations_, rather than the number of _events_. `proxy.process.eventloop.events.max.*` has therefore been reporting an iteration count. Fix it by changing the code to use `count`.
