### PR TITLE
Track minimum-only origin connections

### DIFF
--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -5863,7 +5863,8 @@ HttpSM::do_http_server_open(bool raw, bool only_direct)
     }
 
     ct_state.update_max_count(ccount);
-  } else if (t_state.http_config_param->global_connection_tracker_config.metric_enabled) {
+  } else if (t_state.txn_conf->connection_tracker_config.server_min > 0 ||
+             t_state.http_config_param->global_connection_tracker_config.metric_enabled) {
     auto &ct_state = t_state.outbound_conn_track_state;
     ct_state.reserve();
   }

--- a/tests/gold_tests/origin_connection/minimum_keep_alive.replay.yaml
+++ b/tests/gold_tests/origin_connection/minimum_keep_alive.replay.yaml
@@ -1,0 +1,115 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+autest:
+  description: 'Retain the per-server minimum without a maximum or metrics'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+    process_config:
+      enable_tls: false
+      enable_cache: false
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'http_ss|conn_track'
+      proxy.config.http.keep_alive_no_activity_timeout_out: 1
+      proxy.config.http.per_server.connection.max: 0
+      proxy.config.http.per_server.connection.min: 1
+      proxy.config.http.per_server.connection.metric_enabled: 0
+      proxy.config.http.per_server.connection.match: 'port'
+      proxy.config.http.server_session_sharing.pool: 'global'
+
+    remap_config:
+      - from: "http://www.example.com/"
+        to: "http://127.0.0.1:{SERVER_HTTP_PORT}/"
+
+# Run three transactions concurrently and stagger their responses so that the
+# resulting pooled origin sessions reach their inactivity timeouts in order.
+# ATS should close the first two sessions and keep the final one.
+sessions:
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /first
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, first ]
+
+    server-response:
+      delay: 1s
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    proxy-response:
+      status: 200
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /second
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, second ]
+
+    server-response:
+      delay: 2s
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    proxy-response:
+      status: 200
+
+- transactions:
+  - client-request:
+      method: GET
+      url: /third
+      version: '1.1'
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, third ]
+
+    server-response:
+      delay: 3s
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/origin_connection/per_server_connection_min.test.py
+++ b/tests/gold_tests/origin_connection/per_server_connection_min.test.py
@@ -1,0 +1,29 @@
+'''
+Verify the behavior of proxy.config.http.per_server.connection.min.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = __doc__
+
+replay_run = Test.ATSReplayTest(replay_file='minimum_keep_alive.replay.yaml')
+checker = replay_run.Processes.Process('connection-count')
+checker.Command = 'sleep 5; traffic_ctl metric get proxy.process.http.current_server_connections'
+checker.ReturnCode = 0
+checker.Env = replay_run.Processes.ts.Env
+checker.Streams.stdout = Testers.ContainsExpression(
+    r'^proxy\.process\.http\.current_server_connections\s+1$', 'The origin connection pool should retain exactly one connection.')
+checker.StartBefore(replay_run.Processes.ts)


### PR DESCRIPTION
A per-server keep-alive minimum without a connection maximum or
per-server metrics created a tracker group but never reserved it.
The count remained zero, so idle origin sessions were retained
without limit and their eventual release reported invalid accounting.

Reserve the tracker whenever the keep-alive minimum needs it, and add
replay coverage that lets surplus pooled sessions expire while
preserving the configured minimum.

---

This added test fails, giving a value of 0 without this patch, and
showing the tracked value (1) with it.