### PR TITLE
Cherry-picks for 10.2.0 RC, round 5 (2026-08-10)

### DIFF
--- a/doc/admin-guide/plugins/prefetch.en.rst
+++ b/doc/admin-guide/plugins/prefetch.en.rst
@@ -293,6 +293,13 @@ Plugin parameters
     * if ``true`` the fetch policy would use the **next** URL's cache key that to find out if the **next object** should be prefetched or not
 * ``--log-name`` - specifies a custom log name (if not specified a log is not created)
 
+An invalid parameter value is a configuration error. ``--fetch-count`` and ``--fetch-max`` must be
+decimal numbers that fit in an unsigned integer, ``--fetch-overflow`` must be ``32`` or ``64``, and
+``--fetch-path-pattern`` must compile and may only reference capture groups that the pattern
+defines. A remap rule with an invalid value fails to load, instead of loading with prefetch
+silently disabled. ``traffic_ctl config reload`` rejects such a configuration and keeps the running
+one.
+
 Metrics
 =======
 

--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -68,7 +68,7 @@ public:
 
   /** Get the match at the given index.
    *
-   * @return The match at the given index.
+   * @return The match at the given index, or an empty view.
    */
   std::string_view operator[](size_t index) const;
   /** Get the ovector pointer for the capture groups.  Don't use this unless you know what you are doing.

--- a/plugins/prefetch/configs.cc
+++ b/plugins/prefetch/configs.cc
@@ -21,6 +21,8 @@
  * @brief Plugin configuration.
  */
 
+#include <charconv>  /* std::from_chars() */
+#include <cstring>   /* strlen() */
 #include <fstream>   /* std::ifstream */
 #include <getopt.h>  /* getopt_long() */
 #include <sstream>   /* std::istringstream */
@@ -71,14 +73,44 @@ iequals(const StringView lhs, const StringView rhs)
                     [](const char a, const char b) { return tolower(a) == tolower(b); });
 }
 
-void
+bool
 PrefetchConfig::setFetchOverflow(const char *optarg)
 {
-  if (StringView("64") == optarg) {
+  if (nullptr == optarg) {
+    return false;
+  }
+  if (StringView("32") == optarg) {
+    _fetchOverflow = EvalPolicy::Overflow32;
+  } else if (StringView("64") == optarg) {
     _fetchOverflow = EvalPolicy::Overflow64;
   } else if (iequals("bignum", optarg)) {
     _fetchOverflow = EvalPolicy::Bignum;
+  } else {
+    return false;
   }
+  return true;
+}
+
+/**
+ * @brief Parses @a optarg as an unsigned integer option value.
+ * @param optarg the option value to parse.
+ * @param value set to the parsed value on success, untouched on failure.
+ * @return true if @a optarg is a non-empty string of decimal digits that fits in @a value.
+ */
+static bool
+parseUnsignedInt(const char *optarg, unsigned &value)
+{
+  if (nullptr == optarg) {
+    return false;
+  }
+
+  const char *const end = optarg + strlen(optarg);
+  auto const [parsed, ec]{std::from_chars(optarg, end, value)};
+
+  /* from_chars() reports a leading sign or a non-digit as invalid_argument and a value too large
+   * for @a value as result_out_of_range. Requiring it to consume the whole string rejects trailing
+   * characters such as "10abc". */
+  return std::errc{} == ec && parsed == end;
 }
 
 /**
@@ -147,7 +179,12 @@ PrefetchConfig::init(int argc, char *argv[])
       break;
 
     case 'c': /* --fetch-count */
-      setFetchCount(optarg);
+      if (unsigned count = 0; parseUnsignedInt(optarg, count)) {
+        setFetchCount(count);
+      } else {
+        PrefetchError("invalid --fetch-count '%s': expected a non-negative integer", optarg ? optarg : "");
+        status = false;
+      }
       break;
 
     case 'e': /* --fetch-path-pattern */ {
@@ -156,7 +193,10 @@ PrefetchConfig::init(int argc, char *argv[])
         if (pattern->init(optarg)) {
           _nextPaths.add(std::move(pattern));
         } else {
-          PrefetchError("failed to initialize next object pattern");
+          /* An unusable fetch-path-pattern is a configuration error; fail instance creation so ATS
+           * refuses to load the remap rule rather than silently running with prefetch disabled. */
+          PrefetchError("failed to initialize fetch-path-pattern '%s'", optarg ? optarg : "");
+          status = false;
         }
       }
     } break;
@@ -166,11 +206,19 @@ PrefetchConfig::init(int argc, char *argv[])
     } break;
 
     case 'x': /* --fetch-max */
-      setFetchMax(optarg);
+      if (unsigned max = 0; parseUnsignedInt(optarg, max)) {
+        setFetchMax(max);
+      } else {
+        PrefetchError("invalid --fetch-max '%s': expected a non-negative integer", optarg ? optarg : "");
+        status = false;
+      }
       break;
 
     case 'o': /* --fetch-overflow */
