### PR TITLE
Fix silently dropped Streams.all autest assertions

### DIFF
--- a/tests/gold_tests/h3/h3_sni_check.test.py
+++ b/tests/gold_tests/h3/h3_sni_check.test.py
@@ -119,7 +119,7 @@ ssl_multicert:
                 "SNI not found", "ATS should see the SNI presented by client.")
 
         if self.gold_file:
-            tr.Processes.Default.Streams.all = self.gold_file
+            tr.Processes.Default.Streams.All = self.gold_file
 
 
 # TEST 1: Client request with SNI.

--- a/tests/gold_tests/ip_allow/ip_allow.test.py
+++ b/tests/gold_tests/ip_allow/ip_allow.test.py
@@ -310,7 +310,7 @@ ssl_multicert:
                 "client.*allowed by ip-allow policy", "Request should be allowed by ip_allow")
 
         if self.gold_file:
-            tr.Processes.Default.Streams.all = self.gold_file
+            tr.Processes.Default.Streams.All = self.gold_file
 
 
 # ip_allow tests for h3.

--- a/tests/gold_tests/timeout/default_inactivity_timeout.test.py
+++ b/tests/gold_tests/timeout/default_inactivity_timeout.test.py
@@ -93,7 +93,7 @@ class TestDefaultInactivityTimeout:
 
         # Set up expectectations for the timeout closing the connection.
         tr.Processes.Default.ReturnCode = 1
-        tr.Processes.Default.Streams.all = self.client_gold_file
+        tr.Processes.Default.Streams.All = self.client_gold_file
 
 
 test = TestDefaultInactivityTimeout("global config", use_override=False)

