### PR TITLE
Fix an intermittent cache unit test deadlock at exit

### DIFF
--- a/src/iocore/cache/unit_tests/main.cc
+++ b/src/iocore/cache/unit_tests/main.cc
@@ -162,6 +162,20 @@ struct EventProcessorListener : Catch::EventListenerBase {
     std::string src_dir       = std::string(TS_ABS_TOP_SRCDIR) + "/src/iocore/cache/unit_tests/etc/";
     Layout::get()->sysconfdir = std::move(src_dir);
   }
+
+  // Every test binary using this harness reaches exit() with the event threads
+  // still running, so stop them and wait for them before static destruction
+  // frees the globals they read.
+  void
+  testRunEnded(Catch::TestRunStats const & /* stats ATS_UNUSED */) override
+  {
+    TSSystemState::shut_down_event_system();
+    for (EThread *ethread : eventProcessor.active_ethreads()) {
+      if (ethread->tid != ink_thread_null()) {
+        ink_thread_join(ethread->tid);
+      }
+    }
+  }
 };
 CATCH_REGISTER_LISTENER(EventProcessorListener);
 


### PR DESCRIPTION
The cache unit test harness starts the event and net processors but
never stops them, so every test binary reaches exit() with ET_NET
threads still running. Static destruction then frees globals out from
under those threads: the records table in RecCore.cc is destroyed while
a still-initializing event thread reads it through RecGetRecordInt(),
and the ts::Metrics storage blob is released while NetHandler's activity
loop increments a counter into it. Both are heap-use-after-frees, and
under ASan the reporting thread races the exiting main thread. Usually
the process dies first and the report is truncated to two lines with a
zero exit status, so ctest reports a pass; occasionally the report
deadlocks instead and the test hangs until ctest times it out after
1500 seconds. The short tests that never touch the cache lose this race
most often, which is why CacheAggregateWriteBuffer and CacheStripe are
the ones that fail.

This addresses the deadlock at its source by giving the harness's Catch2
listener a testRunEnded hook that shuts the event system down and joins
the event threads before the test binary returns from main. Once the
threads are gone, static destruction has no concurrent reader to race,
so neither use-after-free can be reported and the ASan reporting
deadlock cannot arise.

### Verification

Built with `--preset ci-rocky` (ASan, Debug) and looped the affected
binaries directly, since a full `ctest` pass rarely trips the race and the
failing runs still exit zero:

| Test | Before | After |
| --- | --- | --- |
| `CacheAggregateWriteBuffer` | 15 ASan reports / 4000 runs | 0 / 2000 runs |
| `CacheStripe` | 3 ASan reports / 600 runs | 0 / 600 runs |

The 15 reports split into the two use-after-frees described above: six
`READ of size 8` in `g_records_ht.find()`, reached from
`initialize_thread_for_net()` on a thread that has not finished starting,
and nine `WRITE of size 8` in `ts::Metrics::Counter::increment()` from
`NetHandler::waitForActivity()`. Both are freed by the main thread from
static destruction.

All 20 `test_cache*` plus `test_ConfigVolumes` targets pass with the fix, so
joining the event threads does not hang the tests that drive the cache and
already call `TSSystemState::shut_down_event_system()` themselves.

Ten full `ctest -j4` passes were clean, which is expected: this bug reports
a zero exit status in the overwhelming majority of cases and is only visible
in CI when the ASan report deadlocks instead, as in the Rocky Linux build
that prompted this patch.
