### PR TITLE
Remove unreachable code reported by Coverity Scan

### DIFF
--- a/plugins/experimental/jax_fingerprint/ja4h/test.cc
+++ b/plugins/experimental/jax_fingerprint/ja4h/test.cc
@@ -105,7 +105,7 @@ public:
 
 private:
   std::string                        _method;
-  int                                _version;
+  int                                _version{};
   std::map<std::string, std::string> _fields{};
 };
 

--- a/src/iocore/cache/unit_tests/test_RWW.cc
+++ b/src/iocore/cache/unit_tests/test_RWW.cc
@@ -240,20 +240,11 @@ public:
           this->_read_event = this_ethread()->schedule_imm(this->_rt);
         }
         return;
-      } else {
-        this->close_write(100);
-        return;
       }
 
-      // write at least one fragment before read it
-      if (this->_latest_fragments == this->_wt->vc->fragment) {
-        base->reenable();
-        return;
-      }
-
-      this->_latest_fragments = this->_wt->vc->fragment;
-      this->_rt->reenable();
-      break;
+      // Once the reader has started, abort the writer to exercise the error path.
+      this->close_write(100);
+      return;
 
     case VC_EVENT_WRITE_COMPLETE:
       REQUIRE(!"should not happen because the writer aborted");

--- a/src/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/src/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -1131,6 +1131,8 @@ TEST_CASE("HdrTest", "[proxy][hdrtest]")
     if (cc_field == nullptr) {
       std::printf("FAILED: missing Cache-Control header\n\n");
       REQUIRE(false);
+      return; // REQUIRE throws, but make the early exit explicit so the dereferences below are
+              // unreachable to a reader and to the compiler
     }
 
     // TODO: Do we need to check the "count" returned?

--- a/src/proxy/http/HttpCacheSM.cc
+++ b/src/proxy/http/HttpCacheSM.cc
@@ -440,7 +440,7 @@ HttpCacheSM::open_write(const HttpCacheKey *key, URL *url, HTTPHdr *request, Cac
   CacheHTTPInfo *info          = allow_multiple ? reinterpret_cast<CacheHTTPInfo *>(CACHE_ALLOW_MULTIPLE_WRITES) : old_info;
   Action        *action_handle = nullptr;
 
-  if (master_sm && master_sm->t_state.cache_info.volume_host_rec) {
+  if (master_sm->t_state.cache_info.volume_host_rec) {
     action_handle =
       cacheProcessor.open_write(this, key, info, pin_in_cache, CACHE_FRAG_TYPE_HTTP, master_sm->t_state.cache_info.volume_host_rec);
   } else {

--- a/src/proxy/http/remap/RemapYamlConfig.cc
+++ b/src/proxy/http/remap/RemapYamlConfig.cc
@@ -183,10 +183,8 @@ remap_validate_yaml_filter_args(acl_filter_rule **rule_pp, const YAML::Node &nod
         return {};
       }
     }
-    if (ipi) {
-      rule->src_ip_cnt++;
-      rule->src_ip_valid = 1;
-    }
+    rule->src_ip_cnt++;
+    rule->src_ip_valid = 1;
     return {};
   };
 
@@ -239,10 +237,8 @@ remap_validate_yaml_filter_args(acl_filter_rule **rule_pp, const YAML::Node &nod
         return {};
       }
     }
-    if (ipi) {
-      rule->src_ip_category_cnt++;
-      rule->src_ip_category_valid = 1;
-    }
+    rule->src_ip_category_cnt++;
+    rule->src_ip_category_valid = 1;
     return {};
   };
 
@@ -284,10 +280,8 @@ remap_validate_yaml_filter_args(acl_filter_rule **rule_pp, const YAML::Node &nod
         return {};
       }
     }
-    if (ipi) {
-      rule->in_ip_cnt++;
-      rule->in_ip_valid = 1;
-    }
+    rule->in_ip_cnt++;
+    rule->in_ip_valid = 1;
     return {};
   };
 


### PR DESCRIPTION
Part 2 of 3 splitting a Coverity Scan cleanup into independently reviewable pieces. Net **-13 lines**; every removal is provably unreachable, so there is no behavior change.

### Removals

- **YAML remap filters** (`RemapYamlConfig.cc`, three lambdas): each tested `if (ipi)` where `ipi` is `&rule->src_ip_array[rule->src_ip_cnt]`, the address of an array element, which is never null. The surrounding `>= ACL_FILTER_MAX_*` bound check already returns before the address is taken, so there is no out-of-range address either.

- **`HttpCacheSM::open_write`**: tested `master_sm &&` after `master_sm->redirection_tries` had already been dereferenced nine lines earlier in the same function. Every other method in the file dereferences it unguarded. Whether `master_sm` can be null at all is a separate question worth its own look; the identical guard at `open_read` is left in place.

- **`test_RWW.cc`**: a block sitting after an `if`/`else` where both arms returned unconditionally. The flattened form is byte-for-byte equivalent in control flow, and the assertions that validate the writer abort are untouched.

### Two additions rather than removals

- An explicit `return` after a Catch2 `REQUIRE(false)` in `test_Hdrs.cc`. `REQUIRE` throws, so this is unreachable at runtime; it makes the exit visible to the compiler and to a reader.
- An explicit initializer on a test member that is assigned before every read today.

Both are there to remove a construct static analysis cannot see through. Happy to drop either if you would rather not carry analyzer-appeasement in the tree.

### Verification

Clean build with no new warnings and the full unit test suite passing (134/134) on Fedora, GCC 16.1.1.

Draft while CI runs.
