### PR TITLE
Trace skipped parent markdown

### DIFF
--- a/src/proxy/http/HttpTransact.cc
+++ b/src/proxy/http/HttpTransact.cc
@@ -3881,6 +3881,8 @@ HttpTransact::handle_response_from_parent(State *s)
     } else {
       if (is_request_retryable(s)) {
         markParentDown(s);
+      } else {
+        TxnDbg(dbg_ctl_http_trans, "skipping parent markdown for unavailable_server retry because request is not retryable");
       }
       s->current.unavailable_server_retry_attempts++;
     }


### PR DESCRIPTION
Log when unavailable-server parent retry handling skips marking the parent down because the request is not retryable. This leaves retry behavior unchanged while making the guarded markdown path visible in transaction debug output.