### PR TITLE
Avoid needless copies reported by Coverity Scan

### DIFF
--- a/plugins/cachekey/cachekey.cc
+++ b/plugins/cachekey/cachekey.cc
@@ -518,7 +518,7 @@ captureWholeHeaders(const ConfigHeaders &config, const String &name, const Strin
   if (config.toBeAdded(name)) {
     String header;
     header.append(name).append(":").append(value);
-    captures.insert(header);
+    captures.insert(std::move(header));
     CacheKeyDebug("adding header '%s: %s'", name.c_str(), value.c_str());
   } else {
     CacheKeyDebug("failed to find header '%s'", name.c_str());

--- a/plugins/cachekey/configs.cc
+++ b/plugins/cachekey/configs.cc
@@ -587,7 +587,7 @@ Configs::setKeyType(const char *arg)
     StringVector types;
     ::commaSeparateString<StringVector>(types, arg);
 
-    for (auto type : types) {
+    for (const auto &type : types) {
       if (9 == type.length() && 0 == strncasecmp(type.c_str(), "cache_key", 9)) {
         _keyTypes.insert(CacheKeyKeyType::CACHE_KEY);
         CacheKeyDebug("setting cache key");

--- a/plugins/esi/lib/EsiParser.cc
+++ b/plugins/esi/lib/EsiParser.cc
@@ -27,6 +27,7 @@
 #include <ts/ts.h>
 
 #include <cctype>
+#include <utility>
 
 using std::string;
 using namespace EsiLib;
@@ -256,7 +257,7 @@ EsiParser::_processSimpleContentTag(DocNode::TYPE node_type, const char *data, i
     TSError("[%s] Could not parse simple content of [%s] node", __FUNCTION__, DocNode::type_names_[node_type]);
     return false;
   }
-  node_list.push_back(new_node);
+  node_list.push_back(std::move(new_node));
   return true;
 }
 
@@ -541,7 +542,7 @@ EsiParser::_processTryTag(const string &data, size_t curr_pos, size_t end_pos, D
     TSError("[%s] try block must contain one each of attempt and except nodes", __FUNCTION__);
     return false;
   }
-  node_list.push_back(try_node);
+  node_list.push_back(std::move(try_node));
   Dbg(dbg_ctl, "[%s] Added try node successfully", __FUNCTION__);
   return true;
 }
@@ -586,7 +587,7 @@ EsiParser::_processChooseTag(const string &data, size_t curr_pos, size_t end_pos
     }
     ++iter;
   }
-  node_list.push_back(choose_node);
+  node_list.push_back(std::move(choose_node));
   return true;
 }
 

--- a/plugins/experimental/access_control/config.cc
+++ b/plugins/experimental/access_control/config.cc
@@ -100,10 +100,10 @@ loadLine<StringMap>(StringMap &map, const String &line)
   std::getline(ss, value, '=');
   trim(key);
   trim(value);
-  map[key] = value;
+  map[key] = std::move(value);
 
 #ifdef ACCESS_CONTROL_LOG_SECRETS
-  AccessControlDebug("Adding secrets[%s]='%s'", key.c_str(), value.c_str());
+  AccessControlDebug("Adding secrets[%s]='%s'", key.c_str(), map[key].c_str());
 #endif
 }
 
@@ -116,10 +116,10 @@ loadLine<StringVector>(StringVector &vector, const String &line)
 {
   String trimmedLine(line);
   trim(trimmedLine);
-  vector.push_back(trimmedLine);
+  vector.push_back(std::move(trimmedLine));
 
 #ifdef ACCESS_CONTROL_LOG_SECRETS
-  AccessControlDebug("Adding secrets[%d]='%s'", (int)(vector.size() - 1), trimmedLine.c_str());
+  AccessControlDebug("Adding secrets[%d]='%s'", (int)(vector.size() - 1), vector.back().c_str());
 #endif
 }
 

--- a/plugins/experimental/access_control/pattern.cc
+++ b/plugins/experimental/access_control/pattern.cc
@@ -163,7 +163,7 @@ Pattern::process(const String &subject, StringVector &result)
     /* Replacement pattern was provided in the configuration - capture and replace. */
     String element;
     if (replace(subject, element)) {
-      result.push_back(element);
+      result.push_back(std::move(element));
     } else {
       return false;
     }
