### PR TITLE
autest: skip tls_engine_abort test when plugin is absent

### DIFF
--- a/tests/gold_tests/tls/tls_engine_abort.test.py
+++ b/tests/gold_tests/tls/tls_engine_abort.test.py
@@ -42,7 +42,8 @@ server = Test.MakeOriginServer("server")
 
 # A wide pause window (well beyond the abort client's 0.4s handshake attempt)
 # so the abort reliably lands while the async job is still in flight.
-Test.PrepareTestPlugin(async_handshake, ts, '-delay-ms=2000')
+if os.path.isfile(async_handshake):
+    Test.PrepareTestPlugin(async_handshake, ts, '-delay-ms=2000')
 
 server.addResponse(
     "sessionlog.json", {


### PR DESCRIPTION
## Description

`tls_engine_abort.test.py` calls `Test.PrepareTestPlugin(async_handshake, ts, '-delay-ms=2000')`
unconditionally. On non-OpenSSL builds (e.g. BoringSSL) `async_handshake.so` is
never built, so this raises `ValueError: PrepareTestPlugin: file does not
exist: ...` and the test errors out instead of skipping cleanly.

`Test.SkipUnless(...)` only registers skip conditions for the framework to
check later — it does not halt execution of the rest of the test script. So
even though the file already guards on:

```python
Test.SkipUnless(
    Condition.HasOpenSSLVersion('1.1.1'),
    Condition.IsOpenSSL(),
    Condition(lambda: os.path.isfile(async_handshake), async_handshake + " not found."),
)
```

the `Test.PrepareTestPlugin(...)` call still runs at load time regardless.

This is the same gap #13372 fixed in `tls_async_handshake.test.py`.
`tls_engine_abort.test.py` was added afterward from that file as a template
but didn't carry the guard over. This PR applies the same fix: guard the call
on file existence so the test skips cleanly on non-OpenSSL builds.

## Test plan

- Ran the autest on a non-OpenSSL (BoringSSL) build; test now skips instead
  of erroring.
- Ran the autest on an OpenSSL build; test still runs and passes as before.
```
