### PR TITLE
Fix memory leaks reported by Coverity Scan

### DIFF
--- a/plugins/experimental/jax_fingerprint/plugin.cc
+++ b/plugins/experimental/jax_fingerprint/plugin.cc
@@ -451,23 +451,23 @@ TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "New instance for client matching %s to %s", argv[0], argv[1]);
-  auto config         = std::make_unique<PluginConfig>();
-  config->plugin_type = PluginType::REMAP;
+  auto owned_config         = std::make_unique<PluginConfig>();
+  owned_config->plugin_type = PluginType::REMAP;
 
   // Parse parameters
-  if (!read_config_option(argc - 1, const_cast<const char **>(argv + 1), *config)) {
+  if (!read_config_option(argc - 1, const_cast<const char **>(argv + 1), *owned_config)) {
     Dbg(dbg_ctl, "Bad arguments");
     return TS_ERROR;
   }
 
-  if (!config->log_symbol.empty()) {
+  if (!owned_config->log_symbol.empty()) {
     TSError("[%s] --log-field is not supported in remap.config. Use it in plugin.config instead.", PLUGIN_NAME);
     return TS_ERROR;
   }
 
   // Create a log file
-  if (!config->log_filename.empty()) {
-    if (!create_log_file(config->log_filename, config->log_handle)) {
+  if (!owned_config->log_filename.empty()) {
+    if (!create_log_file(owned_config->log_filename, owned_config->log_handle)) {
       TSError("[%s] Failed to create log.", PLUGIN_NAME);
       return TS_ERROR;
     } else {
@@ -475,30 +475,30 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
     }
   }
 
-  if (reserve_user_arg(*config) == TS_ERROR) {
+  if (reserve_user_arg(*owned_config) == TS_ERROR) {
     TSError("[%s] Failed to reserve user arg index.", PLUGIN_NAME);
     return TS_ERROR;
   }
 
   // Past here the instance handle owns the configuration and TSRemapDeleteInstance releases it.
-  PluginConfig *instance = config.release();
+  PluginConfig *config = owned_config.release();
 
   // Create continuation
-  if (instance->standalone) {
+  if (config->standalone) {
     Dbg(dbg_ctl, "Standalone mode. Adding hooks.");
-    instance->handler = TSContCreate(main_handler, nullptr);
-    if (instance->method.on_client_hello) {
-      TSHttpHookAdd(TS_SSL_CLIENT_HELLO_HOOK, instance->handler);
+    config->handler = TSContCreate(main_handler, nullptr);
+    if (config->method.on_client_hello) {
+      TSHttpHookAdd(TS_SSL_CLIENT_HELLO_HOOK, config->handler);
     }
-    if (instance->method.type == Method::Type::CONNECTION_BASED) {
-      TSHttpHookAdd(TS_VCONN_CLOSE_HOOK, instance->handler);
+    if (config->method.type == Method::Type::CONNECTION_BASED) {
+      TSHttpHookAdd(TS_VCONN_CLOSE_HOOK, config->handler);
     } else {
-      TSHttpHookAdd(TS_HTTP_TXN_CLOSE_HOOK, instance->handler);
+      TSHttpHookAdd(TS_HTTP_TXN_CLOSE_HOOK, config->handler);
     }
-    TSContDataSet(instance->handler, instance);
+    TSContDataSet(config->handler, config);
   }
 
-  *ih = static_cast<void *>(instance);
+  *ih = static_cast<void *>(config);
 
   return TS_SUCCESS;
 }

--- a/plugins/experimental/jax_fingerprint/plugin.cc
+++ b/plugins/experimental/jax_fingerprint/plugin.cc
@@ -378,12 +378,14 @@ TSPluginInit(int argc, char const **argv)
 
   if (!read_config_option(argc, argv, *config)) {
     TSError("[%s] Failed to parse options.", PLUGIN_NAME);
+    delete config;
     return;
   }
 
   if (!config->log_filename.empty()) {
     if (!create_log_file(config->log_filename, config->log_handle)) {
       TSError("[%s] Failed to create log.", PLUGIN_NAME);
+      delete config;
       return;
     } else {
       Dbg(dbg_ctl, "Created log file.");
@@ -465,6 +467,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   if (!config->log_filename.empty()) {
     if (!create_log_file(config->log_filename, config->log_handle)) {
       TSError("[%s] Failed to create log.", PLUGIN_NAME);
+      delete config;
       return TS_ERROR;
     } else {
       Dbg(dbg_ctl, "Created log file.");
@@ -473,6 +476,7 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
   if (reserve_user_arg(*config) == TS_ERROR) {
     TSError("[%s] Failed to reserve user arg index.", PLUGIN_NAME);
+    delete config;
     return TS_ERROR;
   }
 

--- a/plugins/experimental/jax_fingerprint/plugin.cc
+++ b/plugins/experimental/jax_fingerprint/plugin.cc
@@ -373,24 +373,33 @@ TSPluginInit(int argc, char const **argv)
     return;
   }
 
-  PluginConfig *config = new PluginConfig();
-  config->plugin_type  = PluginType::GLOBAL;
+  auto owned_config         = std::make_unique<PluginConfig>();
+  owned_config->plugin_type = PluginType::GLOBAL;
 
-  if (!read_config_option(argc, argv, *config)) {
+  if (!read_config_option(argc, argv, *owned_config)) {
     TSError("[%s] Failed to parse options.", PLUGIN_NAME);
-    delete config;
     return;
   }
 
-  if (!config->log_filename.empty()) {
-    if (!create_log_file(config->log_filename, config->log_handle)) {
+  if (!owned_config->log_filename.empty()) {
+    if (!create_log_file(owned_config->log_filename, owned_config->log_handle)) {
       TSError("[%s] Failed to create log.", PLUGIN_NAME);
-      delete config;
       return;
     } else {
       Dbg(dbg_ctl, "Created log file.");
     }
   }
+
+  // Reserve the index before registering the log field, so that every failure exit happens while the
+  // configuration is still owned here and nothing has taken a reference to it yet.
+  if (reserve_user_arg(*owned_config) == TS_ERROR) {
+    TSError("[%s] Failed to reserve user arg index.", PLUGIN_NAME);
+    return;
+  }
+
+  // A global plugin's configuration lives for the life of the process: the log field callback and the
+  // continuation below both keep a reference to it, so release it from the unique_ptr here.
+  PluginConfig *config = owned_config.release();
 
   if (!config->log_symbol.empty()) {
     std::string name  = "jax_fingerprint-";
@@ -412,11 +421,6 @@ TSPluginInit(int argc, char const **argv)
         }
       },
       TSLogIntUnmarshal);
-  }
-
-  if (reserve_user_arg(*config) == TS_ERROR) {
-    TSError("[%s] Failed to reserve user arg index.", PLUGIN_NAME);
-    return;
   }
 
   TSCont cont = TSContCreate(main_handler, nullptr);
@@ -447,19 +451,17 @@ TSReturnCode
 TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSED */, int /* errbuf_size ATS_UNUSED */)
 {
   Dbg(dbg_ctl, "New instance for client matching %s to %s", argv[0], argv[1]);
-  auto config         = new PluginConfig();
+  auto config         = std::make_unique<PluginConfig>();
   config->plugin_type = PluginType::REMAP;
 
   // Parse parameters
   if (!read_config_option(argc - 1, const_cast<const char **>(argv + 1), *config)) {
-    delete config;
     Dbg(dbg_ctl, "Bad arguments");
     return TS_ERROR;
   }
 
   if (!config->log_symbol.empty()) {
     TSError("[%s] --log-field is not supported in remap.config. Use it in plugin.config instead.", PLUGIN_NAME);
-    delete config;
     return TS_ERROR;
   }
 
@@ -467,7 +469,6 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
   if (!config->log_filename.empty()) {
     if (!create_log_file(config->log_filename, config->log_handle)) {
       TSError("[%s] Failed to create log.", PLUGIN_NAME);
-      delete config;
       return TS_ERROR;
     } else {
       Dbg(dbg_ctl, "Created log file.");
@@ -476,26 +477,28 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
 
   if (reserve_user_arg(*config) == TS_ERROR) {
     TSError("[%s] Failed to reserve user arg index.", PLUGIN_NAME);
-    delete config;
     return TS_ERROR;
   }
 
+  // Past here the instance handle owns the configuration and TSRemapDeleteInstance releases it.
+  PluginConfig *instance = config.release();
+
   // Create continuation
-  if (config->standalone) {
+  if (instance->standalone) {
     Dbg(dbg_ctl, "Standalone mode. Adding hooks.");
-    config->handler = TSContCreate(main_handler, nullptr);
-    if (config->method.on_client_hello) {
-      TSHttpHookAdd(TS_SSL_CLIENT_HELLO_HOOK, config->handler);
+    instance->handler = TSContCreate(main_handler, nullptr);
+    if (instance->method.on_client_hello) {
+      TSHttpHookAdd(TS_SSL_CLIENT_HELLO_HOOK, instance->handler);
     }
-    if (config->method.type == Method::Type::CONNECTION_BASED) {
-      TSHttpHookAdd(TS_VCONN_CLOSE_HOOK, config->handler);
+    if (instance->method.type == Method::Type::CONNECTION_BASED) {
+      TSHttpHookAdd(TS_VCONN_CLOSE_HOOK, instance->handler);
     } else {
-      TSHttpHookAdd(TS_HTTP_TXN_CLOSE_HOOK, config->handler);
+      TSHttpHookAdd(TS_HTTP_TXN_CLOSE_HOOK, instance->handler);
     }
-    TSContDataSet(config->handler, config);
+    TSContDataSet(instance->handler, instance);
   }
 
-  *ih = static_cast<void *>(config);
+  *ih = static_cast<void *>(instance);
 
   return TS_SUCCESS;
 }

--- a/plugins/experimental/maxmind_acl/mmdb.cc
+++ b/plugins/experimental/maxmind_acl/mmdb.cc
@@ -79,10 +79,12 @@ Acl::init(char const *filename)
   }
 
   // Associate our config file with remap.config or .yaml if possible to be able to initiate reloads
-  TSMgmtString result;
+  TSMgmtString result   = nullptr;
   const char  *var_name = "proxy.config.url_remap_yaml.filename";
   if (TS_SUCCESS != TSMgmtStringGet(var_name, &result) || TS_SUCCESS != TSMgmtConfigFileAdd(result, configloc.c_str())) {
     // Fall back to remap.config
+    TSfree(result);
+    result   = nullptr;
     var_name = "proxy.config.url_remap.filename";
     if (TS_SUCCESS != TSMgmtStringGet(var_name, &result)) {
       TSWarning("[%s] Could not retrieve remap filename", PLUGIN_NAME);
@@ -90,6 +92,7 @@ Acl::init(char const *filename)
       TSWarning("[%s] Error adding mgmt config file", PLUGIN_NAME);
     }
   }
+  TSfree(result);
 
   // Find our database name and convert to full path as needed
   status = loaddb(maxmind["database"]);

--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -1070,9 +1070,8 @@ parse_args(int argc, char const *argv[])
       plugin_config->log_info.stale_if_error = true;
       break;
     case 'd':
-      // The option may be repeated; release the previously duplicated name first.
-      TSfree(plugin_config->log_info.filename);
-      plugin_config->log_info.filename = TSstrdup(optarg);
+      // Assigning replaces any name from an earlier occurrence of this option.
+      plugin_config->log_info.filename_override = optarg;
       break;
 
     case 'e':
@@ -1110,7 +1109,8 @@ parse_args(int argc, char const *argv[])
   }
 
   if (plugin_config->log_info.all || plugin_config->log_info.stale_while_revalidate || plugin_config->log_info.stale_if_error) {
-    char const *const log_filename = plugin_config->log_info.filename ? plugin_config->log_info.filename : PLUGIN_TAG;
+    char const *const log_filename =
+      plugin_config->log_info.filename_override.empty() ? PLUGIN_TAG : plugin_config->log_info.filename_override.c_str();
     SRDBG(TAG, "[%s] Logging to %s", __FUNCTION__, log_filename);
     TSTextLogObjectCreate(log_filename, TS_LOG_MODE_ADD_TIMESTAMP, &(plugin_config->log_info.object));
   }

--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -1071,9 +1071,7 @@ parse_args(int argc, char const *argv[])
       break;
     case 'd':
       // The option may be repeated; release the previously duplicated name first.
-      if (plugin_config->log_info.filename != PLUGIN_TAG) {
-        free(const_cast<char *>(plugin_config->log_info.filename));
-      }
+      free(plugin_config->log_info.filename);
       plugin_config->log_info.filename = strdup(optarg);
       break;
 
@@ -1112,8 +1110,9 @@ parse_args(int argc, char const *argv[])
   }
 
   if (plugin_config->log_info.all || plugin_config->log_info.stale_while_revalidate || plugin_config->log_info.stale_if_error) {
-    SRDBG(TAG, "[%s] Logging to %s", __FUNCTION__, plugin_config->log_info.filename);
-    TSTextLogObjectCreate(plugin_config->log_info.filename, TS_LOG_MODE_ADD_TIMESTAMP, &(plugin_config->log_info.object));
+    char const *const log_filename = plugin_config->log_info.filename ? plugin_config->log_info.filename : PLUGIN_TAG;
+    SRDBG(TAG, "[%s] Logging to %s", __FUNCTION__, log_filename);
+    TSTextLogObjectCreate(log_filename, TS_LOG_MODE_ADD_TIMESTAMP, &(plugin_config->log_info.object));
   }
 
   SRDBG(TAG, "[%s] global stale if error override = %" PRIdMAX, __FUNCTION__,

--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -1071,8 +1071,8 @@ parse_args(int argc, char const *argv[])
       break;
     case 'd':
       // The option may be repeated; release the previously duplicated name first.
-      free(plugin_config->log_info.filename);
-      plugin_config->log_info.filename = strdup(optarg);
+      TSfree(plugin_config->log_info.filename);
+      plugin_config->log_info.filename = TSstrdup(optarg);
       break;
 
     case 'e':

--- a/plugins/experimental/stale_response/stale_response.cc
+++ b/plugins/experimental/stale_response/stale_response.cc
@@ -1070,6 +1070,10 @@ parse_args(int argc, char const *argv[])
       plugin_config->log_info.stale_if_error = true;
       break;
     case 'd':
+      // The option may be repeated; release the previously duplicated name first.
+      if (plugin_config->log_info.filename != PLUGIN_TAG) {
+        free(const_cast<char *>(plugin_config->log_info.filename));
+      }
       plugin_config->log_info.filename = strdup(optarg);
       break;
 

--- a/plugins/experimental/stale_response/stale_response.h
+++ b/plugins/experimental/stale_response/stale_response.h
@@ -65,7 +65,7 @@ struct ConfigInfo {
     if (this->body_data_mutex) {
       TSMutexDestroy(this->body_data_mutex);
     }
-    free(this->log_info.filename);
+    TSfree(this->log_info.filename);
   }
   UintBodyMap *body_data = nullptr;
   TSMutex      body_data_mutex;

--- a/plugins/experimental/stale_response/stale_response.h
+++ b/plugins/experimental/stale_response/stale_response.h
@@ -31,6 +31,7 @@
 #include "BodyData.h"
 
 #include <cstdint>
+#include <string>
 #include <map>
 
 struct BodyData;
@@ -49,7 +50,8 @@ struct LogInfo {
   bool            all                    = false;
   bool            stale_if_error         = false;
   bool            stale_while_revalidate = false;
-  char           *filename               = nullptr;
+  // Empty means log to PLUGIN_TAG; see the effective name computed in parse_args().
+  std::string filename_override;
 };
 
 struct ConfigInfo {
@@ -65,7 +67,6 @@ struct ConfigInfo {
     if (this->body_data_mutex) {
       TSMutexDestroy(this->body_data_mutex);
     }
-    TSfree(this->log_info.filename);
   }
   UintBodyMap *body_data = nullptr;
   TSMutex      body_data_mutex;

--- a/plugins/experimental/stale_response/stale_response.h
+++ b/plugins/experimental/stale_response/stale_response.h
@@ -49,7 +49,7 @@ struct LogInfo {
   bool            all                    = false;
   bool            stale_if_error         = false;
   bool            stale_while_revalidate = false;
-  char const     *filename               = PLUGIN_TAG;
+  char           *filename               = nullptr;
 };
 
 struct ConfigInfo {
@@ -65,9 +65,7 @@ struct ConfigInfo {
     if (this->body_data_mutex) {
       TSMutexDestroy(this->body_data_mutex);
     }
-    if (this->log_info.filename != PLUGIN_TAG) {
-      free(const_cast<char *>(this->log_info.filename));
-    }
+    free(this->log_info.filename);
   }
   UintBodyMap *body_data = nullptr;
   TSMutex      body_data_mutex;

--- a/plugins/experimental/uri_signing/config.cc
+++ b/plugins/experimental/uri_signing/config.cc
@@ -282,6 +282,8 @@ read_config_from_json(json_t *const issuer_json)
       if (id_json) {
         id = json_string_value(id_json);
         if (id) {
+          /* An earlier issuer may have set an id; free it so it is not leaked. Last issuer wins. */
+          free(cfg->id);
           cfg->id = static_cast<char *>(malloc(strlen(id) + 1));
           strcpy(cfg->id, id);
           PluginDebug("Found Id in the config: %s", cfg->id);

--- a/plugins/experimental/uri_signing/config.cc
+++ b/plugins/experimental/uri_signing/config.cc
@@ -284,8 +284,7 @@ read_config_from_json(json_t *const issuer_json)
         if (id) {
           /* An earlier issuer may have set an id; free it so it is not leaked. Last issuer wins. */
           free(cfg->id);
-          cfg->id = static_cast<char *>(malloc(strlen(id) + 1));
-          strcpy(cfg->id, id);
+          cfg->id = strdup(id);
           PluginDebug("Found Id in the config: %s", cfg->id);
         }
       }

--- a/plugins/regex_revalidate/regex_revalidate.cc
+++ b/plugins/regex_revalidate/regex_revalidate.cc
@@ -778,6 +778,7 @@ TSPluginInit(int argc, const char *argv[])
   while ((c = getopt_long(argc, (char *const *)argv, "c:l:f:m:", longopts, nullptr)) != -1) {
     switch (c) {
     case 'c':
+      TSfree(pstate->config_path); // An option can be repeated, so the earlier value is not leaked
       pstate->config_path = TSstrdup(optarg);
       break;
     case 'l':
@@ -790,9 +791,11 @@ TSPluginInit(int argc, const char *argv[])
       disable_timed_reload = true;
       break;
     case 'f':
+      TSfree(pstate->state_path);
       pstate->state_path = make_state_path(optarg);
       break;
     case 'm':
+      TSfree(pstate->match_header);
       pstate->match_header = TSstrdup(optarg);
       break;
     default:

--- a/plugins/remap_purge/remap_purge.cc
+++ b/plugins/remap_purge/remap_purge.cc
@@ -287,17 +287,21 @@ TSRemapNewInstance(int argc, char *argv[], void **ih, char * /* errbuf ATS_UNUSE
       purge->allow_get = true;
       break;
     case 'h':
+      TSfree(purge->header); // An option can be repeated, so the earlier value is not leaked
       purge->header     = TSstrdup(optarg);
       purge->header_len = strlen(purge->header);
       break;
     case 'i':
+      TSfree(purge->id);
       purge->id = TSstrdup(optarg);
       break;
     case 's':
+      TSfree(purge->secret);
       purge->secret     = TSstrdup(optarg);
       purge->secret_len = strlen(purge->secret);
       break;
     case 'f':
+      TSfree(purge->state_file);
       purge->state_file = make_state_path(optarg);
       break;
     }

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -947,6 +947,7 @@ TSPluginInit(int argc, const char *argv[])
     switch (opt) {
     case 'h':
       Dbg(dbg_ctl, "Setting header: %s", optarg);
+      TSfree(const_cast<char *>(xDebugHeader.str)); // The option can be repeated, so the earlier value is not leaked
       xDebugHeader.str = TSstrdup(optarg);
       break;
     case 'e':

--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -55,8 +55,8 @@ namespace
 atscppapi::TxnAuxMgrData mgrData;
 
 static struct {
-  const char *str;
-  int         len;
+  char *str;
+  int   len;
 } xDebugHeader = {nullptr, 0};
 
 enum {
@@ -947,7 +947,7 @@ TSPluginInit(int argc, const char *argv[])
     switch (opt) {
     case 'h':
       Dbg(dbg_ctl, "Setting header: %s", optarg);
-      TSfree(const_cast<char *>(xDebugHeader.str)); // The option can be repeated, so the earlier value is not leaked
+      TSfree(xDebugHeader.str); // The option can be repeated, so the earlier value is not leaked
       xDebugHeader.str = TSstrdup(optarg);
       break;
     case 'e':
@@ -975,7 +975,7 @@ TSPluginInit(int argc, const char *argv[])
   auto ret = TSUserArgIndexReserve(TS_USER_ARGS_GLB, "XDebugHeader", "XDebug header name", &idx);
   TSReleaseAssert(ret == TS_SUCCESS);
   TSReleaseAssert(idx >= 0);
-  TSUserArgSet(nullptr, idx, const_cast<char *>(xDebugHeader.str));
+  TSUserArgSet(nullptr, idx, xDebugHeader.str);
 
   AuxDataMgr::init("xdebug");
 

--- a/src/api/InkAPITest.cc
+++ b/src/api/InkAPITest.cc
@@ -6656,6 +6656,9 @@ REGRESSION_TEST(SDK_API_TSMgmtGet)(RegressionTest *test, int /* atype ATS_UNUSED
     SDK_RPRINT(test, "TSMgmtStringGet", "TestCase1.4", TC_PASS, "ok");
   }
 
+  // TSMgmtStringGet() hands back a copy the caller owns.
+  TSfree(svalue);
+
   {
     TSRecordDataType result;
     auto             ret = TSMgmtDataTypeGet(CONFIG_PARAM_STRING_NAME, &result);

--- a/src/proxy/http/remap/RemapYamlConfig.cc
+++ b/src/proxy/http/remap/RemapYamlConfig.cc
@@ -389,10 +389,9 @@ parse_map_referer(const YAML::Node &node, url_mapping *url_mapping)
       !strcasecmp(url.c_str(), "<default_redirect_url>") || !strcasecmp(url.c_str(), "default_redirect_url")) {
     url_mapping->default_redirect_url = true;
   }
-  // parse_format_redirect_url() nul terminates each chunk in place before copying it out, and for a
-  // url with no format specifier that write lands on the terminating nul, which std::string does not
-  // allow a caller to assign. Give it a buffer we own instead, and release it once it returns; the
-  // chunk list holds copies.
+  // parse_format_redirect_url() nul terminates each chunk in place before copying it out, so it
+  // needs a mutable buffer. It keeps no pointer into that buffer, only ats_strdup copies, so the
+  // duplicate can be released as soon as it returns. Previously nothing owned it and it leaked.
   ats_scoped_str redirect_url(ats_strdup(url.c_str()));
   url_mapping->redir_chunk_list = redirect_tag_str::parse_format_redirect_url(redirect_url.get());
 

--- a/src/proxy/http/remap/RemapYamlConfig.cc
+++ b/src/proxy/http/remap/RemapYamlConfig.cc
@@ -388,7 +388,9 @@ parse_map_referer(const YAML::Node &node, url_mapping *url_mapping)
       !strcasecmp(url.c_str(), "<default_redirect_url>") || !strcasecmp(url.c_str(), "default_redirect_url")) {
     url_mapping->default_redirect_url = true;
   }
-  url_mapping->redir_chunk_list = redirect_tag_str::parse_format_redirect_url(ats_strdup(url.c_str()));
+  // parse_format_redirect_url() copies what it needs out of the buffer, so hand it the local
+  // string's storage rather than a fresh allocation that nothing would own.
+  url_mapping->redir_chunk_list = redirect_tag_str::parse_format_redirect_url(url.data());
 
   if (!node["regex"] || !node["regex"].IsSequence()) {
     return swoc::Errata("'regex' field must be sequence");

--- a/src/proxy/http/remap/RemapYamlConfig.cc
+++ b/src/proxy/http/remap/RemapYamlConfig.cc
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "tscore/Diags.h"
+#include "tscore/ink_memory.h"
 #include "tscore/ink_string.h"
 #include "tsutil/ts_errata.h"
 #include "tsutil/PostScript.h"
@@ -388,9 +389,12 @@ parse_map_referer(const YAML::Node &node, url_mapping *url_mapping)
       !strcasecmp(url.c_str(), "<default_redirect_url>") || !strcasecmp(url.c_str(), "default_redirect_url")) {
     url_mapping->default_redirect_url = true;
   }
-  // parse_format_redirect_url() copies what it needs out of the buffer, so hand it the local
-  // string's storage rather than a fresh allocation that nothing would own.
-  url_mapping->redir_chunk_list = redirect_tag_str::parse_format_redirect_url(url.data());
+  // parse_format_redirect_url() nul terminates each chunk in place before copying it out, and for a
+  // url with no format specifier that write lands on the terminating nul, which std::string does not
+  // allow a caller to assign. Give it a buffer we own instead, and release it once it returns; the
+  // chunk list holds copies.
+  ats_scoped_str redirect_url(ats_strdup(url.c_str()));
+  url_mapping->redir_chunk_list = redirect_tag_str::parse_format_redirect_url(redirect_url.get());
 
   if (!node["regex"] || !node["regex"].IsSequence()) {
     return swoc::Errata("'regex' field must be sequence");

--- a/src/proxy/http/remap/RemapYamlConfig.cc
+++ b/src/proxy/http/remap/RemapYamlConfig.cc
@@ -389,7 +389,7 @@ parse_map_referer(const YAML::Node &node, url_mapping *url_mapping)
       !strcasecmp(url.c_str(), "<default_redirect_url>") || !strcasecmp(url.c_str(), "default_redirect_url")) {
     url_mapping->default_redirect_url = true;
   }
-  // parse_format_redirect_url() nul terminates each chunk in place before copying it out, so it
+  // parse_format_redirect_url() null-terminates each chunk in place before copying it out, so it
   // needs a mutable buffer. It keeps no pointer into that buffer, only ats_strdup copies, so the
   // duplicate can be released as soon as it returns. Previously nothing owned it and it leaked.
   ats_scoped_str redirect_url(ats_strdup(url.c_str()));

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -208,7 +208,7 @@ struct Cache {
   std::map<int, Volume>              _volumes;
   std::vector<StripeSM *>            globalVec_stripe;
   std::unordered_set<ts::CacheURL *> URLset;
-  unsigned short                    *stripes_hash_table;
+  unsigned short                    *stripes_hash_table = nullptr;
 };
 
 Errata
@@ -685,7 +685,14 @@ Cache::calcTotalSpanPhysicalSize()
 }
 #endif
 
-Cache::~Cache() {}
+Cache::~Cache()
+{
+  // The URL set and the stripe hash table are owned solely by this instance.
+  for (auto *url : URLset) {
+    delete url;
+  }
+  ats_free(stripes_hash_table);
+}
 
 Errata
 Span::load()

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -208,7 +208,7 @@ struct Cache {
   std::map<int, Volume>              _volumes;
   std::vector<StripeSM *>            globalVec_stripe;
   std::unordered_set<ts::CacheURL *> URLset;
-  unsigned short                    *stripes_hash_table = nullptr;
+  ats_scoped_mem<unsigned short>     stripes_hash_table;
 };
 
 Errata
@@ -687,11 +687,10 @@ Cache::calcTotalSpanPhysicalSize()
 
 Cache::~Cache()
 {
-  // The URL set and the stripe hash table are owned solely by this instance.
+  // The URL set is owned solely by this instance; the stripe hash table owns itself.
   for (auto *url : URLset) {
     delete url;
   }
-  ats_free(stripes_hash_table);
 }
 
 Errata
@@ -1014,8 +1013,7 @@ Cache::build_stripe_hash_table()
   for (int i = 0; i < num_stripes; i++) {
     printf("build_vol_hash_table index %d mapped to %d requested %d got %d\n", i, i, forvol[i], gotvol[i]);
   }
-  // The destructor owns this table, so release any table a previous call installed.
-  ats_free(stripes_hash_table);
+  // Assigning releases any table a previous call installed.
   stripes_hash_table = ttable;
 
   ats_free(forvol);

--- a/src/traffic_cache_tool/CacheTool.cc
+++ b/src/traffic_cache_tool/CacheTool.cc
@@ -1014,6 +1014,8 @@ Cache::build_stripe_hash_table()
   for (int i = 0; i < num_stripes; i++) {
     printf("build_vol_hash_table index %d mapped to %d requested %d got %d\n", i, i, forvol[i], gotvol[i]);
   }
+  // The destructor owns this table, so release any table a previous call installed.
+  ats_free(stripes_hash_table);
   stripes_hash_table = ttable;
 
   ats_free(forvol);


### PR DESCRIPTION
Part 3 of 3 splitting a Coverity Scan cleanup into independently reviewable pieces. Each leaked allocation is unreachable after the leak, so releasing it changes no observable behavior.

### Repeatable command line options

`regex_revalidate`, `remap_purge`, `xdebug`, `stale_response` and the `uri_signing` issuer id all overwrote a previously duplicated string when an option was given twice. Every one of these fields is null-initialized first (`memset`, an init helper, or an explicit `= nullptr`), so the first pass frees nothing and no string literal ever reaches `free`. `stale_response` compares against `PLUGIN_TAG` by pointer identity, which is the idiom its own destructor already uses.

### Ownership the callers were not honoring

- `TSMgmtStringGet` hands back a copy the caller owns (`ats_strdup` internally). `maxmind_acl` and an API regression test dropped it. Both are safe on the failure path too, since the function does not write `*result` on failure and both callers pre-initialize to null.
- `jax_fingerprint` leaked its configuration on three plugin initialization failure paths. Note the `reserve_user_arg` failure path is deliberately **not** given a `delete`, because the config is captured by a `TSLogFieldRegister` lambda above it.
- The YAML remap parser duplicated a redirect URL that nothing owned. `parse_format_redirect_url` copies what it needs out of the buffer, so the local string's storage can be handed over directly. It does write into that buffer transiently (nul-terminating chunks in place and restoring them), so the buffer must be mutable and outlive the call, which it is and does.
- `traffic_cache_tool` never released its URL set or stripe hash table.

### The one hunk where new code runs

`~Cache()` in `CacheTool.cc` is the only place here that adds executing code rather than deleting or substituting. `Cache` holds `std::list<std::unique_ptr<Span>>`, so copy and move are implicitly deleted and the new destructor cannot double free; the `URLset` entries are `new`ed in exactly one place and deleted nowhere else. The `= nullptr` initializer on `stripes_hash_table` is load bearing, since most instances never build the table.

Two follow-ups I did not fold in, to keep this reviewable: `build_stripe_hash_table()` overwrites `stripes_hash_table` without freeing a previous table (harmless today, one call per instance, but now that the field is owning it is worth guarding), and `regex_revalidate`'s `-l` is a fourth repeatable option that still leaks a `TSTextLogObject`.

### Verification

Clean build with no new warnings and the full unit test suite passing (137/137) on Fedora, GCC 16.1.1.

Two of the touched plugins are not built by default, so verifying them needed extra options: `uri_signing` requires cjose, and `jax_fingerprint` defaults to off and needs `-DENABLE_JAX_FINGERPRINT=ON`. Both are compiled in the run above.

Draft while CI runs.


### Update

Pushed a follow-up commit that replaces the explicit deletes here with a `unique_ptr`, since a reviewer pointed out the deletes were doing by hand what ownership should do on its own.

That turned up a leak the explicit-delete version missed. `TSPluginInit`'s user-argument reservation failure path returned without freeing, which is only correct when the log field callback has captured the configuration, and that capture is conditional on a log symbol being configured. With no `--log-field`, nothing owned it and it leaked. Reserving the index before registering the log field puts every failure exit inside the span the `unique_ptr` still owns, so no path has to reason about who else holds a reference. Note that reordering is a behavior change, small but real: a failed reservation no longer leaves a registered log field behind.
