### PR TITLE
Count HTTP/2 clients in IP connection metrics

### DIFF
--- a/include/proxy/ProxySession.h
+++ b/include/proxy/ProxySession.h
@@ -205,6 +205,9 @@ protected:
   // the new_vc may be an SSLNetVConnection object.
   void _handle_if_ssl(NetVConnection *new_vc);
 
+  /// Update the client connection metric for the remote address family.
+  void _increment_total_client_connections_stat(NetVConnection *new_vc);
+
   NetVConnection *_vc = nullptr; // The netvc associated with the concrete session class
 
 private:

--- a/src/proxy/ProxySession.cc
+++ b/src/proxy/ProxySession.cc
@@ -47,6 +47,24 @@ ProxySession::~ProxySession()
 }
 
 void
+ProxySession::_increment_total_client_connections_stat(NetVConnection *new_vc)
+{
+  switch (new_vc->get_remote_addr()->sa_family) {
+  case AF_INET:
+    Metrics::Counter::increment(http_rsb.total_client_connections_ipv4);
+    break;
+  case AF_INET6:
+    Metrics::Counter::increment(http_rsb.total_client_connections_ipv6);
+    break;
+  case AF_UNIX:
+    Metrics::Counter::increment(http_rsb.total_client_connections_uds);
+    break;
+  default:
+    break;
+  }
+}
+
+void
 ProxySession::set_session_active()
 {
   if (!m_active) {

--- a/src/proxy/http/Http1ClientSession.cc
+++ b/src/proxy/http/Http1ClientSession.cc
@@ -172,26 +172,7 @@ Http1ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   /* inbound requests stat should be incremented here, not after the
    * header has been read */
   Metrics::Counter::increment(http_rsb.total_incoming_connections);
-
-  // check what type of socket address we just accepted
-  // by looking at the address family value of sockaddr_storage
-  // and logging to stat system
-  switch (new_vc->get_remote_addr()->sa_family) {
-  case AF_INET:
-    Metrics::Counter::increment(http_rsb.total_client_connections_ipv4);
-    break;
-  case AF_INET6:
-    Metrics::Counter::increment(http_rsb.total_client_connections_ipv6);
-    break;
-  case AF_UNIX:
-    Metrics::Counter::increment(http_rsb.total_client_connections_uds);
-    break;
-  default:
-    // don't do anything if the address family is not ipv4, ipv6, or unix domain socket
-    // (there are many other address families in <sys/socket.h>
-    // but we don't have a need to report on all the others today)
-    break;
-  }
+  this->_increment_total_client_connections_stat(new_vc);
 
 #ifdef USE_HTTP_DEBUG_LISTS
   ink_mutex_acquire(&debug_cs_list_mutex);

--- a/src/proxy/http2/Http2ClientSession.cc
+++ b/src/proxy/http2/Http2ClientSession.cc
@@ -99,6 +99,7 @@ Http2ClientSession::new_connection(NetVConnection *new_vc, MIOBuffer *iobuf, IOB
   ink_assert(new_vc->mutex->thread_holding == this_ethread());
   Metrics::Gauge::increment(http2_rsb.current_client_session_count);
   Metrics::Counter::increment(http2_rsb.total_client_connection_count);
+  this->_increment_total_client_connections_stat(new_vc);
   this->_milestones.mark(Http2SsnMilestone::OPEN);
 
   // Unique client session identifier.

--- a/src/proxy/http3/Http3Session.cc
+++ b/src/proxy/http3/Http3Session.cc
@@ -129,6 +129,7 @@ void
 HQSession::new_connection(NetVConnection *new_vc, MIOBuffer * /* iobuf ATS_UNUSED */, IOBufferReader * /* reader ATS_UNUSED */)
 {
   this->con_id = new_vc->get_service<QUICSupport>()->get_quic_connection()->connection_id();
+  this->_increment_total_client_connections_stat(new_vc);
   this->_handle_if_ssl(new_vc);
 
   do_api_callout(TS_HTTP_SSN_START_HOOK);

--- a/tests/gold_tests/h2/http2_client_connection_metric.test.py
+++ b/tests/gold_tests/h2/http2_client_connection_metric.test.py
@@ -1,0 +1,20 @@
+'''Verify that HTTP/2 client connections update the IP version metrics.'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = __doc__
+
+Test.ATSReplayTest(replay_file="replay/http2_client_connection_metric.replay.yaml")

--- a/tests/gold_tests/h2/replay/http2_client_connection_metric.replay.yaml
+++ b/tests/gold_tests/h2/replay/http2_client_connection_metric.replay.yaml
@@ -1,0 +1,76 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+meta:
+  version: "1.0"
+
+autest:
+  description: 'Verify HTTP/2 connections update the client IP version metrics'
+
+  server:
+    name: 'server'
+
+  client:
+    name: 'client'
+
+  ats:
+    name: 'ts'
+    process_config:
+      enable_cache: false
+      enable_tls: true
+
+    remap_config:
+    - from: 'https://http2-metrics.test/'
+      to: 'http://127.0.0.1:{SERVER_HTTP_PORT}/'
+
+    metric_checks:
+    - metric: 'proxy.process.http2.total_client_connections'
+      value: 1
+    - metric: 'proxy.process.http.total_client_connections_ipv4'
+      value: 1
+    - metric: 'proxy.process.http.total_client_connections_ipv6'
+      value: 0
+
+sessions:
+- protocol:
+    stack: http2
+    tls:
+      sni: http2-metrics.test
+  transactions:
+  - client-request:
+      headers:
+        fields:
+        - [':method', GET]
+        - [':scheme', https]
+        - [':authority', http2-metrics.test]
+        - [':path', /]
+        - [Content-Length, 0]
+        - [uuid, http2-client-connection-metric]
+
+    proxy-request:
+      headers:
+        fields:
+        - [uuid, {value: http2-client-connection-metric, as: equal}]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [Content-Length, 0]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/tls/gold/tls-tunnel-metrics.gold
+++ b/tests/gold_tests/tls/gold/tls-tunnel-metrics.gold
@@ -1,6 +1,6 @@
 proxy.process.http.total_incoming_connections 14
 proxy.process.http.total_client_connections 14
-proxy.process.http.total_client_connections_ipv4 14
+proxy.process.http.total_client_connections_ipv4 16
 proxy.process.http.total_client_connections_ipv6 0
 proxy.process.http.total_server_connections 0
 proxy.process.http2.total_client_connections 2


### PR DESCRIPTION
The IPv4 and IPv6 client connection metrics only count HTTP/1 sessions,
so deployments using HTTP/2 report fewer accepted connections than
Traffic Server actually handles.

This patch moves address-family accounting into the shared proxy session
and applies it to every supported HTTP protocol. It also adds replay
coverage and updates the existing mixed-protocol metric expectation.

Fixes: #12105