### PR TITLE
Avoid stale H2 writes after 100 Continue

### DIFF
--- a/src/proxy/http2/Http2Stream.cc
+++ b/src/proxy/http2/Http2Stream.cc
@@ -807,12 +807,12 @@ Http2Stream::restart_sending()
     }
   }
 
-  IOBufferReader *reader = this->get_data_reader_for_send();
-  if (reader && !reader->is_read_avail_more_than(0)) {
+  if (this->write_vio.mutex && this->write_vio.ntodo() <= 0) {
     return;
   }
 
-  if (this->write_vio.mutex && this->write_vio.ntodo() == 0) {
+  IOBufferReader *reader = this->get_data_reader_for_send();
+  if (reader && !reader->is_read_avail_more_than(0)) {
     return;
   }
 
@@ -970,6 +970,11 @@ Http2Stream::signal_write_event(int event, bool call_update)
         write_event = nullptr;
       }
       _timeout.update_inactivity();
+      if (event == VC_EVENT_WRITE_COMPLETE) {
+        // HttpSM owns the write buffer and may release it while handling this
+        // event. Drop the unowned alias before transferring control.
+        _send_reader = nullptr;
+      }
       this->write_vio.cont->handleEvent(event, &this->write_vio);
     } else {
       if (this->_write_vio_event) {


### PR DESCRIPTION
HttpSM owns the write buffer attached to an HTTP/2 stream. After WRITE_COMPLETE it may release the buffer while a connection-level write-ready event can restart the stream through the non-owning _send_reader alias. This leaves restart_sending vulnerable to a use-after-free.

Clear _send_reader before delivering WRITE_COMPLETE to HttpSM, and check completed write VIOs before inspecting the reader during connection restarts. This preserves zero-byte completion processing, including END_STREAM.

Testing:
- Fedora debug build and format checks
- Full Apache AuTest matrix: 540 passed, 0 failed, 20 skipped
- Focused H2, HTTP/2, and 100 Continue coverage on the 10.0.x mirror: 29 passed, 0 failed