### PR TITLE
Add ubuntu/resolute dockerfile for 10.2.0 builds

### DIFF
--- a/contrib/docker/ubuntu/resolute/Dockerfile
+++ b/contrib/docker/ubuntu/resolute/Dockerfile
@@ -1,0 +1,128 @@
+#######################
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#  agreements.  See the NOTICE file distributed with this work for additional information regarding
+#  copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with the License.  You may obtain
+#  a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software distributed under the License
+#  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing permissions and limitations under
+#  the License.
+#
+#######################
+FROM ubuntu:resolute AS build-setup
+
+ARG LLVM_VERSION=22
+ARG BASE=/opt
+
+RUN apt update \
+ && apt upgrade --yes \
+ && apt install --no-install-recommends --yes \
+    ca-certificates \
+    clang-${LLVM_VERSION} \
+    clang-tools-${LLVM_VERSION} \
+    lld-${LLVM_VERSION} \
+    cmake \
+    ninja-build \
+    libc-ares-dev \
+    libsystemd-dev \
+    libev-dev \
+    libevent-dev \
+    zlib1g-dev \
+    wget \
+    git \
+    libtool \
+    make \
+    pkg-config \
+    libpsl-dev \
+    libssl-dev \
+# ATS deps
+    libxml2-dev \
+    libjemalloc-dev \
+    libhwloc-dev \
+    libfmt-dev \
+    libpcre2-dev \
+    hwloc \
+    libbrotli-dev \
+    libzstd-dev \
+    luajit \
+    libluajit-5.1-dev \
+    libcap-dev \
+    libmagick++-dev \
+    libmaxminddb-dev \
+    libcjose-dev \
+    libcjose0 \
+    libjansson-dev \
+ && apt clean --yes
+
+# Set up cc (and optionally c++) to use clang-18 via alternatives
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${LLVM_VERSION} 100
+
+FROM build-setup as build
+
+ARG ATS_VERSION=10.2.0
+
+RUN git clone --depth 1 -b ${ATS_VERSION} https://github.com/apache/trafficserver.git \
+ && cmake \
+     -Strafficserver \
+     -Bbuild \
+     -GNinja \
+     -DBUILD_SHARED_LIBS=ON \
+     -DCMAKE_C_COMPILER=clang-22 \
+     -DCMAKE_CXX_COMPILER=clang++-22 \
+     -DCMAKE_LINKER_TYPE=LLD \
+     -DCMAKE_CXX_SCAN_FOR_MODULES=OFF \
+     -DCMAKE_INSTALL_PREFIX=${BASE} \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DBUILD_TESTING=OFF \
+     -DBUILD_REGRESSION_TESTING=OFF \
+     -DENABLE_AUTEST=OFF \
+     -DBUILD_EXPERIMENTAL_PLUGINS=ON \
+     -DENABLE_JEMALLOC=ON \
+     -DENABLE_MALLOC_ALLOCATOR=ON \
+     -DENABLE_CRIPTS=ON \
+     -DENABLE_EXAMPLE=OFF \
+     -DENABLE_LUAJIT=ON \
+ && cmake --build build \
+ && cmake --install build \
+ && rm -rf build trafficserver
+
+FROM ubuntu:resolute
+
+RUN apt update \
+ && apt upgrade --yes \
+ && apt install --no-install-recommends --yes \
+    ca-certificates \
+    libjemalloc2 \
+    libxml2-16 \
+    hwloc \
+    libmaxminddb0 \
+    libfmt10 \
+    libpcre2-8-0 \
+    libbrotli1 \
+    luajit \
+    libcap2 \
+    libevent-2.1-7t64 \
+    libev4t64 \
+    libcares2 \
+    libmagick++-7.q16-5 \
+    libmagickcore-7.q16-10 \
+    libmagickwand-7.q16-10 \
+    libcjose0 \
+    libjansson4 \
+ && apt clean --yes
+
+COPY --from=build /opt /opt
+RUN chown nobody /opt/var/trafficserver /opt/var/log/trafficserver
+ENV PATH="$PATH:/opt/bin"
+
+EXPOSE 8080
+
+CMD ["traffic_server"]


### PR DESCRIPTION
Updated the Dockerfile to use ubuntu/resolute, clang22 and openssl instead of boring.

```
% podman run -it --rm  docker.io/trafficserver/trafficserver:latest /opt/bin/traffic_layout info --features
Trying to pull docker.io/trafficserver/trafficserver:latest...
Getting image source signatures
Copying blob 795448248960 done   |
Copying blob 06e9d71331fb done   |
Copying blob 46516aa72f5c done   |
Copying blob 9c46ef0398a7 done   |
Copying blob f3db1cd94078 done   |
Copying config 0a8e912545 done   |
Writing manifest to image destination
#define BUILD_MACHINE "buildkitsandbox"
#define BUILD_PERSON "root"
#define BUILD_GROUP "root"
#define BUILD_NUMBER "0"
#define TS_HAS_LZMA 1
#define TS_HAS_BROTLI 1
#define TS_HAS_ZSTD 1
#define TS_HAS_CERT_COMPRESSION 1
#define TS_HAS_CERT_COMPRESSION_CALLBACKS 0
#define TS_HAS_CERT_COMPRESSION_ZLIB 1
#define TS_HAS_CERT_COMPRESSION_BROTLI 0
#define TS_HAS_CERT_COMPRESSION_ZSTD 1
#define TS_HAS_CRIPTS 1
#define TS_HAS_PIPE_BUFFER_SIZE_CONFIG 1
#define TS_HAS_JEMALLOC 1
#define TS_HAS_IN6_IS_ADDR_UNSPECIFIED 1
#define TS_HAS_BACKTRACE 1
#define TS_HAS_PROFILER 0
#define TS_USE_FAST_SDK 0
#define TS_USE_DIAGS 1
#define TS_USE_CACHE_SHM 1
#define TS_USE_EPOLL 1
#define TS_USE_KQUEUE 0
#define TS_USE_POSIX_CAP 1
#define TS_USE_TPROXY 1
#define TS_HAS_SO_MARK 1
#define TS_HAS_IP_TOS 1
#define TS_USE_HWLOC 1
#define TS_USE_TLS13 1
#define TS_USE_QUIC 1
#define TS_USE_QMUX 0
#define TS_HAS_OPENSSL_QUIC 1
#define TS_HAS_QUICHE 0
#define TS_HAS_SO_PEERCRED 1
#define TS_USE_REMOTE_UNWINDING 0
#define SIZEOF_VOIDP 8
#define TS_IP_TRANSPARENT 19
#define TS_HAS_128BIT_CAS 1
#define TS_HAS_TESTS 0
#define TS_MAX_THREADS_IN_EACH_THREAD_TYPE 3072
#define TS_MAX_NUMBER_EVENT_THREADS 4096
#define TS_MAX_HOST_NAME_LEN 256
#define TS_PKGSYSUSER "nobody"
#define TS_PKGSYSGROUP "nogroup"
```

```
% podman run -it --rm  docker.io/trafficserver/trafficserver:latest /opt/bin/traffic_layout --version
Apache Traffic Server - traffic_layout - 10.2.0 - (build # 0 on Aug 19 2026 at 20:06:38)
```