### PR TITLE
Bound RegexMatches::operator[] by what the match populated

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -68,7 +68,12 @@ public:
 
   /** Get the match at the given index.
    *
-   * @return The match at the given index.
+   * An index the match did not populate, and a group that did not participate in the match, both
+   * yield an empty view. The result never has a null data(), so it can be handed straight to
+   * memcpy(), std::string::append() and "%.*s". Use get_ovector_pointer() to tell a group that did
+   * not participate from one that matched an empty string.
+   *
+   * @return The match at the given index, or an empty view.
    */
   std::string_view operator[](size_t index) const;
   /** Get the ovector pointer for the capture groups.  Don't use this unless you know what you are doing.

--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -68,11 +68,6 @@ public:
 
   /** Get the match at the given index.
    *
-   * An index the match did not populate, and a group that did not participate in the match, both
-   * yield an empty view. The result never has a null data(), so it can be handed straight to
-   * memcpy(), std::string::append() and "%.*s". Use get_ovector_pointer() to tell a group that did
-   * not participate from one that matched an empty string.
-   *
    * @return The match at the given index, or an empty view.
    */
   std::string_view operator[](size_t index) const;

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -222,17 +222,19 @@ RegexMatches::size() const
 std::string_view
 RegexMatches::operator[](size_t index) const
 {
-  // check if the index is valid
-  if (index >= pcre2_get_ovector_count(_MatchData::get(_match_data))) {
-    return std::string_view();
+  // The ovector is allocated with a fixed number of pairs, but pcre2_match() writes only as far as
+  // the highest participating group. Every pair past that keeps whatever _buffer happened to hold,
+  // so the allocated count is not a usable bound -- _size is what the match actually populated.
+  if (_size <= 0 || index >= static_cast<size_t>(_size)) {
+    return "";
   }
 
   PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(_MatchData::get(_match_data));
 
-  // A group that did not participate in the match has an unset offset. This happens for an optional
-  // group that precedes a participating one, so a valid index is not enough to guarantee an offset.
+  // Within _size a group can still have not participated, in which case PCRE2 sets both of its
+  // offsets to PCRE2_UNSET. An optional group preceding a participating one is the usual way.
   if (PCRE2_UNSET == ovector[2 * index]) {
-    return std::string_view();
+    return "";
   }
 
   return std::string_view(_subject.data() + ovector[2 * index], ovector[2 * index + 1] - ovector[2 * index]);

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -466,7 +466,7 @@ TEST_CASE("RegexMatches edge cases", "[libts][Regex][RegexMatches]")
     // pcre2_match() returns one past the highest participating group, so an earlier optional group
     // that did not participate is still within that count. Its offsets are unset.
     Regex r;
-    REQUIRE(r.compile("(a)?(b)") == true);
+    REQUIRE(r.compile("(a)?(b)"));
 
     RegexMatches matches;
     int          count = r.exec("b", matches);
@@ -475,7 +475,45 @@ TEST_CASE("RegexMatches edge cases", "[libts][Regex][RegexMatches]")
     CHECK(matches[0] == "b");
     CHECK(matches[1] == "");
     CHECK(matches[2] == "b");
-    CHECK(matches[1].data() == nullptr);
+    CHECK(matches[1].data() != nullptr);
+  }
+
+  SECTION("RegexMatches past what the match populated")
+  {
+    // The ovector holds a fixed number of pairs regardless of the pattern, and pcre2_match() writes
+    // no further than the highest participating group. Reading past that must not build a view over
+    // the uninitialized remainder of the buffer.
+    Regex r;
+    REQUIRE(r.compile("(.*-)(\\d+)(\\?.*)?$"));
+
+    RegexMatches matches;
+    int          count = r.exec("/img-7", matches);
+
+    // Three groups defined, but the trailing optional one did not participate.
+    CHECK(r.get_capture_count() == 3);
+    CHECK(count == 3);
+    CHECK(matches[1] == "/img-");
+    CHECK(matches[2] == "7");
+
+    // A group the pattern defines that the match did not reach, ...
+    CHECK(matches[3] == "");
+    CHECK(matches[3].data() != nullptr);
+
+    // ... and an index past the pattern's groups entirely, still inside the allocated ovector.
+    CHECK(matches[9] == "");
+    CHECK(matches[9].data() != nullptr);
+  }
+
+  SECTION("RegexMatches after a failed match")
+  {
+    Regex r;
+    REQUIRE(r.compile("(a)(b)"));
+
+    RegexMatches matches;
+    CHECK(r.exec("zz", matches) < 0);
+
+    CHECK(matches[0] == "");
+    CHECK(matches[0].data() != nullptr);
   }
 }
 


### PR DESCRIPTION
## Problem

`RegexMatches` allocates its ovector with a fixed 10 pairs regardless of the pattern.
`pcre2_match()` fills it in only as far as the highest capture group that participated,
and leaves the rest untouched — holding whatever was already in `_buffer`, which is an
uninitialized member.

`operator[]` checked the index against the *allocated* pair count. So an index past the
pattern's groups passed the check and built a `string_view` out of that leftover memory:
a bad pointer with a meaningless length.

The `PCRE2_UNSET` check added in #13441 doesn't cover this. It catches a group the match
reached but that didn't participate. Entries the match never reached hold stale bytes,
not `PCRE2_UNSET`.

The same is true after a failed match, where PCRE2 leaves the ovector undefined. On
master, `matches[0]` after a failed `exec()` hands back a view over garbage.

Nothing in tree can reach this today: `regex_remap` rejects a `$n` above the pattern's
capture count at config load, prefetch and cachekey bound the index by the match count,
and `SSLSNIConfig` iterates to `matches.size()`. This fixes the contract, not a live bug.

## Fix

Bound the index by the match size — what `pcre2_match()` actually populated — rather than
the allocated pair count. Keep the `PCRE2_UNSET` check for a group inside that range that
didn't participate, which is the case #13441 was about.

Also return `""` rather than a default-constructed `std::string_view` for both empty
cases, so the result never has a null `data()`. Callers pass it straight into functions
that don't accept a null pointer even at zero length:

- `plugins/regex_remap/regex_remap.cc:540` — `memcpy()`
- `plugins/cachekey/pattern.cc:271` — `std::string` ctor
- `plugins/prefetch/pattern.cc:267` — `std::string::append()`
- `plugins/experimental/access_control/pattern.cc:287` — `std::string` ctor

`get_ovector_pointer()` is still available to tell a group that didn't participate from
one that matched an empty string, which is what the PCRE2 docs suggest for that.

## Why there's no check on the end offset

Raised in review on #13441, so worth answering here:

- PCRE2 sets both offsets of an unused group to `PCRE2_UNSET` together, so testing the
  start is enough.
- `end < start` would need `\K` inside a lookaround, which PCRE2 has rejected at compile
  time since 10.38 unless `PCRE2_EXTRA_ALLOW_LOOKAROUND_BSK` is set. ATS never sets it,
  and with it forced on PCRE2 clamps rather than inverting.

## Tests

Three sections in `test_Regex.cc`, all of which fail without the change:

- a non-participating group before a participating one — updated, the view is no longer null
- an index past what the match populated — new
- indexing after a failed match — new

`test_tsutil` passes 506 assertions in 32 cases. Full `ctest` is 127/127.
