### PR TITLE
Strip unauthorized x-amz- request headers in origin_server_auth

### DIFF
--- a/doc/admin-guide/plugins/origin_server_auth.en.rst
+++ b/doc/admin-guide/plugins/origin_server_auth.en.rst
@@ -152,6 +152,11 @@ If ``--v4-include-headers`` is not specified all headers except those specified 
 
 If ``--v4-include-headers`` is specified only the headers specified will be signed except those specified in ``--v4-exclude-headers``
 
+Since all ``x-amz-*`` headers are always signed, an ``x-amz-*`` header sent by a client would otherwise reach the
+origin with a valid signature covering whatever value the client chose. To prevent this, any ``x-amz-*`` header
+present on the client request is stripped before signing unless it is explicitly named in
+``--v4-include-headers``.
+
 
 AWS Authentication version 2
 ============================

--- a/plugins/origin_server_auth/aws_auth_v4.cc
+++ b/plugins/origin_server_auth/aws_auth_v4.cc
@@ -427,7 +427,7 @@ getCanonicalRequestSha256Hash(TsInterface &api, bool signPayload, const StringSe
     std::transform(lowercaseName.begin(), lowercaseName.end(), lowercaseName.begin(), ::tolower);
 
     /* Host, content-type and x-amx-* headers are mandatory */
-    bool xAmzHeader        = (lowercaseName.length() >= X_AMZ.length() && 0 == lowercaseName.compare(0, X_AMZ.length(), X_AMZ));
+    bool xAmzHeader        = isXAmzHeader(lowercaseName);
     bool contentTypeHeader = (0 == CONTENT_TYPE.compare(lowercaseName));
     bool hostHeader        = (0 == HOST.compare(lowercaseName));
     if (!xAmzHeader && !contentTypeHeader && !hostHeader) {

--- a/plugins/origin_server_auth/aws_auth_v4.h
+++ b/plugins/origin_server_auth/aws_auth_v4.h
@@ -69,6 +69,16 @@ static const String HOST                 = "host";
 
 String trimWhiteSpaces(const String &s);
 
+/**
+ * @brief Check if an already-lowercased header name has the "x-amz-" prefix.
+ * @param lowercaseName header name, already lowercased by the caller.
+ */
+inline bool
+isXAmzHeader(const String &lowercaseName)
+{
+  return lowercaseName.length() >= X_AMZ.length() && 0 == lowercaseName.compare(0, X_AMZ.length(), X_AMZ);
+}
+
 template <typename ContainerType>
 void
 commaSeparateString(ContainerType &ss, const String &input, bool trim = true, bool lowerCase = true)

--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -795,6 +795,7 @@ public:
   TSHttpStatus authorizeGcp(S3Config *s3);
   TSHttpStatus authorize(S3Config *s3);
   bool         set_header(const char *header, int header_len, const char *val, int val_len);
+  void         stripUnauthorizedAmzHeaders(const StringSet &allowedHeaders);
 
 private:
   TSHttpTxn _txnp;
@@ -851,6 +852,57 @@ S3Request::set_header(const char *header, int header_len, const char *val, int v
   return ret;
 }
 
+///////////////////////////////////////////////////////////////////////////
+// Unlike isXAmzHeader(), takes the raw (not pre-lowercased) name, so callers
+// can skip lowercasing/allocating for headers that don't match.
+static bool
+hasXAmzPrefix(const char *name, int name_len)
+{
+  return name && name_len >= static_cast<int>(X_AMZ.length()) && 0 == strncasecmp(name, X_AMZ.c_str(), X_AMZ.length());
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Strip any x-amz- request header the client sent that isn't explicitly
+// allow-listed via v4-include-headers. AWS SigV4 always signs whatever
+// x-amz- headers are present at signing time, so an unsolicited client
+// x-amz- header (e.g. x-amz-acl) would otherwise reach S3 with a valid
+// signature, which can trigger bucket-policy denials that get negatively
+// cached.
+void
+S3Request::stripUnauthorizedAmzHeaders(const StringSet &allowedHeaders)
+{
+  TSMLoc field_loc = TSMimeHdrFieldGet(_bufp, _hdr_loc, 0);
+
+  while (field_loc) {
+    TSMLoc next_field_loc = TSMimeHdrFieldNext(_bufp, _hdr_loc, field_loc);
+
+    int         name_len = 0;
+    const char *name     = TSMimeHdrFieldNameGet(_bufp, _hdr_loc, field_loc, &name_len);
+
+    if (hasXAmzPrefix(name, name_len)) {
+      bool strip = allowedHeaders.empty();
+
+      // allowedHeaders is empty in the common case (v4-include-headers unset), where every
+      // x-amz- header is stripped unconditionally, so skip lowercasing/allocating the name
+      // and the set lookup below.
+      if (!strip) {
+        String lowercaseName(name, name_len);
+        std::transform(lowercaseName.begin(), lowercaseName.end(), lowercaseName.begin(),
+                       [](unsigned char c) { return ::tolower(c); });
+        strip = allowedHeaders.end() == allowedHeaders.find(lowercaseName);
+      }
+
+      if (strip) {
+        Dbg(dbg_ctl, "stripping unauthorized client header %.*s", name_len, name);
+        TSMimeHdrFieldDestroy(_bufp, _hdr_loc, field_loc);
+      }
+    }
+
+    TSHandleMLocRelease(_bufp, _hdr_loc, field_loc);
+    field_loc = next_field_loc;
+  }
+}
+
 // dst points to starting offset of dst buffer
 // dst_len remaining space in buffer
 static size_t
@@ -888,6 +940,8 @@ S3Request::authorize(S3Config *s3)
 TSHttpStatus
 S3Request::authorizeAwsV4(S3Config *s3)
 {
+  stripUnauthorizedAmzHeaders(s3->v4includeHeaders());
+
   TsApi  api(_bufp, _hdr_loc, _url_loc);
   time_t now = time(nullptr);
 

--- a/tests/gold_tests/pluginTest/origin_server_auth/amz_strip.replay.yaml
+++ b/tests/gold_tests/pluginTest/origin_server_auth/amz_strip.replay.yaml
@@ -1,0 +1,79 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+autest:
+  description: 'Verify origin_server_auth strips unauthorized x-amz- request headers before signing'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+
+    copy_to_config_dir:
+      - 'rules'
+
+    remap_config:
+      - from: "http://www.example.com/s3-strip"
+        to: "http://127.0.0.1:{SERVER_HTTP_PORT}/s3-strip"
+        plugins:
+          - name: "origin_server_auth.so"
+            args:
+              - "--config"
+              - "rules/v4-strip-test.test_input"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /s3-strip
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ uuid, 1 ]
+        - [ x-amz-acl, public-read ]
+        - [ x-amz-acl, public-read-write ]
+        - [ X-Amz-Tagging, whatever ]
+        - [ x-amz-allowed-test, keep-me ]
+        - [ x-amz-security-token, forged-token-value ]
+
+    # Verify what origin_server_auth actually forwarded to the origin: unauthorized
+    # x-amz- headers (including duplicates and mixed case) must be stripped, while
+    # the one named in v4-include-headers survives.
+    proxy-request:
+      headers:
+        fields:
+        - [ x-amz-acl, { as: absent } ]
+        - [ x-amz-tagging, { as: absent } ]
+        - [ x-amz-security-token, { as: absent } ]
+        - [ x-amz-allowed-test, { value: keep-me, as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/pluginTest/origin_server_auth/amz_strip.test.py
+++ b/tests/gold_tests/pluginTest/origin_server_auth/amz_strip.test.py
@@ -1,0 +1,26 @@
+'''
+Test that origin_server_auth strips unauthorized x-amz- request headers.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+Verify that a client-supplied x-amz- header not named in v4-include-headers is
+stripped before the request is signed and sent to the origin, while one that
+is explicitly allow-listed survives.
+'''
+
+Test.ATSReplayTest(replay_file="amz_strip.replay.yaml")

--- a/tests/gold_tests/pluginTest/origin_server_auth/rules/v4-strip-test.test_input
+++ b/tests/gold_tests/pluginTest/origin_server_auth/rules/v4-strip-test.test_input
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test config for verifying that unauthorized client x-amz- headers are
+# stripped before signing, while explicitly allow-listed ones survive.
+
+access_key=AKIAIOSFODNN7EXAMPLE
+secret_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+version=awsv4
+v4-include-headers=x-amz-allowed-test


### PR DESCRIPTION
AWS SigV4 always signs whatever x-amz- headers are present at signing time, so a client-supplied x-amz- header not named in --v4-include-headers would otherwise reach S3 with a valid signature, which can trigger bucket-policy denials that get negatively cached.