@@ -242,7 +242,7 @@ Pattern::capture(const String &subject, StringVector &result)
     String           dst(match_view.data(), match_view.size());
 
     AccessControlDebug("capturing '%s' %d", dst.c_str(), i);
-    result.push_back(dst);
+    result.push_back(std::move(dst));
   }
 
   return true;

--- a/plugins/experimental/jax_fingerprint/ja4h/test.cc
+++ b/plugins/experimental/jax_fingerprint/ja4h/test.cc
@@ -78,7 +78,7 @@ public:
     SHA256_CTX sha256ctx;
     SHA256_Init(&sha256ctx);
 
-    for (auto ite : this->_fields) {
+    for (auto const &ite : this->_fields) {
       if (this->_should_include_field({ite.first.c_str(), ite.first.size()})) {
         SHA256_Update(&sha256ctx, ite.first.c_str(), ite.first.size());
       }

--- a/plugins/experimental/rate_limit/sni_selector.cc
+++ b/plugins/experimental/rate_limit/sni_selector.cc
@@ -149,7 +149,7 @@ SniSelector::yamlParser(const std::string &yaml_file)
                   return false;
                 }
                 Dbg(dbg_ctl, "Adding alias: %s -> %s", alias.c_str(), name.c_str());
-                addAlias(alias, limiter_ptr);
+                addAlias(std::move(alias), limiter_ptr);
               }
             } else {
               TSError("[%s] aliases node is not a sequence", PLUGIN_NAME);

--- a/plugins/experimental/rate_limit/txn_limiter.cc
+++ b/plugins/experimental/rate_limit/txn_limiter.cc
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <cstdlib>
+#include <utility>
 
 #include "txn_limiter.h"
 
@@ -178,7 +179,7 @@ TxnRateLimiter::initialize(int argc, const char *argv[])
     _action = TSContScheduleEveryOnPool(_queue_cont, QUEUE_DELAY_TIME.count(), TS_THREAD_POOL_TASK);
   }
 
-  this->initializeMetrics(RATE_LIMITER_TYPE_REMAP, tag, prefix);
+  this->initializeMetrics(RATE_LIMITER_TYPE_REMAP, std::move(tag), std::move(prefix));
 
   return true;
 }

--- a/plugins/experimental/stek_share/log_store.cc
+++ b/plugins/experimental/stek_share/log_store.cc
@@ -80,7 +80,7 @@ STEKShareLogStore::append(nuraft::ptr<nuraft::log_entry> &entry)
 
   std::lock_guard<std::mutex> l(logs_lock_);
   size_t                      idx = start_idx_ + logs_.size() - 1;
-  logs_[idx]                      = clone;
+  logs_[idx]                      = std::move(clone);
   return idx;
 }
 
@@ -205,7 +205,7 @@ STEKShareLogStore::pack(uint64_t index, int32_t cnt)
     assert(le.get());
     nuraft::ptr<nuraft::buffer> buf  = le->serialize();
     size_total                      += buf->size();
-    logs.push_back(buf);
+    logs.push_back(std::move(buf));
   }
 
   nuraft::ptr<nuraft::buffer> buf_out = nuraft::buffer::alloc(sizeof(int32_t) + cnt * sizeof(int32_t) + size_total);
@@ -236,7 +236,7 @@ STEKShareLogStore::apply_pack(uint64_t index, nuraft::buffer &pack)
     nuraft::ptr<nuraft::log_entry> le = nuraft::log_entry::deserialize(*buf_local);
     {
       std::lock_guard<std::mutex> l(logs_lock_);
-      logs_[cur_idx] = le;
+      logs_[cur_idx] = std::move(le);
     }
   }
 

--- a/plugins/experimental/stek_share/state_machine.h
+++ b/plugins/experimental/stek_share/state_machine.h
@@ -208,7 +208,7 @@ public:
 
     {
       std::lock_guard<std::mutex> l(snapshot_lock_);
-      snapshot_ = ctx;
+      snapshot_ = std::move(ctx);
     }
 
     nuraft::ptr<std::exception> except(nullptr);

