### PR TITLE
Fix signature on flz_maxcopy to avoid cast error

### DIFF
--- a/lib/fastlz/fastlz.cc
+++ b/lib/fastlz/fastlz.cc
@@ -162,7 +162,7 @@ static void flz_smallcopy(uint8_t* dest, const uint8_t* src, uint32_t count) {
 }
 
 /* special case of memcpy: exactly MAX_COPY bytes */
-static void flz_maxcopy(void* dest, const void* src) {
+static void flz_maxcopy(uint8_t* dest, const uint8_t* src) {
 #if defined(FLZ_ARCH64)
   const uint32_t* p = (const uint32_t*)src;
   uint32_t* q = (uint32_t*)dest;


### PR DESCRIPTION
flz_maxcopy takes void* arguments but calls fastlz_memcopy (taking uint8_t* arguments) without a cast.  I don't see a reason for flz_maxcopy to not take uint8_t* arguments; for arch-specific speedups these get cast to the appropriately-sized pointer.  Resolves build issues on ppc64le architecture.