### PR TITLE
Fall back to the build directory when GIT_COMMON_DIR is unset

### DIFF
--- a/cmake/proxy-verifier.cmake
+++ b/cmake/proxy-verifier.cmake
@@ -15,7 +15,7 @@
 #
 #######################
 
-# This will download and extract proxy-verifier to git common directory and setup variables to point to it.
+# This will download and extract proxy-verifier to PV_DEST_DIR and setup variables to point to it.
 #
 # Required variables:
 #   PROXY_VERIFIER_VERSION
@@ -23,6 +23,7 @@
 #
 # Defines variables:
 #
+#   PV_DEST_DIR            Directory the archive is downloaded to and extracted in
 #   PROXY_VERIFIER_PATH Full path to the extracted proxy verifier for the build architecture
 #   PROXY_VERIFIER_CLIENT  Full path to client-verifier
 #   PROXY_VERIFIER_SERVER  Full path to server-verifier
@@ -35,22 +36,29 @@ if(NOT PROXY_VERIFIER_HASH)
   message(FATAL_ERROR "PROXY_VERIFIER_HASH Required")
 endif()
 
-# GIT_COMMON_DIR is set by the top-level CMakeLists.txt.
-if(NOT GIT_COMMON_DIR)
-  message(FATAL_ERROR "GIT_COMMON_DIR not set. This should be set by the top-level CMakeLists.txt")
+# Prefer the git common directory (set by the top-level CMakeLists.txt) so the download is shared by
+# every worktree and build directory of the same clone. It isn't always available -- a source tree
+# exported without .git, or a worktree whose common directory sits outside the paths visible to the
+# build, such as when the worktree alone is mapped into a container. Fall back to the build
+# directory, which always exists and is writable, rather than failing the configure.
+if(GIT_COMMON_DIR)
+  set(PV_DEST_DIR "${GIT_COMMON_DIR}")
+else()
+  set(PV_DEST_DIR "${CMAKE_BINARY_DIR}")
+  message(STATUS "GIT_COMMON_DIR not set, storing proxy-verifier in the build directory instead")
 endif()
 
 # Convert to absolute path (handles relative .git from regular non-worktree clones).
-get_filename_component(GIT_COMMON_DIR "${GIT_COMMON_DIR}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
+get_filename_component(PV_DEST_DIR "${PV_DEST_DIR}" ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
 
-# Download proxy-verifier to git common directory.
-set(PV_ARCHIVE ${GIT_COMMON_DIR}/proxy-verifier/proxy-verifier.tar.gz)
+# Download proxy-verifier to the destination directory.
+set(PV_ARCHIVE ${PV_DEST_DIR}/proxy-verifier/proxy-verifier.tar.gz)
 file(
   DOWNLOAD https://ci.trafficserver.apache.org/bintray/proxy-verifier-${PROXY_VERIFIER_VERSION}.tar.gz ${PV_ARCHIVE}
   EXPECTED_HASH ${PROXY_VERIFIER_HASH}
   SHOW_PROGRESS
 )
-file(ARCHIVE_EXTRACT INPUT ${PV_ARCHIVE} DESTINATION ${GIT_COMMON_DIR})
+file(ARCHIVE_EXTRACT INPUT ${PV_ARCHIVE} DESTINATION ${PV_DEST_DIR})
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64"
@@ -78,7 +86,7 @@ else()
   message(FATAL_ERROR "Host ${CMAKE_HOST_SYSTEM_NAME} doesnt support running proxy verifier")
 endif()
 
-set(PROXY_VERIFIER_PATH ${GIT_COMMON_DIR}/proxy-verifier-${PROXY_VERIFIER_VERSION}/${PV_SUBDIR})
+set(PROXY_VERIFIER_PATH ${PV_DEST_DIR}/proxy-verifier-${PROXY_VERIFIER_VERSION}/${PV_SUBDIR})
 set(PROXY_VERIFIER_CLIENT ${PROXY_VERIFIER_PATH}/verifier-client)
 set(PROXY_VERIFIER_SERVER ${PROXY_VERIFIER_PATH}/verifier-server)
 


### PR DESCRIPTION
## Description

`cmake/proxy-verifier.cmake` treats an unset `GIT_COMMON_DIR` as a fatal error:

```
CMake Error at cmake/proxy-verifier.cmake:40 (message):
  GIT_COMMON_DIR not set.  This should be set by the top-level CMakeLists.txt
```

But that directory is only a convenient cache shared across worktrees of one clone — nothing about proxy-verifier actually needs it. There are ordinary situations where git can't resolve a common directory, and configure shouldn't fail in any of them:

1. **A release tarball has no `.git` at all.** `asf-distdir` builds the tarball with `git archive --format=tar --prefix=... HEAD`, so the extracted source tree contains no git metadata whatsoever. Anyone configuring that tarball with `-DENABLE_AUTEST=ON` — a normal way to verify a release candidate — hits the fatal error. Worth fixing before the 10.2.0 RC rather than after.

2. **A worktree mapped into a container.** The worktree's `.git` is a *file* pointing at `<host-path>/.git/worktrees/<name>`. If only the worktree directory is mapped in, that path doesn't exist inside the container, `git rev-parse --git-common-dir` exits 128, and `GIT_COMMON_DIR` is left empty.

Note this only affects builds with `ENABLE_AUTEST=ON` (default OFF), since `include(proxy-verifier)` is guarded by it. A default tarball build is unaffected.

## Changes

Introduce `PV_DEST_DIR` as the single destination for the download and extraction, set from `GIT_COMMON_DIR` when git provides one and `CMAKE_BINARY_DIR` otherwise, and drop the `FATAL_ERROR`. When the fallback is taken it says so:

```
-- GIT_COMMON_DIR not set, storing proxy-verifier in the build directory instead
```

The git common directory is still preferred, so the shared-cache behaviour for normal clones and worktrees is unchanged. In the fallback case each build directory keeps its own copy of the archive; CMake skips re-downloading when the existing file already matches `EXPECTED_HASH`, so it is one download per build directory.

## Test plan

Configured with `-DENABLE_AUTEST=ON` in three trees and confirmed the resulting `PROXY_VERIFIER_PATH`:

| Tree | Result |
|---|---|
| Normal clone (`GIT_COMMON_DIR` set) | `<clone>/.git/proxy-verifier-v3.1.3/darwin-arm64` — unchanged from before |
| `git archive` export, no `.git` (the release-tarball case) | `<build>/proxy-verifier-v3.1.3/darwin-arm64` |
| Worktree whose `.git` points at a non-existent path (the container case) | `<build>/proxy-verifier-v3.1.3/darwin-arm64` |

Both fallback trees reproduced the `FATAL_ERROR` before the change and reached `Configuring done` after it. For the fallback I also verified the archive extracts and that `verifier-client` and `verifier-server` are present at `PROXY_VERIFIER_PATH`, and that the generated `tests/autest.sh` receives the build-directory path:

```
--proxy-verifier-bin /tmp/pvbuild-nogit/proxy-verifier-v3.1.3/darwin-arm64
```

`cmake-format` leaves the file unchanged.