--- a/plugins/experimental/stek_share/state_manager.h
+++ b/plugins/experimental/stek_share/state_manager.h
@@ -19,6 +19,8 @@ limitations under the License.
 
 #pragma once
 
+#include <utility>
+
 #include <libnuraft/nuraft.hxx>
 
 #include "log_store.h"
@@ -37,7 +39,7 @@ public:
       int                             server_id  = s.first;
       std::string                     endpoint   = s.second;
       nuraft::ptr<nuraft::srv_config> new_server = nuraft::cs_new<nuraft::srv_config>(server_id, endpoint);
-      saved_config_->get_servers().push_back(new_server);
+      saved_config_->get_servers().push_back(std::move(new_server));
     }
   }
 

--- a/plugins/experimental/stek_share/stek_share.cc
+++ b/plugins/experimental/stek_share/stek_share.cc
@@ -124,7 +124,7 @@ message_handler(TSCont /* contp ATS_UNUSED */, TSEvent event, void *edata)
               TSError("[%s] Raft initialization failed with new config, retrying with old config.", PLUGIN_NAME);
               auto config_old = get_scoped_config(true);
               restore_config(config_old);
-              if (init_raft(nuraft::cs_new<STEKShareSM>(), config_old) == 0) {
+              if (init_raft(nuraft::cs_new<STEKShareSM>(), std::move(config_old)) == 0) {
                 Dbg(dbg_ctl, "Server ID: %d, Endpoint: %s", config->server_id, config->endpoint.c_str());
               } else {
                 TSEmergency("[%s] Raft initialization failed with old config.", PLUGIN_NAME);
@@ -168,7 +168,7 @@ init_raft(nuraft::ptr<nuraft::state_machine> sm_instance, std::shared_ptr<Plugin
   // State machine.
   {
     std::unique_lock lock(stek_share_server.sm_mutex);
-    stek_share_server.sm_instance = sm_instance;
+    stek_share_server.sm_instance = std::move(sm_instance);
   }
 
   // ASIO options.
@@ -349,7 +349,7 @@ load_config_from_file()
   }
 
   std::unique_lock lock(plugin_config_mutex);
-  plugin_config = new_config;
+  plugin_config = std::move(new_config);
 
   return 0;
 }

--- a/plugins/header_rewrite/operators.cc
+++ b/plugins/header_rewrite/operators.cc
@@ -1269,8 +1269,8 @@ OperatorRunPlugin::initialize(Parser &p)
 {
   Operator::initialize(p);
 
-  auto plugin_name = p.get_arg();
-  auto plugin_args = p.get_value();
+  const auto &plugin_name = p.get_arg();
+  const auto &plugin_args = p.get_value();
 
   if (plugin_name.empty()) {
     throw std::runtime_error("run-plugin missing plugin name");

--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -134,7 +134,7 @@ loadRegionMap(StringMap &m, const String &filename)
       Dbg(dbg_ctl, "added entry-point:%s, region:%s", entrypoint.c_str(), region.c_str());
     }
 
-    m[entrypoint] = region;
+    m[entrypoint] = std::move(region);
   }
 
   if (m.at("").empty()) {

--- a/plugins/traffic_dump/session_data.cc
+++ b/plugins/traffic_dump/session_data.cc
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unordered_map>
+#include <utility>
 
 #include <tscore/ink_inet.h>
 
@@ -552,7 +553,7 @@ SessionData::global_session_handler(TSCont /* contp ATS_UNUSED */, TSEvent event
         TSHttpSsnReenable(ssnp, TS_EVENT_HTTP_CONTINUE);
         return TS_EVENT_HTTP_CONTINUE;
       }
-      ssnData->log_name = log_f;
+      ssnData->log_name = std::move(log_f);
       // Write log file beginning to disk
       ssnData->write_to_disk(beginning);
     }

--- a/plugins/traffic_dump/transaction_data.cc
+++ b/plugins/traffic_dump/transaction_data.cc
@@ -331,7 +331,7 @@ TransactionData::write_client_request_node_no_content(TSMBuffer &buffer, TSMLoc 
   std::ostringstream client_request_node;
   client_request_node << R"(,"client-request":{)";
 
-  auto const http_version = _http_version_from_client_stack;
+  auto const &http_version = _http_version_from_client_stack;
   if (http_version == "2") {
     client_request_node << R"("http2":{)";
 

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -8335,7 +8335,7 @@ TSSslServerCertUpdate(const char *cert_path, const char *key_path)
         return TS_ERROR;
       }
       // Atomic Swap
-      cc->setCtx(test_ctx);
+      cc->setCtx(std::move(test_ctx));
       return TS_SUCCESS;
     }
   }
