### PR TITLE
Add focused txn_box comparison test

### DIFF
--- a/tests/gold_tests/pluginTest/txn_box/tuple_comparison/txn_box.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/tuple_comparison/txn_box.yaml
@@ -1,0 +1,33 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+txn_box:
+- when: upstream-rsp
+  do:
+  - with: [ upstream-rsp-status, proxy-req-path ]
+    select:
+    - as-tuple:
+      - eq: 404
+      - match: "example"
+      do:
+      - upstream-rsp-status: [ 200, "OK" ]
+      - upstream-rsp-field<Cache-Control>: "max-age=3600"
+
+  - with: upstream-rsp-status
+    select:
+    - eq: 200
+      do:
+      - upstream-rsp-field<X-Txn-Box>: "selected"

--- a/tests/gold_tests/pluginTest/txn_box/tuple_comparison/txn_box_tuple_comparison.replay.yaml
+++ b/tests/gold_tests/pluginTest/txn_box/tuple_comparison/txn_box_tuple_comparison.replay.yaml
@@ -1,0 +1,97 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+autest:
+  description: 'Verify txn_box compares a heterogeneous tuple'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+
+    process_config:
+      enable_cache: false
+
+    copy_to_config_dir:
+      - 'txn_box.yaml'
+
+    plugin_config:
+      - 'txn_box.so txn_box.yaml'
+
+    remap_config:
+      - from: 'http://example.com/'
+        to: 'http://127.0.0.1:{SERVER_HTTP_PORT}/'
+
+sessions:
+- transactions:
+  - client-request:
+      method: GET
+      version: "1.1"
+      url: /example
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, tuple-comparison ]
+
+    proxy-request:
+      method: GET
+      url: /example
+
+    server-response:
+      status: 404
+      reason: Not Found
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ Cache-Control, { value: 'max-age=3600', as: equal } ]
+
+  - client-request:
+      method: GET
+      version: "1.1"
+      url: /scalar
+      headers:
+        fields:
+        - [ Host, example.com ]
+        - [ uuid, scalar-comparison ]
+
+    proxy-request:
+      method: GET
+      url: /scalar
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 0 ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Txn-Box, { value: 'selected', as: equal } ]

--- a/tests/gold_tests/pluginTest/txn_box/tuple_comparison/txn_box_tuple_comparison.test.py
+++ b/tests/gold_tests/pluginTest/txn_box/tuple_comparison/txn_box_tuple_comparison.test.py
@@ -1,0 +1,24 @@
+'''
+Verify txn_box tuple comparisons with heterogeneous feature types.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = 'Verify txn_box heterogeneous tuple comparisons'
+
+Test.SkipUnless(Condition.PluginExists('txn_box.so'))
+
+Test.ATSReplayTest(replay_file='txn_box_tuple_comparison.replay.yaml')


### PR DESCRIPTION
Txn_box's documented tuple example was reported as failing to load, but
its existing coverage is embedded in a broad static-file test and does
not isolate either reported comparison form.

This adds a replay-based regression test that loads the default txn_box
root as a global plugin and verifies heterogeneous tuple selection and
scalar status selection through response mutations.

Fixes: #12335