-      setFetchOverflow(optarg);
+      if (!setFetchOverflow(optarg)) {
+        PrefetchError("invalid --fetch-overflow '%s': expected 32, 64, or bignum", optarg ? optarg : "");
+        status = false;
+      }
       break;
 
     case 'r': /* --replace-host */

--- a/plugins/prefetch/configs.h
+++ b/plugins/prefetch/configs.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 
 #include "common.h"
@@ -119,9 +120,9 @@ public:
   }
 
   void
-  setFetchCount(const char *optarg)
+  setFetchCount(unsigned count)
   {
-    _fetchCount = getValue(optarg);
+    _fetchCount = count;
   }
 
   unsigned
@@ -131,9 +132,9 @@ public:
   }
 
   void
-  setFetchMax(const char *optarg)
+  setFetchMax(unsigned max)
   {
-    _fetchMax = getValue(optarg);
+    _fetchMax = max;
   }
 
   unsigned
@@ -142,7 +143,7 @@ public:
     return _fetchMax;
   }
 
-  void setFetchOverflow(const char *optarg);
+  bool setFetchOverflow(const char *optarg);
 
   EvalPolicy
   getFetchOverflow() const
@@ -178,6 +179,20 @@ public:
   getNextPath()
   {
     return _nextPaths;
+  }
+
+  /**
+   * @brief Whether an expanded path that collapsed to empty should be reported.
+   *
+   * Whether the replacement collapses depends on the request, so the condition recurs per
+   * transaction for as long as the pattern stays misconfigured. Report it once per remap instance
+   * so a bad pattern is visible without flooding the error log. A config reload builds a new
+   * instance and reports again.
+   */
+  bool
+  shouldReportEmptyPath()
+  {
+    return !_reportedEmptyPath.exchange(true, std::memory_order_relaxed);
   }
 
   void
@@ -226,4 +241,6 @@ private:
   bool         _exactMatch    = false;
   bool         _cmcd_nor      = false;
   MultiPattern _nextPaths;
+
+  std::atomic<bool> _reportedEmptyPath{false}; /* see shouldReportEmptyPath() */
 };

--- a/plugins/prefetch/pattern.cc
+++ b/plugins/prefetch/pattern.cc
@@ -131,45 +131,6 @@ Pattern::empty() const
 }
 
 /**
- * @brief Capture or capture-and-replace depending on whether a replacement string is specified.
- * @see replace()
- * @see capture()
- * @param subject PCRE2 subject string
- * @param result vector of strings where the result of captures or the replacements will be returned.
- * @return true if there was a match and capture or replacement succeeded, false if failure.
- */
-bool
-Pattern::process(const String &subject, StringVector &result)
-{
-  if (!_replacement.empty()) {
-    /* Replacement pattern was provided in the configuration - capture and replace. */
-    String element;
-    if (replace(subject, element)) {
-      result.push_back(element);
-    } else {
-      return false;
-    }
-  } else {
-    /* Replacement was not provided so return all capturing groups except the group zero. */
-    StringVector captures;
-    if (capture(subject, captures)) {
-      if (captures.size() == 1) {
-        result.push_back(captures[0]);
-      } else {
-        StringVector::iterator it = captures.begin() + 1;
-        for (; it != captures.end(); it++) {
-          result.push_back(*it);
-        }
-      }
-    } else {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
  * @brief PCRE2 matches a subject string against the regex pattern.
  * @param subject PCRE2 subject
  * @return true - matched, false - did not.
@@ -190,39 +151,6 @@ Pattern::match(const String &subject)
       PrefetchError("matching error %d", matchCount);
     }
     return false;
-  }
-
-  return true;
-}
-
-/**
- * @brief Return all PCRE2 capture groups that matched in the subject string
- * @param subject PCRE2 subject string
- * @param result reference to vector of strings containing all capture groups
- */
-bool
-Pattern::capture(const String &subject, StringVector &result)
-{
-  PrefetchDebug("matching '%s' to '%s'", _pattern.c_str(), subject.c_str());
-
-  if (_regex.empty()) {
-    return false;
-  }
-
-  RegexMatches matches;
-  int          matchCount = _regex.exec(subject, matches, RE_NOTEMPTY);
-
-  if (matchCount <= 0) {
-    if (matchCount != RE_ERROR_NOMATCH) {
-      PrefetchError("matching error %d", matchCount);
-    }
-    return false;
-  }
-
-  for (int i = 0; i < matchCount; i++) {
-    std::string_view match = matches[i];
-    result.emplace_back(match.data(), match.length());
-    PrefetchDebug("capturing '%s' %d", result.back().c_str(), i);
   }
 
   return true;
@@ -253,25 +181,22 @@ Pattern::replace(const String &subject, String &result)
     return false;
   }
 