@@ -8935,7 +8935,7 @@ TSRPCHandlerDone(TSYaml resp)
 {
   Dbg(dbg_ctl_rpc_api, ">> Handler seems to be done");
   std::lock_guard<std::mutex> lock(::rpc::g_rpcHandlingMutex);
-  auto                        data       = *reinterpret_cast<YAML::Node *>(resp);
+  auto                       &data       = *reinterpret_cast<YAML::Node *>(resp);
   ::rpc::g_rpcHandlerResponseData        = data;
   ::rpc::g_rpcHandlerProcessingCompleted = true;
   ::rpc::g_rpcHandlingCompletion.notify_one();

--- a/src/api/InkAPI.cc
+++ b/src/api/InkAPI.cc
@@ -8935,7 +8935,7 @@ TSRPCHandlerDone(TSYaml resp)
 {
   Dbg(dbg_ctl_rpc_api, ">> Handler seems to be done");
   std::lock_guard<std::mutex> lock(::rpc::g_rpcHandlingMutex);
-  auto                       &data       = *reinterpret_cast<YAML::Node *>(resp);
+  auto const                 &data       = *reinterpret_cast<YAML::Node const *>(resp);
   ::rpc::g_rpcHandlerResponseData        = data;
   ::rpc::g_rpcHandlerProcessingCompleted = true;
   ::rpc::g_rpcHandlingCompletion.notify_one();

--- a/src/config/ssl_multicert.cc
+++ b/src/config/ssl_multicert.cc
@@ -249,16 +249,16 @@ SSLMultiCertParser::parse_yaml(std::string_view content)
   try {
     YAML::Node config = YAML::Load(std::string(content));
     if (config.IsNull()) {
-      return {result, std::move(errata)};
+      return {std::move(result), std::move(errata)};
     }
 
     if (!config[KEY_SSL_MULTICERT]) {
-      return {result, swoc::Errata("expected a toplevel 'ssl_multicert' node")};
+      return {std::move(result), swoc::Errata("expected a toplevel 'ssl_multicert' node")};
     }
 
     YAML::Node entries = config[KEY_SSL_MULTICERT];
     if (!entries.IsSequence()) {
-      return {result, swoc::Errata("expected 'ssl_multicert' to be a sequence")};
+      return {std::move(result), swoc::Errata("expected 'ssl_multicert' to be a sequence")};
     }
 
     for (auto const &entry_node : entries) {
@@ -279,7 +279,7 @@ SSLMultiCertParser::parse_yaml(std::string_view content)
       result.push_back(entry_node.as<SSLMultiCertEntry>());
     }
   } catch (std::exception const &ex) {
-    return {result, swoc::Errata("YAML parse error: {}", ex.what())};
+    return {std::move(result), swoc::Errata("YAML parse error: {}", ex.what())};
   }
 
   return {std::move(result), std::move(errata)};

--- a/src/iocore/net/SSLCertLookup.cc
+++ b/src/iocore/net/SSLCertLookup.cc
@@ -433,7 +433,7 @@ SSLCertLookup::getPolicies(const std::string &secret_name, std::set<shared_SSLMu
 {
   auto iter = cert_secret_registry.find(secret_name);
   if (iter != cert_secret_registry.end()) {
-    for (auto name : iter->second) {
+    for (auto const &name : iter->second) {
       SSLCertContext *cc = this->find(name);
       if (cc) {
         policies.insert(cc->userconfig);

--- a/src/iocore/net/SSLNetVConnection.cc
+++ b/src/iocore/net/SSLNetVConnection.cc
@@ -48,6 +48,7 @@
 #include <netinet/in.h>
 #include <string>
 #include <cstring>
+#include <utility>
 
 #if TS_USE_TLS_ASYNC
 #include <openssl/async.h>
@@ -2398,7 +2399,7 @@ SSLNetVConnection::_ssl_connect()
 
         if (shared_sess && SSL_set_session(ssl, shared_sess.get())) {
           // Keep a reference of this shared pointer in the connection
-          this->client_sess = shared_sess;
+          this->client_sess = std::move(shared_sess);
         }
       }
     }

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -2121,7 +2121,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
   for (const char *keyname = key_tok.getNext(); keyname; keyname = key_tok.getNext()) {
     std::string completeServerKeyPath = Layout::get()->relative_to(params->serverKeyPathOnly, keyname);
-    data.key_list.push_back(completeServerKeyPath);
+    data.key_list.push_back(std::move(completeServerKeyPath));
   }
 
   for (const char *caname = ca_tok.getNext(); caname; caname = ca_tok.getNext()) {
@@ -2136,7 +2136,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
   int  cert_index = 0;
   for (const char *certname = cert_tok.getNext(); certname; certname = cert_tok.getNext()) {
     std::string completeServerCertPath = Layout::relative_to(params->serverCertPathOnly, certname);
-    data.cert_names_list.push_back(completeServerCertPath);
+    data.cert_names_list.push_back(std::move(completeServerCertPath));
   }
 
   for (size_t i = 0; i < data.cert_names_list.size(); i++) {
@@ -2231,7 +2231,7 @@ SSLMultiCertConfigLoader::load_certs_and_cross_reference_names(
 
     if (first_pass) {
       first_pass   = false;
-      common_names = name_set;
+      common_names = std::move(name_set);
     } else {
       // Check that all elements in common_names are in name_set
       auto common_iter = common_names.begin();

--- a/src/iocore/net/UnixNetAccept.cc
+++ b/src/iocore/net/UnixNetAccept.cc
@@ -135,7 +135,7 @@ net_accept(NetAccept *na, void *ep, bool blockable)
     if (!vc) {
       goto Ldone; // note: @a con will clean up the socket when it goes out of scope.
     }
-    vc->enable_inbound_connection_tracking(conn_track_group);
+    vc->enable_inbound_connection_tracking(std::move(conn_track_group));
 
     count++;
     Metrics::Gauge::increment(net_rsb.connections_currently_open);
@@ -420,7 +420,7 @@ NetAccept::do_blocking_accept(EThread *t)
     if (unlikely(!vc)) {
       return -1;
     }
-    vc->enable_inbound_connection_tracking(conn_track_group);
+    vc->enable_inbound_connection_tracking(std::move(conn_track_group));
 
     count++;
     Metrics::Gauge::increment(net_rsb.connections_currently_open);
@@ -588,7 +588,7 @@ NetAccept::acceptFastEvent(int event, void *ep)
 
     vc = static_cast<UnixNetVConnection *>(this->getNetProcessor()->allocate_vc(e->ethread));
     ink_release_assert(vc);
-    vc->enable_inbound_connection_tracking(conn_track_group);
+    vc->enable_inbound_connection_tracking(std::move(conn_track_group));
 
     count++;
     Metrics::Gauge::increment(net_rsb.connections_currently_open);

--- a/src/proxy/HostStatus.cc
+++ b/src/proxy/HostStatus.cc
@@ -309,7 +309,7 @@ HostStatus::getAllHostStatuses(std::vector<HostStatuses> &hosts)
       h.hostname = hsts.first;
       ss << *hsts.second;
       h.status = ss.str();
-      hosts.push_back(h);
+      hosts.push_back(std::move(h));
     }
   }
 }

--- a/src/proxy/http/PreWarmManager.cc
+++ b/src/proxy/http/PreWarmManager.cc
@@ -924,7 +924,7 @@ PreWarmQueue::_reconfigure()
       // copy from old info
       const Info &old_info = res->second;
 
-      new_map[dst] = Info{old_info.init_list, old_info.open_list, conf, old_info.stats_ids, old_info.stat};
+      new_map[dst] = Info{old_info.init_list, old_info.open_list, std::move(conf), old_info.stats_ids, old_info.stat};
     } else {
       // make new info
       PreWarm::SPtrConstStatsIds stats_ids;
@@ -937,7 +937,7 @@ PreWarmQueue::_reconfigure()
 
       Queue *init_list = new Queue();
       Queue *open_list = new Queue();
-      new_map[dst]     = Info{init_list, open_list, conf, stats_ids, {}};
+      new_map[dst]     = Info{init_list, open_list, std::move(conf), std::move(stats_ids), {}};
     }
   }
 

--- a/src/traffic_ctl/CtrlCommands.cc
+++ b/src/traffic_ctl/CtrlCommands.cc
@@ -990,7 +990,7 @@ PluginCommand::plugin_msg()
     // have a value
     params.str = msgs[1];
   }
-  BasicPluginMessageRequest request{params};
+  BasicPluginMessageRequest request{std::move(params)};
   auto                      response = invoke_rpc(request);
   _printer->write_output(response);
 }

--- a/src/traffic_ctl/jsonrpc/ctrl_yaml_codecs.h
+++ b/src/traffic_ctl/jsonrpc/ctrl_yaml_codecs.h
@@ -299,7 +299,7 @@ template <> struct convert<HostStatusLookUpResponse> {
       HostStatusLookUpResponse::HostStatusInfo hi;
       hi.hostName = item["hostname"].Scalar();
       hi.status   = item["status"].Scalar();
-      info.statusList.push_back(hi);
+      info.statusList.push_back(std::move(hi));
     }
     for (auto &&item : errorList) {
       info.errorList.push_back(item.Scalar());

--- a/src/tscore/ArgParser.cc
+++ b/src/tscore/ArgParser.cc
@@ -301,8 +301,8 @@ ArgParser::Command::add_option(std::string const &long_option, std::string const
 {
   std::string lookup_key = key.empty() ? long_option.substr(2) : key;
   check_option(long_option, short_option, lookup_key);
-  _option_list[long_option] = {long_option, short_option == "-" ? "" : short_option, description, envvar, arg_num, default_value,
-                               lookup_key};
+  _option_list[long_option] = {
+    long_option, short_option == "-" ? "" : short_option, description, envvar, arg_num, default_value, std::move(lookup_key)};
   if (short_option != "-" && !short_option.empty()) {
     _option_map[short_option] = long_option;
   }

--- a/src/tscore/Layout.cc
+++ b/src/tscore/Layout.cc
@@ -161,7 +161,7 @@ Layout::Layout(std::string_view const _prefix)
       if ((len + 1) > PATH_NAME_MAX) {
         ink_fatal("TS_ROOT environment variable is too big: %d, max %d\n", len, PATH_NAME_MAX - 1);
       }
-      path = env_path;
+      path = std::move(env_path);
       while (path.back() == '/') {
         path.pop_back();
       }
@@ -169,7 +169,7 @@ Layout::Layout(std::string_view const _prefix)
       // Use compile time --prefix
       path = TS_BUILD_PREFIX;
     }
-    prefix = path;
+    prefix = std::move(path);
   }
   exec_prefix   = layout_relative(prefix, TS_BUILD_EXEC_PREFIX);
   bindir        = layout_relative(prefix, TS_BUILD_BINDIR);

--- a/src/tscore/runroot.cc
+++ b/src/tscore/runroot.cc
@@ -29,6 +29,7 @@
 #include "tscore/Layout.h"
 #include "tscore/runroot.h"
 #include <yaml-cpp/yaml.h>
+#include <utility>
 
 static std::string runroot_file = {};
 
@@ -110,7 +111,7 @@ runroot_extra_handling(const char *executable, bool json)
   if (env_val) {
     path = get_yaml_path(env_val);
     if (!path.empty()) {
-      runroot_file = path;
+      runroot_file = std::move(path);
       if (!json) {
         ink_notice("using the environment variable TS_RUNROOT");
       }
@@ -124,7 +125,7 @@ runroot_extra_handling(const char *executable, bool json)
   if (getcwd(cwd, sizeof(cwd)) != nullptr) {
     path = get_parent_yaml_path(cwd);
     if (!path.empty()) {
-      runroot_file = path;
+      runroot_file = std::move(path);
       if (!json) {
         ink_notice("using cwd as TS_RUNROOT");
       }
@@ -138,7 +139,7 @@ runroot_extra_handling(const char *executable, bool json)
     bindir             = bindir.substr(0, bindir.find_last_of('/')); // getting the bin dir not executable path
     path               = get_parent_yaml_path(bindir);
     if (!path.empty()) {
-      runroot_file = path;
+      runroot_file = std::move(path);
       if (!json) {
         ink_notice("using the installed dir as TS_RUNROOT");
       }
@@ -161,7 +162,7 @@ argparser_runroot_handler(std::string const &value, const char *executable, bool
       if (!json) {
         ink_notice("using command line path as RUNROOT");
       }
-      runroot_file = path;
+      runroot_file = std::move(path);
       return;
     } else if (!json) {
       ink_warning("Unable to access runroot: '%s'", value.c_str());
@@ -201,7 +202,7 @@ runroot_handler(const char **argv, bool json)
       if (!json) {
         ink_notice("using command line path as RUNROOT");
       }
-      runroot_file = path;
+      runroot_file = std::move(path);
       return;
     } else if (!json) {
       ink_warning("Unable to access runroot: '%s'", value.c_str());
@@ -250,7 +251,7 @@ runroot_map(const std::string &file)
       if (value[0] != '/') {
         value = Layout::relative_to(prefix, value);
       }
-      map[it.first.as<std::string>()] = value;
+      map[it.first.as<std::string>()] = std::move(value);
     }
   } catch (YAML::Exception &e) {
     ink_warning("Unable to read '%s': %s", file.c_str(), e.what());

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -254,7 +254,7 @@ namespace details
     push_back(const DerivedMetric &m)
     {
       std::lock_guard l(metrics_lock);
-      metrics.push_back(std::move(m));
+      metrics.push_back(m);
     }
 
     static DerivativeMetrics &


### PR DESCRIPTION
Part 1 of 3 splitting a Coverity Scan cleanup into independently reviewable pieces. This one is deliberately the boring part: **no behavior change anywhere**.

### What this does

- Replaces a copy with `std::move` where the source is never used again (42 sites).
- Binds `const auto &` / `auto const &` instead of copying where a loop variable or local only reads the referent (7 sites).
- Adds `<utility>` to four files that name `std::move` without including it directly.

### How it was checked

Every move source was traced to the end of its scope to confirm it is not read after the move. The three `enable_inbound_connection_tracking(std::move(conn_track_group))` sites are worth a second look if you want a spot check: `conn_track_group` is declared *inside* each accept loop body, so no iteration inherits a moved-from group. A shared declaration there would have silently disabled inbound connection tracking after the first connection.

Every reference conversion was checked to make sure it binds to something that outlives the use, not to a temporary.

### Reports deliberately not acted on

Coverity flags five `auto` copies in the next-hop YAML parsers (`NextHopSelectionStrategy.cc`, `NextHopConsistentHash.cc`). Those are **false positives** and are left alone: the node accessors return by value, so `const auto &x = n["scheme"].Scalar()` binds a reference into a temporary that dies at the end of the statement. GCC's `-Wdangling-reference` confirms it.

`ConfigContext` parameters reported as oversized are also left alone. They are by value by design, because the reload handler signature requires it and the handlers mutate the context.

### Verification

Clean build with no new warnings and the full unit test suite passing (137/137) on Fedora, GCC 16.1.1.

Getting every modified file actually compiled took three extra options, which is worth stating precisely rather than claiming full coverage:

- `uri_signing` needs cjose, `stek_share` needs nuraft, and `jax_fingerprint` defaults to off. With `-DENABLE_URI_SIGNING=ON -DENABLE_STEK_SHARE=ON -DENABLE_JAX_FINGERPRINT=ON` all of them build and their objects appear in the graph.
- The two `access_control` changes sit behind `#ifdef ACCESS_CONTROL_LOG_SECRETS`, which no build here defines, so those two lines are reviewed but not compiled.

Draft while CI runs.

