### PR TITLE
doc: rate_limit uses max_age, not max-age

### DIFF
--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -92,7 +92,7 @@ are available:
 
 .. option:: --maxage
 
-   An optional ``max-age`` for how long a transaction can sit in the delay queue.
+   An optional maximum age for how long a transaction can sit in the delay queue.
    The value (default 0) is the age in seconds.
 
 .. option:: --prefix
@@ -149,7 +149,7 @@ and nodes are documented below.
             rate: 200
             queue:
                size: 1000
-               max-age: 30
+               max_age: 30
             metrics:
                tag: example.com
                prefix: ddos
@@ -163,11 +163,11 @@ and nodes are documented below.
             buckets: 10
             size: 15
             percentage: 90
-            max-age: 300
+            max_age: 300
             perma-block:
                limit: 100
                threshold: 1
-               max-age: 1800
+               max_age: 1800
       lists:
          - name: internal
             cidr:
@@ -212,8 +212,8 @@ For the top level `selector` node, the following options are available:
    how many queued transactions we will allow. When this threshold is reached,
    all additional connections are immediately errored out in the TLS handshake.
 
-   The queue option can include a `size` and a `max-age` option. The size is
-   default to ``UINT_MAX``, which is essentially unlimited. The max-age is
+   The queue option can include a `size` and a `max_age` option. The size is
+   default to ``UINT_MAX``, which is essentially unlimited. The max_age is
    default to ``0``, which means no age limit.
 
    No queue is enabled without this configuration directive, but it can also be
@@ -268,7 +268,7 @@ and the following options:
    This is the minimum percentage of the ``limit`` that the pressure must be at, before
    we start blocking IPs. The default is ``0.9`` which means ``90%`` of the limit.
 
-.. option:: max-age
+.. option:: max_age
 
    This is used for aging out entries out of the LRU, the default is ``0`` which means
    no aging happens. Even with no aging, entries will eventually fall out of buckets
@@ -289,7 +289,7 @@ blocked for a long time. The configuration for this bucket is:
    This option specifies from which bucket an IP is allowed to move from into the
    perma block bucket. A good value here is likely ``0`` or ``1``, which is very conservative.
 
-.. option:: max-age
+.. option:: max_age
 
    Like above, but only applies to the long term (`perma-block`) bucket. Default is
    ``0``, which means no aging to this bucket is applied.

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -275,6 +275,11 @@ and the following options:
    because of the LRU mechanism that kicks in. The aging is here to make sure a spike
    in traffic from an IP doesn't keep the entry for too long in the LRUs.
 
+   Note that this option was incorrectly documented as ``max-age`` with a hyphen in previous
+   versions.  The code ignores ``max-age`` in all versions of this plugin.  We have chosen
+   to keep the behavior the same and update the documentation, so that previously inert
+   configurations don't activate unexpectedly with an upgrade.
+
 In addition, there's an optional configuration for the permanently blocking buckets,
 `perma-block`. This is a special bucket, which is only used for IPs which have been
 blocked for a long time. The configuration for this bucket is:

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -93,7 +93,12 @@ are available:
 .. option:: --maxage
 
    An optional maximum age for how long a transaction can sit in the delay queue.
-   The value (default 0) is the age in seconds.
+   The value (default 0) is the age in **milliseconds**.
+
+   Note that the equivalent YAML setting, ``max_age`` under a ``queue`` node, is in
+   seconds. The two configuration paths have always differed by a factor of 1000, so
+   the units are documented here as they behave rather than made consistent, to avoid
+   changing the expiry of existing configurations.
 
 .. option:: --prefix
 
@@ -212,9 +217,9 @@ For the top level `selector` node, the following options are available:
    how many queued transactions we will allow. When this threshold is reached,
    all additional connections are immediately errored out in the TLS handshake.
 
-   The queue option can include a `size` and a `max_age` option. The size is
-   default to ``UINT_MAX``, which is essentially unlimited. The max_age is
-   default to ``0``, which means no age limit.
+   The queue option can include a `size` and a `max_age` option. The size defaults
+   to ``UINT_MAX``, which is essentially unlimited. The max_age is in seconds and
+   defaults to ``0``, which means no age limit.
 
    No queue is enabled without this configuration directive, but it can also be
    disabled explicitly if the size is set to ``0``.

--- a/doc/admin-guide/plugins/rate_limit.en.rst
+++ b/doc/admin-guide/plugins/rate_limit.en.rst
@@ -96,9 +96,7 @@ are available:
    The value (default 0) is the age in **milliseconds**.
 
    Note that the equivalent YAML setting, ``max_age`` under a ``queue`` node, is in
-   seconds. The two configuration paths have always differed by a factor of 1000, so
-   the units are documented here as they behave rather than made consistent, to avoid
-   changing the expiry of existing configurations.
+   seconds.
 
 .. option:: --prefix
 
@@ -279,11 +277,6 @@ and the following options:
    no aging happens. Even with no aging, entries will eventually fall out of buckets
    because of the LRU mechanism that kicks in. The aging is here to make sure a spike
    in traffic from an IP doesn't keep the entry for too long in the LRUs.
-
-   Note that this option was incorrectly documented as ``max-age`` with a hyphen in previous
-   versions.  The code ignores ``max-age`` in all versions of this plugin.  We have chosen
-   to keep the behavior the same and update the documentation, so that previously inert
-   configurations don't activate unexpectedly with an upgrade.
 
 In addition, there's an optional configuration for the permanently blocking buckets,
 `perma-block`. This is a special bucket, which is only used for IPs which have been


### PR DESCRIPTION
The rate_limit YAML parser reads `max_age` with an underscore, in three places:

* the `queue` node — `plugins/experimental/rate_limit/limiter.h`
* the `ip-rep` node — `plugins/experimental/rate_limit/ip_reputation.cc`
* the `perma-block` sub-node — same file

Every mention in the documentation spelled it `max-age`, including all three
worked examples. A configuration copied from the docs therefore left `_max_age`
at its default of `0` in each case, which silently disables queue expiry (the
expiry pass in `sni_queue_cont()` is gated on
`max_age() > std::chrono::milliseconds::zero()`) and both IP-reputation aging
paths.

This changes the documentation rather than the parser, so that configurations
which are inert today stay inert on upgrade instead of suddenly beginning to
expire queue entries or age out LRU entries with whatever value the operator
wrote.

The `--maxage` pparam description also referred to a ``max-age`` that matches
neither the option name nor the YAML key, so it now just says "maximum age".

`max-age` was the only key in the documentation that did not match the parser;
`ip-rep` and `perma-block` really are hyphenated in the code.
