### PR TITLE
Fix bad return in `validate_hostname`

### DIFF
--- a/src/tscore/X509HostnameValidator.cc
+++ b/src/tscore/X509HostnameValidator.cc
@@ -281,7 +281,7 @@ validate_hostname(X509 *x, std::string_view hostname, bool is_ip, char **peernam
     astrlen = ASN1_STRING_to_UTF8(&astr, str);
 
     if (astrlen < 0) {
-      return -1;
+      return false;
     }
     retval = equal(astr, astrlen, hostname_data, hostname_len);
     if (retval && peername) {


### PR DESCRIPTION
The function has a `bool` return type, but returned `-1` to indicate an error on UTF-8 conversion failure. This patch corrects the return statement to return `false`.