-  /* Verify the replacement has the right number of matching groups */
-  for (int i = 0; i < _tokenCount; i++) {
-    if (_tokens[i] >= matchCount) {
-      PrefetchError("invalid reference in replacement string: $%d", _tokens[i]);
-      return false;
-    }
-  }
-
   int previous = 0;
   for (int i = 0; i < _tokenCount; i++) {
-    int              replIndex = _tokens[i];
-    std::string_view dst       = matches[replIndex];
+    int replIndex = _tokens[i];
 
-    String src(_replacement, _tokenOffset[i], 2);
+    /* $replIndex was validated at config-load time against the number of groups the pattern defines, but
+     * the group may still not have participated in *this* match (e.g. a trailing optional group such as
+     * "(\?.*)?" when the subject has no query string).  pcre2_match() returns one past the highest
+     * participating group, so substitute an empty string for a group at or beyond that -- the documented
+     * PCRE2 semantics for an unmatched group -- rather than failing the whole replacement.  Use ""
+     * rather than a default-constructed view so data() is never null, which "%.*s" requires. */
+    std::string_view dst = (replIndex < matchCount) ? matches[replIndex] : std::string_view{""};
 
-    PrefetchDebug("replacing '%s' with '%.*s'", src.c_str(), static_cast<int>(dst.length()), dst.data());
+    PrefetchDebug("replacing '$%d' with '%.*s'", replIndex, static_cast<int>(dst.length()), dst.data());
 
     result.append(_replacement, previous, _tokenOffset[i] - previous);
-    result.append(dst.data(), dst.length());
+    result.append(dst);
 
     previous = _tokenOffset[i] + 2; /* 2 is the size of $0 or $1 or $2, ... or $9 */
   }
@@ -327,6 +252,31 @@ Pattern::compile()
         _tokenCount++;
         /* Skip the next char */
         i++;
+      }
+    }
+  }
+
+  /* Validate replacement references against the number of capture groups the pattern actually defines
+   * (not how many happen to participate in any given match) at config-load time.  This catches a
+   * genuinely out-of-range reference such as $5 against a 3-group pattern, and a pattern that defines
+   * more groups than can be captured -- RegexMatches holds the whole match plus TOKENCOUNT-1 groups. */
+  if (success) {
+    int32_t captureCount = _regex.get_capture_count();
+    if (captureCount < 0) {
+      PrefetchError("failed to get capture count for regex '%s'", _pattern.c_str());
+      success = false;
+    } else if (captureCount > TOKENCOUNT - 1) {
+      PrefetchError("regex '%s' defines %d capture groups; the prefetch plugin supports at most %d (references $0..$%d)",
+                    _pattern.c_str(), captureCount, TOKENCOUNT - 1, TOKENCOUNT - 1);
+      success = false;
+    } else {
+      for (int i = 0; i < _tokenCount; i++) {
+        if (_tokens[i] > captureCount) {
+          PrefetchError("invalid reference $%d in replacement '%s': pattern defines only %d group(s)", _tokens[i],
+                        _replacement.c_str(), captureCount);
+          success = false;
+          break;
+        }
       }
     }
   }

--- a/plugins/prefetch/pattern.h
+++ b/plugins/prefetch/pattern.h
@@ -40,9 +40,7 @@ public:
   bool init(const String &config);
   bool empty() const;
   bool match(const String &subject);
-  bool capture(const String &subject, StringVector &result);
   bool replace(const String &subject, String &result);
-  bool process(const String &subject, StringVector &result);
 
 private:
   bool compile();

