### PR TITLE
keep buflen in sync in dns_process address copy path

### DIFF
--- a/src/iocore/dns/DNS.cc
+++ b/src/iocore/dns/DNS.cc
@@ -1889,8 +1889,9 @@ dns_process(DNSHandler *handler, HostEnt *buf, int len)
           memcpy((*hap++ = bp), cp, n);
           Dbg(dbg_ctl_dns, "received %s = %s", QtypeName(type),
               inet_ntop(T_AAAA == type ? AF_INET6 : AF_INET, bp, ip_string, sizeof(ip_string)));
-          bp += n;
-          cp += n;
+          bp     += n;
+          cp     += n;
+          buflen  = sizeof(buf->hostbuf) - (bp - buf->hostbuf);
         }
       } else {
         goto Lerror;


### PR DESCRIPTION
dns_process copies each answer record into the fixed HostEnt hostbuf while keeping a running buflen for the space left at the write cursor, but the branch that memcpys an A/AAAA address when the source is not word aligned advances the cursor by the alignment padding and the record length without decrementing buflen. Since every later name expansion hands that same buflen to dn_expand as its output limit, the stale, over-large value lets a crafted response (a large address record followed by a record whose owner name expands near the end of hostbuf) write the expanded name past the buffer and into the adjacent srv_hosts vector. This restores buflen from the cursor after the copy so it stays consistent, matching what the name, CNAME and PTR paths already do.