### PR TITLE
Remove dead JSONRPC server_shutdown handler

### DIFF
--- a/include/mgmt/rpc/handlers/server/Server.h
+++ b/include/mgmt/rpc/handlers/server/Server.h
@@ -26,7 +26,6 @@ namespace rpc::handlers::server
 {
 swoc::Rv<YAML::Node> server_start_drain(std::string_view const &id, YAML::Node const &params);
 swoc::Rv<YAML::Node> server_stop_drain(std::string_view const &id, YAML::Node const &);
-void                 server_shutdown(YAML::Node const &);
 swoc::Rv<YAML::Node> get_server_status(std::string_view const &id, YAML::Node const &);
 swoc::Rv<YAML::Node> get_connection_tracker_info(std::string_view const &id, YAML::Node const &params);
 

--- a/src/mgmt/rpc/handlers/server/Server.cc
+++ b/src/mgmt/rpc/handlers/server/Server.cc
@@ -18,7 +18,6 @@
   limitations under the License.
 */
 
-#include "../../../../iocore/cache/P_CacheDir.h"
 #include "iocore/eventsystem/EventProcessor.h"
 #include "iocore/net/ConnectionTracker.h"
 #include "mgmt/rpc/handlers/server/Server.h"
@@ -174,12 +173,6 @@ server_stop_drain(std::string_view const & /* id ATS_UNUSED */, YAML::Node const
   }
 
   return resp;
-}
-
-void
-server_shutdown(YAML::Node const &)
-{
-  sync_cache_dir_on_shutdown();
 }
 
 swoc::Rv<YAML::Node>


### PR DESCRIPTION
Never registered nor called since it was added in #7478, and its void(YAML::Node) signature never matched the method handler shape it sat among.  Shutdown already syncs the cache dir from the event thread in traffic_server.cc; doing it from an RPC thread would race the dir writers.  Dropping it also removes mgmt's relative-path include of iocore's private P_CacheDir.h.