--- a/plugins/prefetch/plugin.cc
+++ b/plugins/prefetch/plugin.cc
@@ -663,6 +663,19 @@ contHandleFetch(const TSCont contp, TSEvent event, void *edata)
               String expandedPath;
 
               if (config.getNextPath().replace(workingPath, expandedPath)) {
+                if (expandedPath.empty()) {
+                  /* A replacement that collapses to empty (e.g. every referenced group was optional and
+                   * absent) would otherwise be scheduled with a zero-length path, which BgFetch skips --
+                   * leaving the original request path in place and prefetching the pristine URL itself.
+                   * Stop rather than issue that self-prefetch. Report once per instance; whether the
+                   * replacement collapses depends on the request, so this recurs per transaction. */
+                  if (config.shouldReportEmptyPath()) {
+                    PrefetchError("prefetch pattern produced an empty path; check the fetch-path-pattern replacement");
+                  } else {
+                    PrefetchDebug("prefetch pattern produced an empty path");
+                  }
+                  break;
+                }
                 PrefetchDebug("replaced: %s", expandedPath.c_str());
                 expand(expandedPath, config.getFetchOverflow());
                 PrefetchDebug("expanded: %s cachekey: %s", expandedPath.c_str(), data->_cachekey.c_str());

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -907,10 +907,19 @@ HttpSM::state_watch_for_client_abort(int event, void *data)
   case VC_EVENT_EOS: {
     // We got an early EOS.
     if (!terminate_sm) { // Not done already
+      // ProxySession::do_io_shutdown dereferences its NetVConnection
+      // unconditionally, so only shut down while the peer is still attached.
       NetVConnection *netvc = _ua.get_txn()->get_netvc();
+
       if (_ua.get_txn()->allow_half_open() || tunnel.has_consumer_besides_client()) {
         if (netvc) {
-          netvc->do_io_shutdown(IO_SHUTDOWN_READ);
+          // Shut the read side down through the transaction rather than through
+          // the NetVConnection. For multiplexed protocols the NetVConnection is
+          // shared by every stream on the connection, so shutting its read side
+          // down here would stop the session from reading frames for all of the
+          // other streams. HTTP/2 and HTTP/3 therefore implement
+          // do_io_shutdown() as a no-op.
+          _ua.get_txn()->do_io_shutdown(IO_SHUTDOWN_READ);
         }
       } else if (t_state.txn_conf->cache_http &&
                  (server_entry != nullptr && server_entry->vc_read_handler == &HttpSM::state_read_server_response_header)) {

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -222,17 +222,19 @@ RegexMatches::size() const
 std::string_view
 RegexMatches::operator[](size_t index) const
 {
-  // check if the index is valid
-  if (index >= pcre2_get_ovector_count(_MatchData::get(_match_data))) {
-    return std::string_view();
+  // The ovector is allocated with a fixed number of pairs, but pcre2_match() writes only as far as
+  // the highest participating group. Every pair past that keeps whatever _buffer happened to hold,
+  // so the allocated count is not a usable bound -- _size is what the match actually populated.
+  if (_size <= 0 || index >= static_cast<size_t>(_size)) {
+    return "";
   }
 
   PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(_MatchData::get(_match_data));
 
-  // A group that did not participate in the match has an unset offset. This happens for an optional
-  // group that precedes a participating one, so a valid index is not enough to guarantee an offset.
+  // Within _size a group can still have not participated, in which case PCRE2 sets both of its
+  // offsets to PCRE2_UNSET. An optional group preceding a participating one is the usual way.
   if (PCRE2_UNSET == ovector[2 * index]) {
-    return std::string_view();
+    return "";
   }
 
   return std::string_view(_subject.data() + ovector[2 * index], ovector[2 * index + 1] - ovector[2 * index]);

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -466,7 +466,7 @@ TEST_CASE("RegexMatches edge cases", "[libts][Regex][RegexMatches]")
     // pcre2_match() returns one past the highest participating group, so an earlier optional group
     // that did not participate is still within that count. Its offsets are unset.
     Regex r;
-    REQUIRE(r.compile("(a)?(b)") == true);
+    REQUIRE(r.compile("(a)?(b)"));
 
     RegexMatches matches;
     int          count = r.exec("b", matches);
@@ -475,7 +475,45 @@ TEST_CASE("RegexMatches edge cases", "[libts][Regex][RegexMatches]")
     CHECK(matches[0] == "b");
     CHECK(matches[1] == "");
     CHECK(matches[2] == "b");
-    CHECK(matches[1].data() == nullptr);
+    CHECK(matches[1].data() != nullptr);
+  }
+
+  SECTION("RegexMatches past what the match populated")
+  {
+    // The ovector holds a fixed number of pairs regardless of the pattern, and pcre2_match() writes
+    // no further than the highest participating group. Reading past that must not build a view over
+    // the uninitialized remainder of the buffer.
+    Regex r;
+    REQUIRE(r.compile("(.*-)(\\d+)(\\?.*)?$"));
+
+    RegexMatches matches;
+    int          count = r.exec("/img-7", matches);
+
+    // Three groups defined, but the trailing optional one did not participate.
+    CHECK(r.get_capture_count() == 3);
+    CHECK(count == 3);
+    CHECK(matches[1] == "/img-");
+    CHECK(matches[2] == "7");
+
+    // A group the pattern defines that the match did not reach, ...
+    CHECK(matches[3] == "");
+    CHECK(matches[3].data() != nullptr);
+
+    // ... and an index past the pattern's groups entirely, still inside the allocated ovector.
+    CHECK(matches[9] == "");
+    CHECK(matches[9].data() != nullptr);
+  }
+
+  SECTION("RegexMatches after a failed match")
+  {
+    Regex r;
+    REQUIRE(r.compile("(a)(b)"));
+
+    RegexMatches matches;
+    CHECK(r.exec("zz", matches) < 0);
+
+    CHECK(matches[0] == "");
+    CHECK(matches[0].data() != nullptr);
   }
 }
 

--- a/tests/gold_tests/h2/http2_client_reset_keeps_session_reading.test.py
+++ b/tests/gold_tests/h2/http2_client_reset_keeps_session_reading.test.py
@@ -1,0 +1,23 @@
+'''Verify an HTTP/2 stream reset does not stop the session from reading.'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = __doc__
+
+Test.SkipUnless(
+    Condition.HasOpenSSLVersion('1.1.1'), Condition.HasProxyVerifierVersion('2.8.0'), Condition.PluginExists('null_transform.so'))
+
+Test.ATSReplayTest(replay_file="replay/http2_client_reset_keeps_session_reading.replay.yaml")

--- a/tests/gold_tests/h2/replay/http2_client_reset_keeps_session_reading.replay.yaml
+++ b/tests/gold_tests/h2/replay/http2_client_reset_keeps_session_reading.replay.yaml
@@ -1,0 +1,149 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# A response transform makes the tunnel run the whole body through the transform
+# before anything is written back to the client. While that is happening the
+# client stream has no write of its own, so a client stream reset is delivered as
+# a VC_EVENT_EOS on the stream's read VIO and lands in
+# HttpSM::state_watch_for_client_abort. The transform write consumer is still
+# alive there, so the SM half closes the client read side to let the rest of the
+# transaction finish.
+#
+# That shutdown has to apply to the stream, not to the underlying connection: for
+# HTTP/2 the NetVConnection is shared by every stream, so shutting its read side
+# down stops the session from reading frames for all of the other streams. The
+# second request below is sent after the reset and only gets a response if ATS is
+# still reading the connection.
+#
+
+meta:
+  version: '1.0'
+
+autest:
+  description: 'Verify an HTTP/2 stream reset does not stop the session from reading'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+
+    process_config:
+      enable_tls: true
+      enable_cache: true
+
+    plugin_config:
+      # A response transform so the tunnel has a consumer besides the client
+      # while the body is being read from the origin.
+      - 'null_transform.so'
+
+    records_config:
+      proxy.config.diags.debug.enabled: 1
+      proxy.config.diags.debug.tags: 'http|http_tunnel'
+      # Let the rest of the transaction run for as long as the origin takes.
+      proxy.config.http.background_fill_active_timeout: 0
+      proxy.config.http.background_fill_completed_threshold: 0.0
+      # The origin speaks HTTP/2 so that it can delay the response body without
+      # delaying the response header.
+      proxy.config.ssl.client.alpn_protocols: 'h2,http/1.1'
+      proxy.config.ssl.client.verify.server.policy: 'PERMISSIVE'
+
+    remap_config:
+      - 'map / https://127.0.0.1:{SERVER_HTTPS_PORT}'
+
+    log_validation:
+      traffic_out:
+        contains:
+          - expression: 'adding consumer .transform write.'
+            description: 'Verify the tunnel had a consumer besides the client'
+          - expression: 'state_watch_for_client_abort, VC_EVENT_EOS'
+            description: 'Verify the stream reset was handled as a client abort'
+
+sessions:
+- protocol:
+    stack: http2
+    tls:
+      sni: test_sni
+
+  transactions:
+
+  # Stream 1: the origin sends the response header right away and then stalls
+  # before the body, so the transform stage of the tunnel is still running when
+  # the client resets the stream.
+  - client-request:
+      frames:
+      - HEADERS:
+          headers:
+            fields:
+            - [":method", GET]
+            - [":scheme", https]
+            - [":authority", example.data.com]
+            - [":path", /reset-mid-transform]
+            - [uuid, reset-mid-transform]
+      - RST_STREAM:
+          delay: 1s
+          error-code: CANCEL
+
+    server-response:
+      frames:
+      - HEADERS:
+          headers:
+            fields:
+            - [":status", 200]
+            - [Content-Type, text/html]
+            - [Content-Length, '11']
+            - [Cache-Control, 'max-age=300']
+      - DATA:
+          delay: 3s
+          content:
+            encoding: plain
+            data: server_test
+            size: 11
+
+  # Stream 3: sent after the reset above. ATS only sees this request if it is
+  # still reading the connection, so a missing response here means one stream's
+  # abort took the whole connection down with it.
+  - client-request:
+      delay: 2s
+      headers:
+        fields:
+        - [":method", GET]
+        - [":scheme", https]
+        - [":authority", example.data.com]
+        - [":path", /after-the-reset]
+        - [uuid, after-the-reset]
+
+    server-response:
+      headers:
+        fields:
+        - [":status", 200]
+        - [Content-Type, text/html]
+        - [Content-Length, '16']
+        - [X-Response, after-the-reset]
+      content:
+        encoding: plain
+        data: after_the_reset
+        size: 16
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [X-Response, {value: 'after-the-reset', as: equal}]

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_bad_count_refused.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_bad_count_refused.test.py
@@ -1,0 +1,53 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test that prefetch.so treats a --fetch-count that does not fit in an unsigned as a configuration
+error: ATS refuses to load the remap rule (and fails to start) instead of truncating the value.
+
+The value below is a string of decimal digits, so it passes a digits-only check, but it exceeds the
+range of the unsigned the plugin stores it in.
+'''
+
+ts = Test.MakeATSProcess("ts")
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'prefetch',
+})
+ts.Disk.remap_config.AddLine(
+    "map http://domain.in http://127.0.0.1:8080" + " @plugin=prefetch.so" + " @pparam=--front=true" +
+    " @pparam=--fetch-policy=simple" + " @pparam=--fetch-count=5000000000")
+
+ts.ReturnCode = 33  # Emergency exit: remap.config failed to load.
+ts.Ready = 0
+# ATS is expected to log the rejection; this ContainsExpression both asserts it and replaces the
+# default "diags.log must not contain ERROR:" check (the rejection is logged via TSError).
+ts.Disk.diags_log.Content = Testers.ContainsExpression(
+    "invalid --fetch-count '5000000000'", "an out-of-range fetch-count must be rejected at config load")
+
+tr = Test.AddTestRun("prefetch rejects an out-of-range fetch-count at load")
+# Wait for the rejection message with a separate watcher: gating ts readiness on the log line directly
+# can race the process exiting before autest observes the line.
+watcher = Test.Processes.Process("watcher")
+watcher.Command = "sleep 30"
+watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "invalid --fetch-count '5000000000'")
+watcher.StartBefore(ts)
+
+tr.Processes.Default.Command = "echo done"
+tr.TimeOut = 30
+tr.Processes.Default.StartBefore(watcher)

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_bad_pattern_refused.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_bad_pattern_refused.test.py
@@ -1,0 +1,54 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test that prefetch.so treats an unusable fetch-path-pattern as a configuration error: ATS refuses to
+load the remap rule (and fails to start) instead of silently running with prefetch disabled.
+
+The pattern below defines 10 capture groups.  The plugin's ovector (OVECOUNT = TOKENCOUNT*3) can hold
+offsets for the whole match plus at most TOKENCOUNT-1 (9) groups, so the pattern is rejected at
+config-load time; that fails the remap instance, and remap.config fails to load.
+'''
+
+ts = Test.MakeATSProcess("ts")
+ts.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 1,
+    'proxy.config.diags.debug.tags': 'prefetch',
+})
+ts.Disk.remap_config.AddLine(
+    "map http://domain.in http://127.0.0.1:8080" + " @plugin=prefetch.so" + " @pparam=--front=true" +
+    " @pparam=--fetch-policy=simple" + r" @pparam=--fetch-path-pattern=/(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)/$1/")
+
+ts.ReturnCode = 33  # Emergency exit: remap.config failed to load.
+ts.Ready = 0
+# ATS is expected to log the rejection; this ContainsExpression both asserts it and replaces the
+# default "diags.log must not contain ERROR:" check (the rejection is logged via TSError).
+ts.Disk.diags_log.Content = Testers.ContainsExpression(
+    "defines 10 capture groups", "over-limit fetch-path-pattern must be rejected at config load")
+
+tr = Test.AddTestRun("prefetch rejects an over-limit capture-group pattern at load")
+# Wait for the rejection message with a separate watcher: gating ts readiness on the log line directly
+# can race the process exiting before autest observes the line.
+watcher = Test.Processes.Process("watcher")
+watcher.Command = "sleep 30"
+watcher.Ready = When.FileContains(ts.Disk.diags_log.Name, "defines 10 capture groups")
+watcher.StartBefore(ts)
+
+tr.Processes.Default.Command = "echo done"
+tr.TimeOut = 30
+tr.Processes.Default.StartBefore(watcher)

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_empty_replacement.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_empty_replacement.test.py
@@ -1,0 +1,90 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test prefetch.so does not self-prefetch when a valid pattern's replacement collapses to an empty path.
+
+The replacement here is just "$3", where group 3 ("(\\?.*)?") is optional.  For a query-less request
+that group is absent, so the replacement expands to the empty string.  An empty expanded path would
+otherwise be scheduled with zero length, which BgFetch skips -- leaving the pristine request path and
+prefetching the URL itself.  The plugin must instead log and stop; the client request is still served.
+'''
+
+server = Test.MakeOriginServer("server")
+for i in list(range(1, 1 + 2)):
+    request_header = {
+        "headers":
+            f"GET /texts/demo-{i} HTTP/1.1\r\n"
+            "Host: does.not.matter\r\n"  # But cannot be omitted.
+            "\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }
+    response_header = {
+        "headers": "HTTP/1.1 200 OK\r\n"
+                   "Connection: close\r\n"
+                   "Cache-control: max-age=85000\r\n"
+                   "\r\n",
+        "timestamp": "1469733493.993",
+        "body": f"This is the body for demo-{i}.\n"
+    }
+    server.addResponse("sessionlog.json", request_header, response_header)
+
+dns = Test.MakeDNServer("dns")
+
+ts = Test.MakeATSProcess("ts")
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|prefetch',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+        'proxy.config.dns.resolv_conf': "NULL",
+    })
+# A valid pattern (3 defined groups, $3 in range) whose replacement is only the optional $3 group.
+ts.Disk.remap_config.AddLine(
+    f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" + " @plugin=cachekey.so @pparam=--remove-all-params=true"
+    " @plugin=prefetch.so" + " @pparam=--front=true" + " @pparam=--fetch-policy=simple" +
+    r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(\?.*)?$/$3/" + " @pparam=--fetch-count=3")
+ts.ReturnCode = Any(0, -2)
+
+# The empty replacement must be logged and skipped.  This ContainsExpression both asserts the message
+# and replaces the default "diags.log must not contain ERROR:" check (it is logged via TSError).
+ts.Disk.diags_log.Content = Testers.ContainsExpression(
+    "produced an empty path", "an empty replacement must be logged and skipped, not self-prefetched")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(ts)
+tr.Processes.Default.Command = 'echo start TS, HTTP server and DNS.'
+tr.Processes.Default.ReturnCode = 0
+
+# The client request is still served normally even though the prefetch is skipped.
+tr = Test.AddTestRun()
+tr.MakeCurlCommand(f'--verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1')
+tr.Processes.Default.ReturnCode = 0
+
+Test.AddAwaitFileContainsTestRun('Await the empty-path skip to be logged.', ts.Disk.diags_log.Name, 'produced an empty path')
+
+# The self-prefetch that the old code issued would re-fetch the original path.  With the fix the loop
+# stops before scheduling, so "failed to process the pattern" (the old second-iteration symptom on the
+# emptied working path) must never appear.
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (f"grep -c 'failed to process the pattern' {ts.Disk.traffic_out.Name} || true")
+tr.Streams.stdout = Testers.ContainsExpression("0", "no per-request pattern-processing failure")
+tr.Processes.Default.ReturnCode = 0

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_optional_group.gold
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_optional_group.gold
@@ -1,0 +1,4 @@
+GET http://domain.in/texts/demo-1 HTTP/1.1
+GET http://domain.in/texts/demo-2 HTTP/1.1
+GET http://domain.in/texts/demo-3 HTTP/1.1
+GET http://domain.in/texts/demo-4 HTTP/1.1

--- a/tests/gold_tests/pluginTest/prefetch/prefetch_optional_group.test.py
+++ b/tests/gold_tests/pluginTest/prefetch/prefetch_optional_group.test.py
@@ -1,0 +1,95 @@
+'''
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Test prefetch.so with an optional trailing capture group that does not participate in the match.
+
+The fetch-path-pattern below ends in an optional "(\\?.*)?" group that only participates when the
+subject carries a query string.  For a query-less request that group is absent, so pcre_exec() returns
+3 -- one past the highest *participating* group -- even though the pattern defines a 3rd group that the
+replacement references as $3.  The old code compared $3 against that return value and wrongly rejected
+it; a non-participating group must instead substitute an empty string rather than fail the whole
+replacement (which previously logged "invalid reference in replacement string: $3" and silently
+dropped every prefetch).  Mirrors the production hls/mvod remap pattern
+"/(.*-)(\\.m3u8)(\\?.*)?$/$1-0.mp4$3/".
+'''
+
+server = Test.MakeOriginServer("server")
+for i in list(range(1, 1 + 4)):
+    request_header = {
+        "headers":
+            f"GET /texts/demo-{i} HTTP/1.1\r\n"
+            "Host: does.not.matter\r\n"  # But cannot be omitted.
+            "\r\n",
+        "timestamp": "1469733493.993",
+        "body": ""
+    }
+    response_header = {
+        "headers": "HTTP/1.1 200 OK\r\n"
+                   "Connection: close\r\n"
+                   "Cache-control: max-age=85000\r\n"
+                   "\r\n",
+        "timestamp": "1469733493.993",
+        "body": f"This is the body for demo-{i}.\n"
+    }
+    server.addResponse("sessionlog.json", request_header, response_header)
+
+dns = Test.MakeDNServer("dns")
+
+ts = Test.MakeATSProcess("ts")
+ts.Disk.records_config.update(
+    {
+        'proxy.config.diags.debug.enabled': 1,
+        'proxy.config.diags.debug.tags': 'http|dns|prefetch',
+        'proxy.config.dns.nameservers': f"127.0.0.1:{dns.Variables.Port}",
+        'proxy.config.dns.resolv_conf': "NULL",
+    })
+ts.Disk.remap_config.AddLine(
+    f"map http://domain.in http://127.0.0.1:{server.Variables.Port}" + " @plugin=cachekey.so @pparam=--remove-all-params=true"
+    " @plugin=prefetch.so" + " @pparam=--front=true" + " @pparam=--fetch-policy=simple" +
+    r" @pparam=--fetch-path-pattern=/(.*-)(\d+)(\?.*)?$/$1{$2+1}$3/" + " @pparam=--fetch-count=3")
+ts.ReturnCode = Any(0, -2)
+
+# Belt-and-suspenders next to the gold comparison (which is the primary guard): a regression that
+# re-introduces a per-request rejection of the non-participating $3 logs an "invalid reference ..."
+# error.  This pattern is valid (3 defined groups, $3 in range) so the compile-time validator never
+# fires either, hence no "invalid reference" text should ever reach the log.
+ts.Disk.traffic_out.Content = Testers.ExcludesExpression(
+    "invalid reference", "optional non-participating group must not fail the replacement")
+
+tr = Test.AddTestRun()
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(dns)
+tr.Processes.Default.StartBefore(ts)
+tr.Processes.Default.Command = 'echo start TS, HTTP server and DNS.'
+tr.Processes.Default.ReturnCode = 0
+
+tr = Test.AddTestRun()
+tr.MakeCurlCommand(f'--verbose --proxy 127.0.0.1:{ts.Variables.port} http://domain.in/texts/demo-1')
+tr.Processes.Default.ReturnCode = 0
+
+# The original request and the three prefetches are logged independently and may finish out of
+# order, so wait for every expected URL to be logged before comparing, and sort both sides so the
+# comparison does not depend on completion order.
+for tag in ['demo-1', 'demo-2', 'demo-3', 'demo-4']:
+    Test.AddAwaitFileContainsTestRun(f'Await {tag} to be logged.', ts.Disk.traffic_out.Name, tag)
+
+tr = Test.AddTestRun()
+tr.Processes.Default.Command = (f"grep 'GET http://domain.in' {ts.Disk.traffic_out.Name} | sort")
+tr.Streams.stdout = "prefetch_optional_group.gold"
+tr.Processes.Default.ReturnCode = 0


### PR DESCRIPTION
Fifth round of cherry-picks for the 10.2.0 release candidate, covering the PRs at "For v10.2.0" in the [ATS v10.2.x project](https://github.com/orgs/apache/projects/573).

All picked with `git cherry-pick -x` in master merge order; every pick applied cleanly with no conflicts, and each commit's diffstat matches its master commit exactly.

| PR | Title |
|---|---|
| #13517 | Bound `RegexMatches::operator[]` by what the match populated |
| #13352 | prefetch: don't drop replacements for non-participating optional capture groups |
| #13523 | Shut the client read side down per transaction, not per connection |

**Merge order is load-bearing here even though no files overlap.** #13352's `replace()` relies on `matches[replIndex]` returning a non-null view for a capture group inside the match count that did not participate:

```cpp
std::string_view dst = (replIndex < matchCount) ? matches[replIndex] : std::string_view{""};
PrefetchDebug("replacing '$%d' with '%.*s'", replIndex, static_cast<int>(dst.length()), dst.data());
```

The `""` there covers only the out-of-range branch. The non-participating-but-in-range case is what #13517 fixes centrally, by returning `""` instead of a default-constructed `std::string_view` from `RegexMatches::operator[]`. #13441 — already on this branch — introduced that null-`data()` return, so picking #13352 without #13517 first would leave a null pointer reaching `"%.*s"` and `std::string::append`. #13517 merged four minutes before #13352 upstream, so master merge order gives the correct sequence.

#13523 completes the other half of #12529: `state_watch_for_client_abort` reached past the transaction to the shared `NetVConnection` to half-close the client read side, which for HTTP/2 and HTTP/3 stopped the whole session from reading frames for every other stream. #12529 converted the two branches it touched but left the pre-existing `IO_SHUTDOWN_READ` call, and `HttpSM.cc` was the only site in the tree still doing that.

Verified before pushing: every `Disk.*` attribute, `Test.*` helper and `Condition.*` used by the new tests exists on this branch — including `Test.AddAwaitFileContainsTestRun` and `Condition.HasProxyVerifierVersion('2.8.0')`, which this branch satisfies since it pins Proxy Verifier v3.1.3 — and all eight `proxy.config.*` records the new tests reference resolve in `RecordsConfig.cc`. No picked test reaches for a master-only config idiom (`ssl_multicert_yaml` or `storage_yaml`).

Local build is clean and `ctest` is **167/167**. `cmake --build ... --target format` makes no changes.

Draft so the full CI matrix runs against the picked set before the release branch moves; it will be landed by fast-forward.
