### PR TITLE
Initialize logging queues before workers

### DIFF
--- a/src/proxy/logging/Log.cc
+++ b/src/proxy/logging/Log.cc
@@ -1242,7 +1242,11 @@ void
 Log::create_threads()
 {
   char desc[64];
-  preproc_notify = new EventNotify[preproc_threads];
+  preproc_notify  = new EventNotify[preproc_threads];
+  flush_notify    = new EventNotify;
+  flush_data_list = new InkAtomicList;
+
+  ink_atomiclist_init(flush_data_list, "Logging flush buffer list", 0);
 
   size_t stacksize;
   stacksize = RecGetRecordInt("proxy.config.thread.default.stacksize").value_or(0);
@@ -1261,10 +1265,6 @@ Log::create_threads()
   // TODO: Enable multiple flush threads, such as
   //       one flush thread per file.
   //
-  flush_notify    = new EventNotify;
-  flush_data_list = new InkAtomicList;
-
-  ink_atomiclist_init(flush_data_list, "Logging flush buffer list", 0);
   Continuation *flush_cont = new LoggingFlushContinuation(0);
   eventProcessor.spawn_thread(flush_cont, "[LOG_FLUSH]", stacksize);
 }


### PR DESCRIPTION
Pre-initialization plugin log buffers can be waiting when the logging
workers start. A preprocessing thread can consume one before the flush
queue exists and crash traffic_server while pushing the buffer to a null
queue.

This patch addresses the initialization race by constructing every
logging notification and queue before spawning either worker. No logging
thread can observe partially initialized shared queue state.

This completes the startup ordering protection from #13472, which
prevents plugins from waking a preprocessor before its notification
exists but does not protect the flush queue after that worker starts.