--- a/tests/gold_tests/timeout/gold/client_default_inactivity_timeout.gold
+++ b/tests/gold_tests/timeout/gold/client_default_inactivity_timeout.gold
@@ -1,4 +1,4 @@
-```
+``
 ``PARSE_INCOMPLETE
 ``Failed HTTP/1 transaction with key: timeout2
 ``

--- a/tests/gold_tests/timeout/quic_no_activity_timeout.test.py
+++ b/tests/gold_tests/timeout/quic_no_activity_timeout.test.py
@@ -106,7 +106,7 @@ ssl_multicert:
             tr.Processes.Default.ReturnCode = 0
 
         if self.gold_file:
-            tr.Processes.Default.Streams.all = self.gold_file
+            tr.Processes.Default.Streams.All = self.gold_file
 
 
 # Tests start.

--- a/tests/gold_tests/tls/allow-plain.test.py
+++ b/tests/gold_tests/tls/allow-plain.test.py
@@ -80,7 +80,7 @@ tr.MakeCurlCommand(
 tr.Processes.Default.ReturnCode = 0
 tr.StillRunningAfter = server
 tr.StillRunningAfter = ts
-tr.Processes.Default.Streams.all = Testers.ContainsExpression("TLS", "Should negiotiate TLS")
+tr.Processes.Default.Streams.All = Testers.ContainsExpression("TLS", "Should negiotiate TLS")
 
 # non-TLS curl should also work to the same port
 tr2 = Test.AddTestRun()
@@ -91,7 +91,7 @@ tr2.MakeCurlCommand(
 tr2.Processes.Default.ReturnCode = 0
 tr2.StillRunningAfter = server
 tr2.StillRunningAfter = ts
-tr2.Processes.Default.Streams.all = Testers.ExcludesExpression("TLS", "Should not negiotiate TLS")
+tr2.Processes.Default.Streams.All = Testers.ExcludesExpression("TLS", "Should not negiotiate TLS")
 
 # Make sure a post > 32K works.  Early version forgot to free a reader which caused a stall once the initial buffer filled
 # Seems like we needed to make a second resquest to trigger the issue
@@ -103,4 +103,4 @@ tr3.MakeCurlCommand(
 tr3.Processes.Default.ReturnCode = 0
 tr3.StillRunningAfter = server
 tr3.StillRunningAfter = ts
-tr3.Processes.Default.Streams.all = Testers.ExcludesExpression("TLS", "Should not negiotiate TLS")
+tr3.Processes.Default.Streams.All = Testers.ExcludesExpression("TLS", "Should not negiotiate TLS")

--- a/tests/gold_tests/tls/tls_hooks_client_verify.test.py
+++ b/tests/gold_tests/tls/tls_hooks_client_verify.test.py
@@ -45,6 +45,8 @@ ts.Disk.records_config.update(
         'proxy.config.ssl.server.private_key.path': '{0}'.format(ts.Variables.SSLDir),
         'proxy.config.exec_thread.autoconfig.scale': 1.0,
         'proxy.config.ssl.CA.cert.filename': '{0}/signer.pem'.format(ts.Variables.SSLDir),
+        # The origin serves a self-signed cert; this test verifies inbound client certs.
+        'proxy.config.ssl.client.verify.server.policy': 'PERMISSIVE',
         'proxy.config.url_remap.pristine_host_hdr': 1
     })
 
@@ -87,7 +89,7 @@ tr.MakeCurlCommand(
     .format(ts.Variables.ssl_port),
     ts=ts)
 tr.Processes.Default.ReturnCode = 0
-tr.Processes.Default.Streams.all = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
+tr.Processes.Default.Streams.All = Testers.ExcludesExpression("Could Not Connect", "Curl attempt should have succeeded")
 
 tr2 = Test.AddTestRun("request bad name")
 tr2.StillRunningAfter = ts
@@ -97,7 +99,7 @@ tr2.MakeCurlCommand(
     .format(ts.Variables.ssl_port),
     ts=ts)
 tr2.Processes.Default.ReturnCode = 35
-tr2.Processes.Default.Streams.all = Testers.ContainsExpression("error", "Curl attempt should have failed")
+tr2.Processes.Default.Streams.All = Testers.ContainsExpression("error", "Curl attempt should have failed")
 
 tr3 = Test.AddTestRun("request badly signed cert")
 tr3.Setup.Copy("ssl/server.pem")
@@ -109,7 +111,7 @@ tr3.MakeCurlCommand(
         ts.Variables.ssl_port),
     ts=ts)
 tr3.Processes.Default.ReturnCode = 35
-tr3.Processes.Default.Streams.all = Testers.ContainsExpression("error", "Curl attempt should have failed")
+tr3.Processes.Default.Streams.All = Testers.ContainsExpression("error", "Curl attempt should have failed")
 
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     r"Client verify callback 0 [\da-fx]+? - event is good good HS", "verify callback happens 2 times")

--- a/tests/gold_tests/tls/tls_sni_groups.test.py
+++ b/tests/gold_tests/tls/tls_sni_groups.test.py
@@ -82,7 +82,7 @@ tr.ReturnCode = 0
 tr.StillRunningAfter = ts
 ts.Disk.traffic_out.Content += Testers.ContainsExpression(
     "Setting groups list from server_groups_list to x25519", "Should log setting the server groups")
-tr.Processes.Default.Streams.all = Testers.IncludesExpression(
+tr.Processes.Default.Streams.All = Testers.IncludesExpression(
     f"SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384 / x25519", "Curl should log using x25519 in the SSL connection")
 
 tr = Test.AddTestRun("Test 1: fail")
@@ -108,6 +108,6 @@ if Condition.HasOpenSSLVersion("3.5.0"):
     tr.StillRunningAfter = ts
     ts.Disk.traffic_out.Content += Testers.ContainsExpression(
         "Setting groups list from server_groups_list to X25519MLKEM768", "Should log setting the server groups")
-    tr.Processes.Default.Streams.all = Testers.IncludesExpression(
+    tr.Processes.Default.Streams.All = Testers.IncludesExpression(
         f"SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / X25519MLKEM768",
         f"Curl should log using X25519MLKEM768 in the SSL connection")


### PR DESCRIPTION
AuTest's `Streams` entity defines `All`, not `all`, and does not override `__setattr__`, so every `Streams.all = ...` assignment created a dead instance attribute rather than registering a tester. Twelve assertions across seven gold tests had never run, and two of the expectations behind them had rotted unnoticed as a result.

This renames those assignments to `Streams.All` so the assertions register, and corrects the two expectations they exposed: `client_default_inactivity_timeout.gold` opened with three backticks rather than the two that mark an AuTest wildcard, and `tls_hooks_client_verify` left `proxy.config.ssl.client.verify.server.policy` at the default `ENFORCED` while its origin serves a self-signed cert.

`cert_update.test.py` has two more of these, left alone because #13576 is already rewriting that file.
