### PR TITLE
Change libswoc test for undefined errno to a much higher number

### DIFF
--- a/lib/swoc/unit_tests/test_bw_format.cc
+++ b/lib/swoc/unit_tests/test_bw_format.cc
@@ -525,7 +525,7 @@ TEST_CASE("bwstring std formats", "[libswoc][bwprint]") {
 
   w.print("{}", swoc::bwf::Errno(13));
   REQUIRE(w.view() == "EACCES: Permission denied [13]"sv);
-  w.clear().print("{}", swoc::bwf::Errno(134));
+  w.clear().print("{}", swoc::bwf::Errno(192));
   REQUIRE(w.view().substr(0, 22) == "Unknown: Unknown error"sv);
   w.clear().print("{:s}", swoc::bwf::Errno(13));
   REQUIRE(w.view() == "EACCES: Permission denied"sv);


### PR DESCRIPTION
libswoc tests include one that expects errno 134 to be unknown; this is no longer the case in Linux 7.2.  This patch increases the errno to one that should be unknown for the forseeable future.