### PR TITLE
Trace skipped X-Remap injection

### DIFF
--- a/plugins/xdebug/xdebug.cc
+++ b/plugins/xdebug/xdebug.cc
@@ -402,8 +402,11 @@ InjectRemapHeader(TSHttpTxn txn, TSMBuffer buffer, TSMLoc hdr)
       TSfree(const_cast<char *>(toUrlStr));
     }
 
-    if (len > 0) {
+    if (len <= 0) {
+      Dbg(dbg_ctl, "skipping X-Remap header injection because snprintf returned %d", len);
+    } else {
       if (static_cast<size_t>(len) >= sizeof(buf)) {
+        Dbg(dbg_ctl, "truncating X-Remap header from %d to %zu bytes", len, sizeof(buf) - 1);
         len = sizeof(buf) - 1;
       }
       TSReleaseAssert(TSMimeHdrFieldValueStringInsert(buffer, hdr, dst, -1 /* idx */, buf, len) == TS_SUCCESS);


### PR DESCRIPTION
Add debug breadcrumbs when xdebug skips X-Remap injection because snprintf fails or returns an empty value, and when the generated value is truncated to the fixed buffer. This makes the secured formatting path easier to diagnose without changing header behavior.