### PR TITLE
Metrics: close the id lookup race and bounds gaps left by the lock revert

### DIFF
--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -357,12 +357,36 @@ private:
       return {_cur_blob, _cur_off};
     }
 
+    /** Whether @a id names a slot that has actually been allocated.
+     *
+     * The single gate for every id based accessor. Ids arriving through the @c TSStat* API are
+     * plugin supplied and untrusted, so three things have to hold: the id is not negative, the
+     * offset is one @c _makeId could have produced -- the offset field is 16 bits wide but a real
+     * offset is always below @c MAX_SIZE, so a larger one is malformed rather than merely stale --
+     * and the slot has been handed out. Blobs are filled in increasing order and never freed, so
+     * that last part means either an earlier blob, or below the allocation point in the current one.
+     */
+    bool
+    _is_allocated(IdType id) const
+    {
+      if (id < 0) {
+        return false;
+      }
+
+      auto [blob_ix, offset] = _splitID(id);
+
+      // The blob comparison is against <= / <, not a test for "not the current blob", because
+      // addBlob() stores a new blob before advancing _cur_blob: for those two instructions
+      // _blobs[_cur_blob + 1] is non-null while still holding nothing. Requiring the index to be no
+      // greater than _cur_blob, and the offset to be below _cur_off in that blob, is correct
+      // whichever of the two the reader happens to observe first.
+      return offset < MAX_SIZE && blob_ix <= _cur_blob && _blobs[blob_ix] != nullptr && (blob_ix < _cur_blob || offset < _cur_off);
+    }
+
     bool
     valid(IdType id) const
     {
-      auto [blob, entry] = _splitID(id);
-
-      return (id >= 0 && ((blob < _cur_blob && entry < MAX_SIZE) || (blob == _cur_blob && entry <= _cur_off)));
+      return _is_allocated(id);
     }
   };
 

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -362,6 +362,13 @@ private:
       return {_cur_blob.load(std::memory_order_relaxed), _cur_off.load(std::memory_order_relaxed)};
     }
 
+    bool
+    valid(IdType id) const
+    {
+      return _is_allocated(id);
+    }
+
+  private:
     /** Whether @a id names an allocated slot.
      *
      * The gate for every id based accessor, since ids from the @c TSStat* API are untrusted. An id
@@ -384,12 +391,6 @@ private:
       // A non-null blob past cur_blob is allocated but not yet published, hence <= and < rather
       // than a test for "not the current blob".
       return offset < MAX_SIZE && blob_ix <= cur_blob && _blobs[blob_ix] != nullptr && (blob_ix < cur_blob || offset < cur_off);
-    }
-
-    bool
-    valid(IdType id) const
-    {
-      return _is_allocated(id);
     }
   };
 

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -308,26 +308,23 @@ private:
     return (t << METRIC_TYPE_BITS | blob << 16 | offset);
   }
 
-  /// A position with no type bits, which is how the next free slot is tracked and compared.
+  /// As @c _makeId, without the type bits.
   static constexpr uint32_t
   _pack(uint16_t blob, uint16_t offset)
   {
     return static_cast<uint32_t>(blob) << 16 | offset;
   }
 
-  // _pack must not collide with the type bits, and an offset must fit the field it is packed into.
+  // A packed position must not reach the type bits, and an offset must fit its field.
   static_assert(MAX_SIZE <= 0x10000);
   static_assert(MAX_BLOBS <= (1 << (METRIC_TYPE_BITS - 16)));
 
   class Storage
   {
-    /* The next free slot, packed as @c _makeId would pack it: the blob index above the offset. One
-     * value rather than two because readers need the pair to be coherent -- a reader that caught a
-     * new offset against an old blob index, or the reverse, would reject ids that exist or accept
-     * ids that do not. Release stored last, after whatever it publishes: the blob pointer when it
-     * crosses a blob, the slot's name otherwise. It only ever increases, so an id is allocated
-     * exactly when it packs below it. _blobs needs no atomic because it is only read at an index
-     * this value has published. Writers hold _mutex and load relaxed.
+    /* The next free slot, packed as @c _makeId packs one. A single value because a reader that
+     * caught a new offset against an old blob index, or the reverse, would reject ids that exist
+     * or accept ids that do not. Release stored last, after the blob pointer or the slot's name it
+     * publishes. Only ever increases, so an id is allocated exactly when it packs below it.
      */
     BlobStorage           _blobs;
     std::atomic<uint32_t> _next_free{0};
@@ -357,7 +354,7 @@ private:
     MetricType       type(IdType id) const;
     bool             rename(IdType id, const std::string_view name);
 
-    /// The next free slot, as the id it will be given. Also the exclusive bound for iteration.
+    /// The id the next slot will get, which is also iteration's exclusive bound.
     IdType
     next_free_id() const
     {
@@ -386,14 +383,12 @@ private:
 
       auto [blob_ix, offset] = _splitID(id);
 
-      // The offset check is not implied by the comparison below: _splitID takes the low 16 bits, so
-      // an id in an earlier blob can name an offset past MAX_SIZE and still pack below the bound.
+      // Not implied below: an earlier blob can name an offset past MAX_SIZE and still pack under.
       if (offset >= MAX_SIZE) {
         return false;
       }
 
-      // Acquiring the bound also makes visible everything published under it, the blob pointer
-      // included, so _blobs needs no separate check.
+      // Acquiring the bound acquires the blob install, so _blobs needs no check of its own.
       return _pack(blob_ix, offset) < _next_free.load(std::memory_order_acquire);
     }
   };

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -145,12 +145,6 @@ public:
   {
     return _storage->lookup(id, out_name, type);
   }
-  bool
-  rename(IdType id, const std::string_view name)
-  {
-    return _storage->rename(id, name);
-  }
-
   AtomicType &
   operator[](IdType id)
   {
@@ -325,6 +319,9 @@ private:
      * caught a new offset against an old blob index, or the reverse, would reject ids that exist
      * or accept ids that do not. Release stored last, after the blob pointer or the slot's name it
      * publishes. Only ever increases, so an id is allocated exactly when it packs below it.
+     *
+     * A slot's name is written once, before the store that publishes it, and never changes, which
+     * is what lets @c name and @c lookup hand out a view of it without the mutex.
      */
     BlobStorage           _blobs;
     std::atomic<uint32_t> _next_free{0};
@@ -352,7 +349,6 @@ private:
     AtomicType      *lookup(Metrics::IdType id, std::string_view *out_name = nullptr, MetricType *out_type = nullptr) const;
     std::string_view name(IdType id) const;
     MetricType       type(IdType id) const;
-    bool             rename(IdType id, const std::string_view name);
 
     /// The id the next slot will get, which is also iteration's exclusive bound.
     IdType

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -320,14 +320,10 @@ private:
 
   class Storage
   {
-    /* _cur_blob and _cur_off are the two publication points. Each is written last, with a release
-     * store, after whatever it makes visible: the blob pointer and the reset of _cur_off for
-     * _cur_blob, the slot's name for _cur_off. A reader loads them with acquire, _cur_blob first --
-     * see _is_allocated(). That is what makes the pair consistent without reading it as one word,
-     * and it is why _blobs itself needs no atomic: it is only ever read at an index no greater than
-     * _cur_blob, and that write is sequenced before the release store the reader acquired.
-     *
-     * Writers all hold _mutex, so they load these relaxed; there is no other writer to race with.
+    /* _cur_blob and _cur_off are release stored last, after whatever they publish: the blob pointer
+     * for _cur_blob, the slot's name for _cur_off. Readers acquire load them, _cur_blob first.
+     * _blobs needs no atomic because it is only read at an index no greater than _cur_blob.
+     * Writers hold _mutex and load relaxed.
      */
     BlobStorage           _blobs;
     std::atomic<uint16_t> _cur_blob{0};
@@ -366,14 +362,11 @@ private:
       return {_cur_blob.load(std::memory_order_relaxed), _cur_off.load(std::memory_order_relaxed)};
     }
 
-    /** Whether @a id names a slot that has actually been allocated.
+    /** Whether @a id names an allocated slot.
      *
-     * The single gate for every id based accessor. Ids arriving through the @c TSStat* API are
-     * plugin supplied and untrusted, so three things have to hold: the id is not negative, the
-     * offset is one @c _makeId could have produced -- the offset field is 16 bits wide but a real
-     * offset is always below @c MAX_SIZE, so a larger one is malformed rather than merely stale --
-     * and the slot has been handed out. Blobs are filled in increasing order and never freed, so
-     * that last part means either an earlier blob, or below the allocation point in the current one.
+     * The gate for every id based accessor, since ids from the @c TSStat* API are untrusted. An id
+     * qualifies when it is non-negative, its offset is one @c _makeId could produce, and its slot
+     * has been handed out.
      */
     bool
     _is_allocated(IdType id) const
@@ -384,15 +377,12 @@ private:
 
       auto [blob_ix, offset] = _splitID(id);
 
-      // Load the outer publication point first: seeing a value for _cur_blob means everything
-      // addBlob() wrote before releasing it -- the blob pointer, and the reset of _cur_off -- is
-      // visible here too. Reading _cur_off first would defeat that.
+      // _cur_blob first: acquiring it also makes visible everything published under it.
       auto const cur_blob = _cur_blob.load(std::memory_order_acquire);
       auto const cur_off  = _cur_off.load(std::memory_order_acquire);
 
-      // The blob comparison is against <= / <, not a test for "not the current blob", because
-      // addBlob() stores a new blob before advancing _cur_blob: until it does, _blobs[cur_blob + 1]
-      // is non-null while still holding nothing.
+      // A non-null blob past cur_blob is allocated but not yet published, hence <= and < rather
+      // than a test for "not the current blob".
       return offset < MAX_SIZE && blob_ix <= cur_blob && _blobs[blob_ix] != nullptr && (blob_ix < cur_blob || offset < cur_off);
     }
 

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -35,8 +35,6 @@
 #include <variant>
 #include <optional>
 
-#include "swoc/MemSpan.h"
-
 #include "tsutil/Assert.h"
 
 namespace ts
@@ -85,8 +83,7 @@ public:
 
   enum class MetricType : int { COUNTER = 0, GAUGE };
 
-  using IdType   = int32_t; // Could be a tuple, but one way or another, they have to be combined to an int32_t.
-  using SpanType = swoc::MemSpan<AtomicType>;
+  using IdType = int32_t; // Could be a tuple, but one way or another, they have to be combined to an int32_t.
 
   static constexpr uint16_t MAX_BLOBS        = 8192;
   static constexpr uint16_t MAX_SIZE         = 1024;                               // For a total of 8M metrics
@@ -267,9 +264,7 @@ public:
   iterator
   end() const
   {
-    auto [blob, offset] = _storage->current();
-
-    return iterator(*this, _makeId(blob, offset, MetricType::COUNTER));
+    return iterator(*this, _storage->next_free_id());
   }
 
   iterator
@@ -292,12 +287,6 @@ private:
     return _storage->create(name, type);
   }
 
-  SpanType
-  _createSpan(size_t size, MetricType type, IdType *id = nullptr)
-  {
-    return _storage->createSpan(size, type, id);
-  }
-
   // These are little helpers around managing the ID's
   static constexpr std::tuple<uint16_t, uint16_t>
   _splitID(IdType value)
@@ -318,16 +307,29 @@ private:
     return (t << METRIC_TYPE_BITS | blob << 16 | offset);
   }
 
+  /// A position with no type bits, which is how the next free slot is tracked and compared.
+  static constexpr uint32_t
+  _pack(uint16_t blob, uint16_t offset)
+  {
+    return static_cast<uint32_t>(blob) << 16 | offset;
+  }
+
+  // _pack must not collide with the type bits, and an offset must fit the field it is packed into.
+  static_assert(MAX_SIZE <= 0x10000);
+  static_assert(MAX_BLOBS <= (1 << (METRIC_TYPE_BITS - 16)));
+
   class Storage
   {
-    /* _cur_blob and _cur_off are release stored last, after whatever they publish: the blob pointer
-     * for _cur_blob, the slot's name for _cur_off. Readers acquire load them, _cur_blob first.
-     * _blobs needs no atomic because it is only read at an index no greater than _cur_blob.
-     * Writers hold _mutex and load relaxed.
+    /* The next free slot, packed as @c _makeId would pack it: the blob index above the offset. One
+     * value rather than two because readers need the pair to be coherent -- a reader that caught a
+     * new offset against an old blob index, or the reverse, would reject ids that exist or accept
+     * ids that do not. Release stored last, after whatever it publishes: the blob pointer when it
+     * crosses a blob, the slot's name otherwise. It only ever increases, so an id is allocated
+     * exactly when it packs below it. _blobs needs no atomic because it is only read at an index
+     * this value has published. Writers hold _mutex and load relaxed.
      */
     BlobStorage           _blobs;
-    std::atomic<uint16_t> _cur_blob{0};
-    std::atomic<uint16_t> _cur_off{0};
+    std::atomic<uint32_t> _next_free{0};
     LookupTable           _lookups;
     mutable std::mutex    _mutex;
 
@@ -352,14 +354,13 @@ private:
     AtomicType      *lookup(Metrics::IdType id, std::string_view *out_name = nullptr, MetricType *out_type = nullptr) const;
     std::string_view name(IdType id) const;
     MetricType       type(IdType id) const;
-    SpanType         createSpan(size_t size, const MetricType type = MetricType::COUNTER, IdType *id = nullptr);
     bool             rename(IdType id, const std::string_view name);
 
-    std::pair<int16_t, int16_t>
-    current() const
+    /// The next free slot, as the id it will be given. Also the exclusive bound for iteration.
+    IdType
+    next_free_id() const
     {
-      std::lock_guard lock(_mutex);
-      return {_cur_blob.load(std::memory_order_relaxed), _cur_off.load(std::memory_order_relaxed)};
+      return static_cast<IdType>(_next_free.load(std::memory_order_acquire));
     }
 
     bool
@@ -384,13 +385,15 @@ private:
 
       auto [blob_ix, offset] = _splitID(id);
 
-      // _cur_blob first: acquiring it also makes visible everything published under it.
-      auto const cur_blob = _cur_blob.load(std::memory_order_acquire);
-      auto const cur_off  = _cur_off.load(std::memory_order_acquire);
+      // The offset check is not implied by the comparison below: _splitID takes the low 16 bits, so
+      // an id in an earlier blob can name an offset past MAX_SIZE and still pack below the bound.
+      if (offset >= MAX_SIZE) {
+        return false;
+      }
 
-      // A non-null blob past cur_blob is allocated but not yet published, hence <= and < rather
-      // than a test for "not the current blob".
-      return offset < MAX_SIZE && blob_ix <= cur_blob && _blobs[blob_ix] != nullptr && (blob_ix < cur_blob || offset < cur_off);
+      // Acquiring the bound also makes visible everything published under it, the blob pointer
+      // included, so _blobs needs no separate check.
+      return _pack(blob_ix, offset) < _next_free.load(std::memory_order_acquire);
     }
   };
 
@@ -404,7 +407,6 @@ public:
   {
   public:
     using self_type = Gauge;
-    using SpanType  = Metrics::SpanType;
 
     class AtomicType : public Metrics::AtomicType
     {
@@ -480,14 +482,6 @@ public:
       return reinterpret_cast<AtomicType *>(instance.lookup(instance._create(tmpname, MetricType::GAUGE)));
     }
 
-    static Metrics::Gauge::SpanType
-    createSpan(size_t size, IdType *id = nullptr)
-    {
-      auto &instance = Metrics::instance();
-
-      return instance._createSpan(size, MetricType::GAUGE, id);
-    }
-
     static void
     increment(AtomicType *metric, uint64_t val = 1)
     {
@@ -522,7 +516,6 @@ public:
   {
   public:
     using self_type = Counter;
-    using SpanType  = Metrics::SpanType;
 
     class AtomicType : public Metrics::AtomicType
     {
@@ -596,14 +589,6 @@ public:
       std::string tmpname  = std::string(prefix) + std::string(name);
 
       return reinterpret_cast<AtomicType *>(instance.lookup(instance._create(tmpname, MetricType::COUNTER)));
-    }
-
-    static Metrics::Counter::SpanType
-    createSpan(size_t size, IdType *id = nullptr)
-    {
-      auto &instance = Metrics::instance();
-
-      return instance._createSpan(size, MetricType::COUNTER, id);
     }
 
     static void

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -320,11 +320,20 @@ private:
 
   class Storage
   {
-    BlobStorage        _blobs;
-    uint16_t           _cur_blob = 0;
-    uint16_t           _cur_off  = 0;
-    LookupTable        _lookups;
-    mutable std::mutex _mutex;
+    /* _cur_blob and _cur_off are the two publication points. Each is written last, with a release
+     * store, after whatever it makes visible: the blob pointer and the reset of _cur_off for
+     * _cur_blob, the slot's name for _cur_off. A reader loads them with acquire, _cur_blob first --
+     * see _is_allocated(). That is what makes the pair consistent without reading it as one word,
+     * and it is why _blobs itself needs no atomic: it is only ever read at an index no greater than
+     * _cur_blob, and that write is sequenced before the release store the reader acquired.
+     *
+     * Writers all hold _mutex, so they load these relaxed; there is no other writer to race with.
+     */
+    BlobStorage           _blobs;
+    std::atomic<uint16_t> _cur_blob{0};
+    std::atomic<uint16_t> _cur_off{0};
+    LookupTable           _lookups;
+    mutable std::mutex    _mutex;
 
   public:
     Storage(const Storage &)            = delete;
@@ -354,7 +363,7 @@ private:
     current() const
     {
       std::lock_guard lock(_mutex);
-      return {_cur_blob, _cur_off};
+      return {_cur_blob.load(std::memory_order_relaxed), _cur_off.load(std::memory_order_relaxed)};
     }
 
     /** Whether @a id names a slot that has actually been allocated.
@@ -375,12 +384,16 @@ private:
 
       auto [blob_ix, offset] = _splitID(id);
 
+      // Load the outer publication point first: seeing a value for _cur_blob means everything
+      // addBlob() wrote before releasing it -- the blob pointer, and the reset of _cur_off -- is
+      // visible here too. Reading _cur_off first would defeat that.
+      auto const cur_blob = _cur_blob.load(std::memory_order_acquire);
+      auto const cur_off  = _cur_off.load(std::memory_order_acquire);
+
       // The blob comparison is against <= / <, not a test for "not the current blob", because
-      // addBlob() stores a new blob before advancing _cur_blob: for those two instructions
-      // _blobs[_cur_blob + 1] is non-null while still holding nothing. Requiring the index to be no
-      // greater than _cur_blob, and the offset to be below _cur_off in that blob, is correct
-      // whichever of the two the reader happens to observe first.
-      return offset < MAX_SIZE && blob_ix <= _cur_blob && _blobs[blob_ix] != nullptr && (blob_ix < _cur_blob || offset < _cur_off);
+      // addBlob() stores a new blob before advancing _cur_blob: until it does, _blobs[cur_blob + 1]
+      // is non-null while still holding nothing.
+      return offset < MAX_SIZE && blob_ix <= cur_blob && _blobs[blob_ix] != nullptr && (blob_ix < cur_blob || offset < cur_off);
     }
 
     bool

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <atomic>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <variant>

--- a/include/tsutil/Metrics.h
+++ b/include/tsutil/Metrics.h
@@ -308,7 +308,7 @@ private:
   static constexpr MetricType
   _extractType(IdType value)
   {
-    return MetricType{value >> METRIC_TYPE_BITS};
+    return MetricType{static_cast<int>((static_cast<uint32_t>(value) >> METRIC_TYPE_BITS) & 0x1)};
   }
 
   static constexpr IdType

--- a/src/records/unit_tests/test_RecRegister.cc
+++ b/src/records/unit_tests/test_RecRegister.cc
@@ -26,6 +26,7 @@
 #include "test_Diags.h"
 
 #include <atomic>
+#include <string>
 #include <thread>
 
 TEST_CASE("RecRegisterConfig - Type Dispatch", "[librecords][RecConfig]")
@@ -103,7 +104,8 @@ TEST_CASE("RecLookupRecord - Concurrent metric registration", "[librecords][RecL
   std::atomic<bool> finished{false};
   std::thread       register_metrics([&]() {
     for (int i = 0; i < 100000; ++i) {
-      ts::Metrics::Counter::createSpan(1);
+      // Any registration will do; the point is to grow the store while lookups run.
+      ts::Metrics::Counter::create("proxy.test.concurrent.reg." + std::to_string(i));
     }
     finished.store(true, std::memory_order_release);
   });

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -62,8 +62,9 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
   // The write below is to _blobs[_cur_blob + 1], so the last usable blob index is MAX_BLOBS - 1.
   release_assert(_cur_blob < MAX_BLOBS - 1);
 
-  _blobs[++_cur_blob] = std::move(blob);
-  _cur_off            = 0;
+  _blobs[_cur_blob + 1] = std::move(blob);
+  _cur_off              = 0;
+  ++_cur_blob;
 }
 
 Metrics::IdType
@@ -113,14 +114,16 @@ Metrics::Storage::lookup(const std::string_view name) const
 Metrics::AtomicType *
 Metrics::Storage::lookup(Metrics::IdType id, std::string_view *out_name, Metrics::MetricType *out_type) const
 {
-  auto [blob_ix, offset]         = _splitID(id);
-  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
+  auto [blob_ix, offset] = _splitID(id);
 
-  // Do a sanity check on the ID, to make sure we don't index outside of the realm of possibility.
-  if (!blob || (blob_ix == _cur_blob && offset > _cur_off)) {
-    blob   = _blobs[0].get();
-    offset = 0;
+  // Anything that does not name an allocated slot resolves to the reserved bad_id slot rather than
+  // indexing out of range.
+  if (!_is_allocated(id)) {
+    blob_ix = 0;
+    offset  = 0;
   }
+
+  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
 
   if (out_name) {
     *out_name = std::get<0>(std::get<0>(*blob)[offset]);
@@ -159,14 +162,16 @@ Metrics::Storage::lookup(const std::string_view name, Metrics::IdType *out_id, M
 std::string_view
 Metrics::Storage::name(Metrics::IdType id) const
 {
-  auto [blob_ix, offset]         = _splitID(id);
-  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
+  auto [blob_ix, offset] = _splitID(id);
 
-  // Do a sanity check on the ID, to make sure we don't index outside of the realm of possibility.
-  if (!blob || (blob_ix == _cur_blob && offset > _cur_off)) {
-    blob   = _blobs[0].get();
-    offset = 0;
+  // Anything that does not name an allocated slot resolves to the reserved bad_id slot rather than
+  // indexing out of range.
+  if (!_is_allocated(id)) {
+    blob_ix = 0;
+    offset  = 0;
   }
+
+  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
 
   const std::string &result = std::get<0>(std::get<0>(*blob)[offset]);
 
@@ -225,13 +230,13 @@ Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdT
 bool
 Metrics::Storage::rename(Metrics::IdType id, std::string_view name)
 {
-  auto [blob_ix, offset]         = _splitID(id);
-  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
-
   // We can only rename Metrics that are already allocated
-  if (!blob || (blob_ix == _cur_blob && offset > _cur_off)) {
+  if (!_is_allocated(id)) {
     return false;
   }
+
+  auto [blob_ix, offset]         = _splitID(id);
+  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
 
   std::string    &cur = std::get<0>(std::get<0>(*blob)[offset]);
   std::lock_guard lock(_mutex);

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -199,11 +199,13 @@ Metrics::Storage::rename(Metrics::IdType id, std::string_view name)
     return false;
   }
 
+  // Held across the whole rename: the name is the key _lookups is indexed by, so replacing it has
+  // to be serialized against every other writer of that slot's name.
+  std::lock_guard lock(_mutex);
+
   auto [blob_ix, offset]         = _splitID(id);
   Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
-
-  std::string    &cur = std::get<0>(std::get<0>(*blob)[offset]);
-  std::lock_guard lock(_mutex);
+  std::string              &cur  = std::get<0>(std::get<0>(*blob)[offset]);
 
   if (cur.length() > 0) {
     _lookups.erase(cur);

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -201,7 +201,10 @@ Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdT
   // On the final blob there is nowhere left to grow, so refuse a span that would fill or overflow
   // it rather than letting addBlob() assert. Same intent as the guard in create(), and the same
   // cost: some slots of the last blob go unused.
-  if (_cur_blob.load(std::memory_order_relaxed) >= MAX_BLOBS - 1 && _cur_off.load(std::memory_order_relaxed) + size >= MAX_SIZE) {
+  auto cur_blob = _cur_blob.load(std::memory_order_relaxed);
+  auto cur_off  = _cur_off.load(std::memory_order_relaxed);
+
+  if (cur_blob >= MAX_BLOBS - 1 && cur_off + size >= MAX_SIZE) {
     if (id) {
       *id = 0; // Slot 0 is the reserved bad_id.
     }
@@ -209,13 +212,11 @@ Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdT
   }
 
   // A span has to be contiguous, so one that does not fit in the current blob starts a new one.
-  if (_cur_off.load(std::memory_order_relaxed) + size > MAX_SIZE) {
+  if (cur_off + size > MAX_SIZE) {
     addBlob();
+    cur_blob = _cur_blob.load(std::memory_order_relaxed);
+    cur_off  = _cur_off.load(std::memory_order_relaxed);
   }
-
-  // Re-read: addBlob() above may have moved both.
-  auto const cur_blob = _cur_blob.load(std::memory_order_relaxed);
-  auto const cur_off  = _cur_off.load(std::memory_order_relaxed);
 
   Metrics::IdType           span_start = _makeId(cur_blob, cur_off, type);
   Metrics::NamesAndAtomics *blob       = _blobs[cur_blob].get();

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -58,17 +58,16 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
 {
   auto blob = std::make_unique<Metrics::NamesAndAtomics>();
 
-  auto const cur_blob = _cur_blob.load(std::memory_order_relaxed);
+  auto const [cur_blob, cur_off] = _splitID(static_cast<IdType>(_next_free.load(std::memory_order_relaxed)));
 
   debug_assert(blob);
   // The write below is to _blobs[cur_blob + 1], so the last usable blob index is MAX_BLOBS - 1.
   release_assert(cur_blob < MAX_BLOBS - 1);
 
   _blobs[cur_blob + 1] = std::move(blob);
-  _cur_off.store(0, std::memory_order_relaxed);
 
-  // Publishes the blob; both writes above are sequenced before it.
-  _cur_blob.store(cur_blob + 1, std::memory_order_release);
+  // Publishes the blob and the offset reset as one value; the write above is sequenced before it.
+  _next_free.store(_pack(cur_blob + 1, 0), std::memory_order_release);
 }
 
 Metrics::IdType
@@ -81,11 +80,10 @@ Metrics::Storage::create(std::string_view name, const MetricType type)
     return it->second;
   }
 
-  // The slot is written below and the bookkeeping only then advances, calling addBlob() once
-  // _cur_off reaches MAX_SIZE. Refusing the final slot of the final blob keeps addBlob() from
-  // ever being reached in an exhausted store, at a cost of one slot out of MAX_BLOBS * MAX_SIZE.
-  auto const cur_blob = _cur_blob.load(std::memory_order_relaxed);
-  auto const cur_off  = _cur_off.load(std::memory_order_relaxed);
+  // The slot is written below and the bookkeeping only then advances, calling addBlob() once the
+  // offset reaches MAX_SIZE. Refusing the final slot of the final blob keeps addBlob() from ever
+  // being reached in an exhausted store, at a cost of one slot out of MAX_BLOBS * MAX_SIZE.
+  auto const [cur_blob, cur_off] = _splitID(static_cast<IdType>(_next_free.load(std::memory_order_relaxed)));
 
   if (cur_blob >= MAX_BLOBS - 1 && cur_off >= MAX_SIZE - 1) {
     return 0; // Slot 0 is the reserved bad_id. Cannot grow further.
@@ -98,11 +96,11 @@ Metrics::Storage::create(std::string_view name, const MetricType type)
   names[cur_off] = std::make_tuple(std::string(name), id);
   _lookups.emplace(std::get<0>(names[cur_off]), id);
 
-  // Publishes the slot; the name write above is sequenced before it.
-  _cur_off.store(cur_off + 1, std::memory_order_release);
-
   if (cur_off + 1 >= MAX_SIZE) {
-    addBlob(); // This resets _cur_off to 0 as well
+    addBlob(); // Publishes the next blob with a zero offset.
+  } else {
+    // Publishes the slot's name.
+    _next_free.store(_pack(cur_blob, cur_off + 1), std::memory_order_release);
   }
 
   return id;
@@ -190,55 +188,6 @@ Metrics::MetricType
 Metrics::Storage::type(IdType id) const
 {
   return _extractType(id);
-}
-
-Metrics::SpanType
-Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdType *id)
-{
-  release_assert(size <= MAX_SIZE);
-  std::lock_guard lock(_mutex);
-
-  // On the final blob there is nowhere left to grow, so refuse a span that would fill or overflow
-  // it rather than letting addBlob() assert. Same intent as the guard in create(), and the same
-  // cost: some slots of the last blob go unused.
-  auto cur_blob = _cur_blob.load(std::memory_order_relaxed);
-  auto cur_off  = _cur_off.load(std::memory_order_relaxed);
-
-  if (cur_blob >= MAX_BLOBS - 1 && cur_off + size >= MAX_SIZE) {
-    if (id) {
-      *id = 0; // Slot 0 is the reserved bad_id.
-    }
-    return {};
-  }
-
-  // A span has to be contiguous, so one that does not fit in the current blob starts a new one.
-  if (cur_off + size > MAX_SIZE) {
-    addBlob();
-    cur_blob = _cur_blob.load(std::memory_order_relaxed);
-    cur_off  = _cur_off.load(std::memory_order_relaxed);
-  }
-
-  Metrics::IdType           span_start = _makeId(cur_blob, cur_off, type);
-  Metrics::NamesAndAtomics *blob       = _blobs[cur_blob].get();
-  Metrics::AtomicStorage   &atomics    = std::get<1>(*blob);
-  Metrics::SpanType         span       = Metrics::SpanType(&atomics[cur_off], size);
-
-  if (id) {
-    *id = span_start;
-  }
-
-  // Publishes the span's slots.
-  _cur_off.store(cur_off + size, std::memory_order_release);
-
-  // create() grows as soon as it consumes the last slot; do the same here. Otherwise a span ending
-  // exactly on the boundary leaves _cur_off at MAX_SIZE, and the next create() writes one past the
-  // end of the blob's name array. It also makes end() unreachable for iterator::next(), which
-  // wraps on ++offset == MAX_SIZE.
-  if (cur_off + size >= MAX_SIZE) {
-    addBlob();
-  }
-
-  return span;
 }
 
 bool

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -58,13 +58,18 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
 {
   auto blob = std::make_unique<Metrics::NamesAndAtomics>();
 
-  debug_assert(blob);
-  // The write below is to _blobs[_cur_blob + 1], so the last usable blob index is MAX_BLOBS - 1.
-  release_assert(_cur_blob < MAX_BLOBS - 1);
+  auto const cur_blob = _cur_blob.load(std::memory_order_relaxed);
 
-  _blobs[_cur_blob + 1] = std::move(blob);
-  _cur_off              = 0;
-  ++_cur_blob;
+  debug_assert(blob);
+  // The write below is to _blobs[cur_blob + 1], so the last usable blob index is MAX_BLOBS - 1.
+  release_assert(cur_blob < MAX_BLOBS - 1);
+
+  _blobs[cur_blob + 1] = std::move(blob);
+  _cur_off.store(0, std::memory_order_relaxed);
+
+  // Publishes the new blob. Both writes above are sequenced before this, so a reader that acquires
+  // this value sees the blob pointer and the reset offset.
+  _cur_blob.store(cur_blob + 1, std::memory_order_release);
 }
 
 Metrics::IdType
@@ -80,18 +85,25 @@ Metrics::Storage::create(std::string_view name, const MetricType type)
   // The slot is written below and the bookkeeping only then advances, calling addBlob() once
   // _cur_off reaches MAX_SIZE. Refusing the final slot of the final blob keeps addBlob() from
   // ever being reached in an exhausted store, at a cost of one slot out of MAX_BLOBS * MAX_SIZE.
-  if (_cur_blob >= MAX_BLOBS - 1 && _cur_off >= MAX_SIZE - 1) {
+  auto const cur_blob = _cur_blob.load(std::memory_order_relaxed);
+  auto const cur_off  = _cur_off.load(std::memory_order_relaxed);
+
+  if (cur_blob >= MAX_BLOBS - 1 && cur_off >= MAX_SIZE - 1) {
     return 0; // Slot 0 is the reserved bad_id. Cannot grow further.
   }
 
-  Metrics::IdType           id    = _makeId(_cur_blob, _cur_off, type);
-  Metrics::NamesAndAtomics *blob  = _blobs[_cur_blob].get();
+  Metrics::IdType           id    = _makeId(cur_blob, cur_off, type);
+  Metrics::NamesAndAtomics *blob  = _blobs[cur_blob].get();
   Metrics::NameStorage     &names = std::get<0>(*blob);
 
-  names[_cur_off] = std::make_tuple(std::string(name), id);
-  _lookups.emplace(std::get<0>(names[_cur_off]), id);
+  names[cur_off] = std::make_tuple(std::string(name), id);
+  _lookups.emplace(std::get<0>(names[cur_off]), id);
 
-  if (++_cur_off >= MAX_SIZE) {
+  // Publishes the slot. The name write above is sequenced before this, so a reader that acquires
+  // this value can read the name.
+  _cur_off.store(cur_off + 1, std::memory_order_release);
+
+  if (cur_off + 1 >= MAX_SIZE) {
     addBlob(); // This resets _cur_off to 0 as well
   }
 
@@ -193,7 +205,7 @@ Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdT
   // On the final blob there is nowhere left to grow, so refuse a span that would fill or overflow
   // it rather than letting addBlob() assert. Same intent as the guard in create(), and the same
   // cost: some slots of the last blob go unused.
-  if (_cur_blob >= MAX_BLOBS - 1 && _cur_off + size >= MAX_SIZE) {
+  if (_cur_blob.load(std::memory_order_relaxed) >= MAX_BLOBS - 1 && _cur_off.load(std::memory_order_relaxed) + size >= MAX_SIZE) {
     if (id) {
       *id = 0; // Slot 0 is the reserved bad_id.
     }
@@ -201,26 +213,32 @@ Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdT
   }
 
   // A span has to be contiguous, so one that does not fit in the current blob starts a new one.
-  if (_cur_off + size > MAX_SIZE) {
+  if (_cur_off.load(std::memory_order_relaxed) + size > MAX_SIZE) {
     addBlob();
   }
 
-  Metrics::IdType           span_start = _makeId(_cur_blob, _cur_off, type);
-  Metrics::NamesAndAtomics *blob       = _blobs[_cur_blob].get();
+  // Re-read: addBlob() above may have moved both.
+  auto const cur_blob = _cur_blob.load(std::memory_order_relaxed);
+  auto const cur_off  = _cur_off.load(std::memory_order_relaxed);
+
+  Metrics::IdType           span_start = _makeId(cur_blob, cur_off, type);
+  Metrics::NamesAndAtomics *blob       = _blobs[cur_blob].get();
   Metrics::AtomicStorage   &atomics    = std::get<1>(*blob);
-  Metrics::SpanType         span       = Metrics::SpanType(&atomics[_cur_off], size);
+  Metrics::SpanType         span       = Metrics::SpanType(&atomics[cur_off], size);
 
   if (id) {
     *id = span_start;
   }
 
-  _cur_off += size;
+  // Publishes the span's slots. Unlike create() there are no names to make visible, but a reader
+  // still must not see the offset advance before the blob it advanced within.
+  _cur_off.store(cur_off + size, std::memory_order_release);
 
   // create() grows as soon as it consumes the last slot; do the same here. Otherwise a span ending
   // exactly on the boundary leaves _cur_off at MAX_SIZE, and the next create() writes one past the
   // end of the blob's name array. It also makes end() unreachable for iterator::next(), which
   // wraps on ++offset == MAX_SIZE.
-  if (_cur_off >= MAX_SIZE) {
+  if (cur_off + size >= MAX_SIZE) {
     addBlob();
   }
 

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -58,7 +58,6 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
 {
   auto blob = std::make_unique<Metrics::NamesAndAtomics>();
 
-  // Only the blob index is needed; the offset resets to zero below.
   auto const cur_blob = static_cast<uint16_t>(_next_free.load(std::memory_order_relaxed) >> 16);
 
   debug_assert(blob);
@@ -67,7 +66,7 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
 
   _blobs[cur_blob + 1] = std::move(blob);
 
-  // Publishes the blob and the offset reset as one value; the write above is sequenced before it.
+  // One store publishes both; the install above is sequenced before it.
   _next_free.store(_pack(cur_blob + 1, 0), std::memory_order_release);
 }
 
@@ -98,7 +97,7 @@ Metrics::Storage::create(std::string_view name, const MetricType type)
   _lookups.emplace(std::get<0>(names[cur_off]), id);
 
   if (cur_off + 1 >= MAX_SIZE) {
-    addBlob(); // Publishes the next blob with a zero offset.
+    addBlob();
   } else {
     // Publishes the slot's name.
     _next_free.store(_pack(cur_blob, cur_off + 1), std::memory_order_release);
@@ -199,8 +198,7 @@ Metrics::Storage::rename(Metrics::IdType id, std::string_view name)
     return false;
   }
 
-  // Held across the whole rename: the name is the key _lookups is indexed by, so replacing it has
-  // to be serialized against every other writer of that slot's name.
+  // The name is the key _lookups is indexed by, so the whole replacement is serialized.
   std::lock_guard lock(_mutex);
 
   auto [blob_ix, offset]         = _splitID(id);

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -190,30 +190,6 @@ Metrics::Storage::type(IdType id) const
   return _extractType(id);
 }
 
-bool
-Metrics::Storage::rename(Metrics::IdType id, std::string_view name)
-{
-  // We can only rename Metrics that are already allocated
-  if (!_is_allocated(id)) {
-    return false;
-  }
-
-  // The name is the key _lookups is indexed by, so the whole replacement is serialized.
-  std::lock_guard lock(_mutex);
-
-  auto [blob_ix, offset]         = _splitID(id);
-  Metrics::NamesAndAtomics *blob = _blobs[blob_ix].get();
-  std::string              &cur  = std::get<0>(std::get<0>(*blob)[offset]);
-
-  if (cur.length() > 0) {
-    _lookups.erase(cur);
-  }
-  cur = name;
-  _lookups.emplace(cur, id);
-
-  return true;
-}
-
 // Iterator implementation
 void
 Metrics::iterator::next()

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -67,8 +67,7 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
   _blobs[cur_blob + 1] = std::move(blob);
   _cur_off.store(0, std::memory_order_relaxed);
 
-  // Publishes the new blob. Both writes above are sequenced before this, so a reader that acquires
-  // this value sees the blob pointer and the reset offset.
+  // Publishes the blob; both writes above are sequenced before it.
   _cur_blob.store(cur_blob + 1, std::memory_order_release);
 }
 
@@ -99,8 +98,7 @@ Metrics::Storage::create(std::string_view name, const MetricType type)
   names[cur_off] = std::make_tuple(std::string(name), id);
   _lookups.emplace(std::get<0>(names[cur_off]), id);
 
-  // Publishes the slot. The name write above is sequenced before this, so a reader that acquires
-  // this value can read the name.
+  // Publishes the slot; the name write above is sequenced before it.
   _cur_off.store(cur_off + 1, std::memory_order_release);
 
   if (cur_off + 1 >= MAX_SIZE) {
@@ -128,8 +126,7 @@ Metrics::Storage::lookup(Metrics::IdType id, std::string_view *out_name, Metrics
 {
   auto [blob_ix, offset] = _splitID(id);
 
-  // Anything that does not name an allocated slot resolves to the reserved bad_id slot rather than
-  // indexing out of range.
+  // Anything not naming an allocated slot resolves to the reserved bad_id slot.
   if (!_is_allocated(id)) {
     blob_ix = 0;
     offset  = 0;
@@ -176,8 +173,7 @@ Metrics::Storage::name(Metrics::IdType id) const
 {
   auto [blob_ix, offset] = _splitID(id);
 
-  // Anything that does not name an allocated slot resolves to the reserved bad_id slot rather than
-  // indexing out of range.
+  // Anything not naming an allocated slot resolves to the reserved bad_id slot.
   if (!_is_allocated(id)) {
     blob_ix = 0;
     offset  = 0;
@@ -230,8 +226,7 @@ Metrics::Storage::createSpan(size_t size, Metrics::MetricType type, Metrics::IdT
     *id = span_start;
   }
 
-  // Publishes the span's slots. Unlike create() there are no names to make visible, but a reader
-  // still must not see the offset advance before the blob it advanced within.
+  // Publishes the span's slots.
   _cur_off.store(cur_off + size, std::memory_order_release);
 
   // create() grows as soon as it consumes the last slot; do the same here. Otherwise a span ending

--- a/src/tsutil/Metrics.cc
+++ b/src/tsutil/Metrics.cc
@@ -58,7 +58,8 @@ Metrics::Storage::addBlob() // The mutex must be held before calling this!
 {
   auto blob = std::make_unique<Metrics::NamesAndAtomics>();
 
-  auto const [cur_blob, cur_off] = _splitID(static_cast<IdType>(_next_free.load(std::memory_order_relaxed)));
+  // Only the blob index is needed; the offset resets to zero below.
+  auto const cur_blob = static_cast<uint16_t>(_next_free.load(std::memory_order_relaxed) >> 16);
 
   debug_assert(blob);
   // The write below is to _blobs[cur_blob + 1], so the last usable blob index is MAX_BLOBS - 1.

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -95,31 +95,11 @@ TEST_CASE("Metrics", "[libtsapi][Metrics]")
     REQUIRE(m[storeid].load() == 42);
   }
 
-  SECTION("Span allocation")
+  SECTION("rename")
   {
-    ts::Metrics::IdType span_id;
-    auto                fooid = m.lookup("foo");
-    auto                span  = Metrics::Counter::createSpan(17, &span_id);
+    auto fooid = m.lookup("foo");
 
-    REQUIRE(span.size() == 17);
-    // Not fixed offsets: those only hold against a virgin store. Assert instead that the span
-    // was allocated above the earlier metric and that every id in it is valid. Both ids are
-    // counters, so they are directly comparable -- ids encode the metric type, and so are not
-    // ordered across differing types.
     REQUIRE(fooid != ts::Metrics::NOT_FOUND);
-    REQUIRE(span_id != ts::Metrics::NOT_FOUND);
-    REQUIRE(span_id > fooid);
-    for (size_t i = 0; i < span.size(); ++i) {
-      REQUIRE(m.valid(span_id + static_cast<ts::Metrics::IdType>(i)));
-    }
-
-    m.rename(span_id + 0, "span.0");
-    m.rename(span_id + 1, "span.1");
-    m.rename(span_id + 2, "span.2");
-    REQUIRE(m.name(fooid) == "foo");
-    REQUIRE(m.name(span_id + 0) == "span.0");
-    REQUIRE(m.name(span_id + 1) == "span.1");
-    REQUIRE(m.name(span_id + 2) == "span.2");
     m.rename(fooid, "foo-new");
     REQUIRE(m.name(fooid) == "foo-new");
     REQUIRE(m.lookup("foo") == ts::Metrics::NOT_FOUND);
@@ -608,34 +588,6 @@ TEST_CASE("Metrics blob growth boundary", "[libtsapi][Metrics]")
   std::vector<Metrics::Counter::AtomicType *> sorted_ptrs = ptrs;
   std::sort(sorted_ptrs.begin(), sorted_ptrs.end());
   REQUIRE(std::adjacent_find(sorted_ptrs.begin(), sorted_ptrs.end()) == sorted_ptrs.end());
-}
-
-TEST_CASE("Metrics span lands exactly on a blob boundary", "[libtsapi][Metrics]")
-{
-  // A span of MAX_SIZE always lands at offset 0 of an empty blob and fills it, whatever the current
-  // offset was, so it reaches the blob boundary deterministically. createSpan only targets the
-  // published store, so this allocates there.
-  Metrics::IdType span_id = Metrics::NOT_FOUND;
-  auto            span    = Metrics::Counter::createSpan(Metrics::MAX_SIZE, &span_id);
-
-  REQUIRE(span.size() == Metrics::MAX_SIZE);
-  REQUIRE(span_id != Metrics::NOT_FOUND);
-  REQUIRE(span_id != 0); // 0 is the reserved bad_id, returned only when the store cannot grow.
-
-  // The store must still be usable, and the new metric must be a real, resolvable entry rather
-  // than something written past the end of a blob.
-  auto p = Metrics::Counter::createPtr("span.boundary.after");
-  REQUIRE(p != nullptr);
-
-  auto &m  = Metrics::instance();
-  auto  id = m.lookup("span.boundary.after");
-  REQUIRE(id != Metrics::NOT_FOUND);
-  REQUIRE(m.valid(id));
-
-  // And it must behave like any other metric.
-  Metrics::Counter::increment(p, 7);
-  REQUIRE(Metrics::Counter::load(p) == 7);
-  REQUIRE(Metrics::Counter::createPtr("span.boundary.after") == p);
 }
 
 TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]")

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -95,17 +95,6 @@ TEST_CASE("Metrics", "[libtsapi][Metrics]")
     REQUIRE(m[storeid].load() == 42);
   }
 
-  SECTION("rename")
-  {
-    auto fooid = m.lookup("foo");
-
-    REQUIRE(fooid != ts::Metrics::NOT_FOUND);
-    m.rename(fooid, "foo-new");
-    REQUIRE(m.name(fooid) == "foo-new");
-    REQUIRE(m.lookup("foo") == ts::Metrics::NOT_FOUND);
-    REQUIRE(m.lookup("foo-new") == fooid);
-  }
-
   SECTION("lookup")
   {
     auto nm = m.lookup("notametric");

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -611,14 +611,9 @@ TEST_CASE("Metrics blob growth boundary", "[libtsapi][Metrics]")
 
 TEST_CASE("Metrics span lands exactly on a blob boundary", "[libtsapi][Metrics]")
 {
-  // A span has to be contiguous, so createSpan(MAX_SIZE) always starts a fresh blob and then fills
-  // it completely, whatever the current offset was. That makes this the one span size that reaches
-  // the boundary case deterministically: the offset ends up at MAX_SIZE, and unlike create(),
-  // createSpan used not to grow a new blob afterwards. The next create() then indexed one past the
-  // end of the blob's name array, and end() became an id that iterator::next() can never reach
-  // because it wraps at ++offset == MAX_SIZE.
-  //
-  // createSpan only ever targets the published store, so this necessarily allocates there.
+  // A span of MAX_SIZE always lands at offset 0 of an empty blob and fills it, whatever the current
+  // offset was, so it reaches the blob boundary deterministically. createSpan only targets the
+  // published store, so this allocates there.
   Metrics::IdType span_id = Metrics::NOT_FOUND;
   auto            span    = Metrics::Counter::createSpan(Metrics::MAX_SIZE, &span_id);
 
@@ -644,10 +639,9 @@ TEST_CASE("Metrics span lands exactly on a blob boundary", "[libtsapi][Metrics]"
 
 TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]")
 {
-  // The offset field of an id is 16 bits, but a real offset is always below MAX_SIZE. Ids reaching
-  // the id based accessors come from plugins via TSStat*, so a malformed offset must not index past
-  // the end of a blob's 1024 entry arrays. Force a second blob first: with only one blob every
-  // blob_ix != 0 is unallocated and would be caught by the null check alone.
+  // An id's offset field is 16 bits but a real offset is below MAX_SIZE, so a malformed one must
+  // not index past a blob's arrays. Two blobs are needed for the offset check to be what rejects
+  // it; with one, the null blob check would.
   auto &h = Metrics::hidden_instance();
 
   for (int i = 0; i < Metrics::MAX_SIZE + 8; ++i) {
@@ -668,19 +662,10 @@ TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]
 
 TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][Metrics]")
 {
-  // Storage has no lock on the id based read paths, so a reader resolving an id races a writer
-  // registering a new metric -- a plugin TSStatCreate or a config reload against live traffic.
-  // Safety rests on _cur_blob and _cur_off being atomic, release stored after whatever they
-  // publish, and acquire loaded with _cur_blob first. Driving both sides at once is what makes a
-  // regression visible: under the tsan preset, making either counter non-atomic again reports a
-  // data race here.
-  //
-  // What this does NOT catch is a downgrade of those stores and loads to relaxed. Atomics are
-  // race free at any ordering, so TSAN stays quiet and the assertions below still hold; only a
-  // weakly ordered machine would ever observe the difference, and not reliably. Treat the memory
-  // orders in Storage as reviewed rather than tested.
-  //
-  // Enough metrics to cross several blob boundaries, which is where the publication order matters.
+  // The id based read paths take no lock, so resolving an id races a concurrent create. Run both
+  // sides at once, across enough metrics to cross several blob boundaries. Under the tsan preset a
+  // non-atomic allocation counter reports a data race here; relaxing the memory orders does not,
+  // since atomics are race free at any ordering.
   constexpr int     N_READERS = 4;
   constexpr int     N_CREATE  = Metrics::MAX_SIZE * 2 + 64;
   auto             &h         = Metrics::hidden_instance();

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -24,6 +24,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <array>
 #include <iterator>
 #include <memory>
@@ -662,5 +663,73 @@ TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]
     REQUIRE(h.valid(id) == false);
     REQUIRE(h.lookup(id) == bad);
     REQUIRE(h.name(id) == h.name(Metrics::IdType{0}));
+  }
+}
+
+TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][Metrics]")
+{
+  // Storage has no lock on the id based read paths, so a reader resolving an id races a writer
+  // registering a new metric -- a plugin TSStatCreate or a config reload against live traffic.
+  // Safety rests on _cur_blob and _cur_off being atomic, release stored after whatever they
+  // publish, and acquire loaded with _cur_blob first. Driving both sides at once is what makes a
+  // regression visible: under the tsan preset, making either counter non-atomic again reports a
+  // data race here.
+  //
+  // What this does NOT catch is a downgrade of those stores and loads to relaxed. Atomics are
+  // race free at any ordering, so TSAN stays quiet and the assertions below still hold; only a
+  // weakly ordered machine would ever observe the difference, and not reliably. Treat the memory
+  // orders in Storage as reviewed rather than tested.
+  //
+  // Enough metrics to cross several blob boundaries, which is where the publication order matters.
+  constexpr int     N_READERS = 4;
+  constexpr int     N_CREATE  = Metrics::MAX_SIZE * 2 + 64;
+  auto             &h         = Metrics::hidden_instance();
+  std::atomic<bool> stop{false};
+  std::atomic<int>  mismatches{0};
+
+  std::vector<std::thread> readers;
+
+  for (int t = 0; t < N_READERS; ++t) {
+    readers.emplace_back([&]() {
+      while (!stop.load(std::memory_order_relaxed)) {
+        for (Metrics::IdType id = 0; id < N_CREATE; ++id) {
+          if (!h.valid(id)) {
+            continue;
+          }
+
+          // valid() said this id names an allocated slot, so lookup() must agree and hand back a
+          // real metric rather than clamping to the reserved bad_id slot. A publication ordering
+          // mistake shows up here as a name that is still empty.
+          std::string_view    name;
+          Metrics::MetricType type;
+          auto               *m = h.lookup(id, &name, &type);
+
+          if (m == nullptr || (id != 0 && name.empty())) {
+            mismatches.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+      }
+    });
+  }
+
+  for (int i = 0; i < N_CREATE; ++i) {
+    REQUIRE(Metrics::Counter::createHiddenPtr("pub.order." + std::to_string(i)) != nullptr);
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  for (auto &r : readers) {
+    r.join();
+  }
+
+  CHECK(mismatches.load() == 0);
+
+  // Everything the writer created must be resolvable by name and by id afterwards.
+  for (int i = 0; i < N_CREATE; ++i) {
+    auto const nm = "pub.order." + std::to_string(i);
+    auto const id = h.lookup(nm);
+
+    REQUIRE(id != Metrics::NOT_FOUND);
+    REQUIRE(h.valid(id));
+    REQUIRE(h.name(id) == nm);
   }
 }

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -593,8 +593,8 @@ TEST_CASE("Metrics blob growth boundary", "[libtsapi][Metrics]")
 TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]")
 {
   // An id's offset field is 16 bits but a real offset is below MAX_SIZE, so a malformed one must
-  // not index past a blob's arrays. Two blobs are needed for the offset check to be what rejects
-  // it; with one, the null blob check would.
+  // not index past a blob's arrays. Filling past one blob puts the ids below in earlier blobs,
+  // where they pack under the bound and only the MAX_SIZE test rejects them.
   auto &h = Metrics::hidden_instance();
 
   for (int i = 0; i < Metrics::MAX_SIZE + 8; ++i) {
@@ -604,8 +604,6 @@ TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]
   auto const *bad = h.lookup(Metrics::IdType{0}); // the reserved bad_id slot
   REQUIRE(bad != nullptr);
 
-  // blob 0 is allocated, so the null check does not fire; only the MAX_SIZE test stands between
-  // this and atomics[65535].
   for (Metrics::IdType id : {Metrics::IdType{0x0000FFFF}, Metrics::IdType{0x00000400}, Metrics::IdType{0x0001FFFF}}) {
     REQUIRE(h.valid(id) == false);
     REQUIRE(h.lookup(id) == bad);
@@ -639,9 +637,8 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
     c.store(Metrics::NOT_FOUND, std::memory_order_relaxed);
   }
 
-  // Precomputed so a reader can compare against the name it must see without allocating in the
-  // loop. Checking the name is the whole point: an id that lookup() clamps resolves to the reserved
-  // bad_id slot, whose name is not empty, so only the expected name distinguishes the two.
+  // A clamped lookup resolves to the bad_id slot, whose name is not empty, so only the expected
+  // name detects one.
   std::vector<std::string> names;
 
   names.reserve(N_CREATE);
@@ -663,8 +660,7 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
             continue;
           }
 
-          // valid() accepted the id, so lookup() must hand back that metric rather than clamping
-          // to the reserved bad_id slot.
+          // valid() accepted the id, so lookup() must return that metric and not clamp.
           std::string_view    name;
           Metrics::MetricType type;
           auto               *m = h.lookup(id, &name, &type);
@@ -673,15 +669,14 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
             mismatches.fetch_add(1, std::memory_order_relaxed);
           }
 
-          // Published as it happens rather than summed at the end, so the writer can wait for it.
+          // Published as it happens so the writer can wait for one.
           resolved.fetch_add(1, std::memory_order_relaxed);
         }
       }
     });
   }
 
-  // Every reader has to be in its loop before the writer starts, or the writer can finish and set
-  // stop before any of them does work, and the test passes without having raced anything.
+  // Readers must be in their loops before the writer starts, or nothing races.
   while (ready.load(std::memory_order_acquire) < N_READERS) {
     std::this_thread::yield();
   }
@@ -691,9 +686,8 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
     created[i].store(h.lookup(names[i]), std::memory_order_relaxed);
   }
 
-  // Readers being in their loops is not enough to guarantee they did any work: on a single CPU the
-  // writer can run to completion first, and every reader would then see stop and resolve nothing.
-  // Wait for one actual resolution so the check below cannot pass vacuously.
+  // Being in the loop is not doing work: on one CPU the writer can finish first and every reader
+  // would then see stop. Wait for a real resolution so the check below cannot pass vacuously.
   while (resolved.load(std::memory_order_relaxed) == 0) {
     std::this_thread::yield();
   }

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -640,3 +640,27 @@ TEST_CASE("Metrics span lands exactly on a blob boundary", "[libtsapi][Metrics]"
   REQUIRE(Metrics::Counter::load(p) == 7);
   REQUIRE(Metrics::Counter::createPtr("span.boundary.after") == p);
 }
+
+TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]")
+{
+  // The offset field of an id is 16 bits, but a real offset is always below MAX_SIZE. Ids reaching
+  // the id based accessors come from plugins via TSStat*, so a malformed offset must not index past
+  // the end of a blob's 1024 entry arrays. Force a second blob first: with only one blob every
+  // blob_ix != 0 is unallocated and would be caught by the null check alone.
+  auto &h = Metrics::hidden_instance();
+
+  for (int i = 0; i < Metrics::MAX_SIZE + 8; ++i) {
+    REQUIRE(Metrics::Counter::createHiddenPtr("f1.fill." + std::to_string(i)) != nullptr);
+  }
+
+  auto const *bad = h.lookup(Metrics::IdType{0}); // the reserved bad_id slot
+  REQUIRE(bad != nullptr);
+
+  // blob 0 is allocated, so the null check does not fire; only the MAX_SIZE test stands between
+  // this and atomics[65535].
+  for (Metrics::IdType id : {Metrics::IdType{0x0000FFFF}, Metrics::IdType{0x00000400}, Metrics::IdType{0x0001FFFF}}) {
+    REQUIRE(h.valid(id) == false);
+    REQUIRE(h.lookup(id) == bad);
+    REQUIRE(h.name(id) == h.name(Metrics::IdType{0}));
+  }
+}

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -629,6 +629,7 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
 
   auto             &h = Metrics::hidden_instance();
   std::atomic<bool> stop{false};
+  std::atomic<int>  ready{0};
   std::atomic<int>  mismatches{0};
   std::atomic<int>  resolved{0};
 
@@ -638,11 +639,21 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
     c.store(Metrics::NOT_FOUND, std::memory_order_relaxed);
   }
 
+  // Precomputed so a reader can compare against the name it must see without allocating in the
+  // loop. Checking the name is the whole point: an id that lookup() clamps resolves to the reserved
+  // bad_id slot, whose name is not empty, so only the expected name distinguishes the two.
+  std::vector<std::string> names;
+
+  names.reserve(N_CREATE);
+  for (int i = 0; i < N_CREATE; ++i) {
+    names.push_back("pub.order." + std::to_string(i));
+  }
+
   std::vector<std::thread> readers;
 
   for (int t = 0; t < N_READERS; ++t) {
     readers.emplace_back([&]() {
-      int n = 0;
+      ready.fetch_add(1, std::memory_order_release);
 
       while (!stop.load(std::memory_order_relaxed)) {
         for (int i = 0; i < N_CREATE; ++i) {
@@ -652,27 +663,39 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
             continue;
           }
 
-          // valid() accepted the id, so lookup() must hand back the metric with its name rather
-          // than clamping to the reserved bad_id slot.
+          // valid() accepted the id, so lookup() must hand back that metric rather than clamping
+          // to the reserved bad_id slot.
           std::string_view    name;
           Metrics::MetricType type;
           auto               *m = h.lookup(id, &name, &type);
 
-          if (m == nullptr || name.empty()) {
+          if (m == nullptr || name != names[i]) {
             mismatches.fetch_add(1, std::memory_order_relaxed);
           }
-          ++n;
+
+          // Published as it happens rather than summed at the end, so the writer can wait for it.
+          resolved.fetch_add(1, std::memory_order_relaxed);
         }
       }
-      resolved.fetch_add(n, std::memory_order_relaxed);
     });
   }
 
-  for (int i = 0; i < N_CREATE; ++i) {
-    auto const nm = "pub.order." + std::to_string(i);
+  // Every reader has to be in its loop before the writer starts, or the writer can finish and set
+  // stop before any of them does work, and the test passes without having raced anything.
+  while (ready.load(std::memory_order_acquire) < N_READERS) {
+    std::this_thread::yield();
+  }
 
-    REQUIRE(Metrics::Counter::createHiddenPtr(nm) != nullptr);
-    created[i].store(h.lookup(nm), std::memory_order_relaxed);
+  for (int i = 0; i < N_CREATE; ++i) {
+    REQUIRE(Metrics::Counter::createHiddenPtr(names[i]) != nullptr);
+    created[i].store(h.lookup(names[i]), std::memory_order_relaxed);
+  }
+
+  // Readers being in their loops is not enough to guarantee they did any work: on a single CPU the
+  // writer can run to completion first, and every reader would then see stop and resolve nothing.
+  // Wait for one actual resolution so the check below cannot pass vacuously.
+  while (resolved.load(std::memory_order_relaxed) == 0) {
+    std::this_thread::yield();
   }
 
   stop.store(true, std::memory_order_relaxed);
@@ -687,12 +710,11 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
   auto hi = std::numeric_limits<Metrics::IdType>::min();
 
   for (int i = 0; i < N_CREATE; ++i) {
-    auto const nm = "pub.order." + std::to_string(i);
-    auto const id = h.lookup(nm);
+    auto const id = h.lookup(names[i]);
 
     REQUIRE(id != Metrics::NOT_FOUND);
     REQUIRE(h.valid(id));
-    REQUIRE(h.name(id) == nm);
+    REQUIRE(h.name(id) == names[i]);
 
     lo = std::min(lo, id);
     hi = std::max(hi, id);

--- a/src/tsutil/unit_tests/test_Metrics.cc
+++ b/src/tsutil/unit_tests/test_Metrics.cc
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <array>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <string>
 #include <thread>
@@ -663,42 +664,63 @@ TEST_CASE("Metrics malformed id offsets resolve to bad_id", "[libtsapi][Metrics]
 TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][Metrics]")
 {
   // The id based read paths take no lock, so resolving an id races a concurrent create. Run both
-  // sides at once, across enough metrics to cross several blob boundaries. Under the tsan preset a
+  // sides at once, over enough metrics to cross several blob boundaries. Under the tsan preset a
   // non-atomic allocation counter reports a data race here; relaxing the memory orders does not,
   // since atomics are race free at any ordering.
-  constexpr int     N_READERS = 4;
-  constexpr int     N_CREATE  = Metrics::MAX_SIZE * 2 + 64;
-  auto             &h         = Metrics::hidden_instance();
+  //
+  // Readers take ids from what the writer has registered rather than counting integers: an id packs
+  // the blob index above the offset, so consecutive integers only ever name the first blob. The
+  // store is relaxed, so a reader can pick up an id whose slot is not published yet, which is the
+  // case of interest.
+  constexpr int N_READERS = 4;
+  constexpr int N_CREATE  = Metrics::MAX_SIZE * 2 + 64;
+
+  auto             &h = Metrics::hidden_instance();
   std::atomic<bool> stop{false};
   std::atomic<int>  mismatches{0};
+  std::atomic<int>  resolved{0};
+
+  std::vector<std::atomic<Metrics::IdType>> created(N_CREATE);
+
+  for (auto &c : created) {
+    c.store(Metrics::NOT_FOUND, std::memory_order_relaxed);
+  }
 
   std::vector<std::thread> readers;
 
   for (int t = 0; t < N_READERS; ++t) {
     readers.emplace_back([&]() {
+      int n = 0;
+
       while (!stop.load(std::memory_order_relaxed)) {
-        for (Metrics::IdType id = 0; id < N_CREATE; ++id) {
-          if (!h.valid(id)) {
+        for (int i = 0; i < N_CREATE; ++i) {
+          auto const id = created[i].load(std::memory_order_relaxed);
+
+          if (id == Metrics::NOT_FOUND || !h.valid(id)) {
             continue;
           }
 
-          // valid() said this id names an allocated slot, so lookup() must agree and hand back a
-          // real metric rather than clamping to the reserved bad_id slot. A publication ordering
-          // mistake shows up here as a name that is still empty.
+          // valid() accepted the id, so lookup() must hand back the metric with its name rather
+          // than clamping to the reserved bad_id slot.
           std::string_view    name;
           Metrics::MetricType type;
           auto               *m = h.lookup(id, &name, &type);
 
-          if (m == nullptr || (id != 0 && name.empty())) {
+          if (m == nullptr || name.empty()) {
             mismatches.fetch_add(1, std::memory_order_relaxed);
           }
+          ++n;
         }
       }
+      resolved.fetch_add(n, std::memory_order_relaxed);
     });
   }
 
   for (int i = 0; i < N_CREATE; ++i) {
-    REQUIRE(Metrics::Counter::createHiddenPtr("pub.order." + std::to_string(i)) != nullptr);
+    auto const nm = "pub.order." + std::to_string(i);
+
+    REQUIRE(Metrics::Counter::createHiddenPtr(nm) != nullptr);
+    created[i].store(h.lookup(nm), std::memory_order_relaxed);
   }
 
   stop.store(true, std::memory_order_relaxed);
@@ -707,8 +729,11 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
   }
 
   CHECK(mismatches.load() == 0);
+  CHECK(resolved.load() > 0);
 
-  // Everything the writer created must be resolvable by name and by id afterwards.
+  auto lo = std::numeric_limits<Metrics::IdType>::max();
+  auto hi = std::numeric_limits<Metrics::IdType>::min();
+
   for (int i = 0; i < N_CREATE; ++i) {
     auto const nm = "pub.order." + std::to_string(i);
     auto const id = h.lookup(nm);
@@ -716,5 +741,12 @@ TEST_CASE("Metrics id lookup is safe against concurrent creation", "[libtsapi][M
     REQUIRE(id != Metrics::NOT_FOUND);
     REQUIRE(h.valid(id));
     REQUIRE(h.name(id) == nm);
+
+    lo = std::min(lo, id);
+    hi = std::max(hi, id);
   }
+
+  // More metrics than fit in one blob, so the ids must span blobs. A spread no wider than a blob
+  // would mean the sweep above never left the first one.
+  REQUIRE(hi - lo > Metrics::MAX_SIZE);
 }

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -33,6 +33,9 @@ target_link_libraries(benchmark_ProxyAllocator PRIVATE Catch2::Catch2WithMain ts
 add_executable(benchmark_SharedMutex benchmark_SharedMutex.cc)
 target_link_libraries(benchmark_SharedMutex PRIVATE Catch2::Catch2 ts::tscore libswoc::libswoc)
 
+add_executable(benchmark_Metrics benchmark_Metrics.cc)
+target_link_libraries(benchmark_Metrics PRIVATE Catch2::Catch2 ts::tsutil libswoc::libswoc)
+
 add_executable(benchmark_Random benchmark_Random.cc)
 target_link_libraries(benchmark_Random PRIVATE Catch2::Catch2WithMain ts::tscore)
 

--- a/tools/benchmark/benchmark_Metrics.cc
+++ b/tools/benchmark/benchmark_Metrics.cc
@@ -2,18 +2,17 @@
 
   Micro benchmark tool for ts::Metrics
 
-  The metric values are lock free atomics, but reaching one from an id is not free, and the read
-  paths that get there have very different costs. Four cases, all scaled by thread count because
-  contention is the interesting axis:
+  Metric values are lock free atomics; reaching one from an id is not. Four cases, scaled by thread
+  count:
 
-    increment(id)     what TSStatIntIncrement does: valid() then lookup(id) then fetch_add
-    increment(ptr)    what core, cripts and a few plugins do: a bare fetch_add on a cached pointer
-    lookup(id)        the lock free id resolution on its own
-    lookup(name)      the same resolution by name, which still takes Storage's mutex
+    increment(id)     valid() then lookup(id) then fetch_add, as TSStatIntIncrement does
+    increment(ptr)    a bare fetch_add on a cached pointer, as core does
+    lookup(id)        lock free id resolution
+    lookup(name)      the same resolution through the mutex guarded name map
 
-  increment(id) against increment(ptr) is the cost a plugin pays for having only an id. lookup(id)
-  against lookup(name) isolates the mutex: the two do comparable work, so a gap that widens with
-  thread count is contention rather than instructions.
+  increment(id) against increment(ptr) is what an id costs a plugin. lookup(id) against
+  lookup(name) isolates the mutex, and serves as a control: it must degrade with thread count, or
+  the harness is not loading the machine.
 
   @section license License
 
@@ -60,7 +59,7 @@ struct Conf {
 
 Conf conf;
 
-/// The metrics every case operates on, created once so no case pays for creation.
+/// The metrics every case operates on, created once.
 struct Fixture {
   std::vector<Metrics::IdType>                ids;
   std::vector<Metrics::Counter::AtomicType *> ptrs;
@@ -77,8 +76,7 @@ struct Fixture {
     for (int i = 0; i < conf.nmetrics; ++i) {
       names.push_back("benchmark.metrics." + std::to_string(i));
 
-      // createPtr is what core and cripts do: create once at init and keep the pointer. It also
-      // registers the name, so the id and name lookups below resolve to the same metric.
+      // Registers the name too, so the id and name lookups resolve to the same metric.
       ptrs.push_back(Metrics::Counter::createPtr(names.back()));
       ids.push_back(m.lookup(names.back()));
     }
@@ -87,10 +85,7 @@ struct Fixture {
 
 Fixture *fixture = nullptr;
 
-/** Run @a op on every thread, @c nops times each, and return a value derived from the results.
- *
- * The return value exists so nothing can be optimized away; it is not meaningful.
- */
+/// Run @a op on every thread, @c nops times each. The return value only defeats optimization.
 template <typename F>
 int64_t
 run(F &&op)
@@ -105,8 +100,7 @@ run(F &&op)
       int64_t local = 0;
 
       for (int i = 0; i < conf.nops; ++i) {
-        // Stride the starting point per thread so they are not all hammering one metric, which
-        // would measure cacheline ping-pong on that one atomic rather than the lookup path.
+        // Stride per thread, or this measures cacheline ping-pong on one atomic.
         local += op((t + i) % conf.nmetrics);
       }
       sink.fetch_add(local, std::memory_order_relaxed);
@@ -128,7 +122,6 @@ TEST_CASE("Micro benchmark of ts::Metrics", "")
 
   SECTION("increment by id")
   {
-    // The TSStatIntIncrement path: validation, then id resolution, then the add.
     BENCHMARK("increment(id)")
     {
       return run([&m](int i) -> int64_t {
@@ -141,7 +134,7 @@ TEST_CASE("Micro benchmark of ts::Metrics", "")
 
   SECTION("increment by cached pointer")
   {
-    // What core does. This is the floor: no resolution at all.
+    // The floor: no resolution at all.
     BENCHMARK("increment(ptr)")
     {
       return run([](int i) -> int64_t {
@@ -154,7 +147,6 @@ TEST_CASE("Micro benchmark of ts::Metrics", "")
 
   SECTION("lookup by id")
   {
-    // Lock free resolution.
     BENCHMARK("lookup(id)")
     {
       return run([&m](int i) -> int64_t { return m.lookup(fixture->ids[i]) != nullptr; });
@@ -163,7 +155,6 @@ TEST_CASE("Micro benchmark of ts::Metrics", "")
 
   SECTION("lookup by name")
   {
-    // The same resolution, but through the mutex guarded name map.
     BENCHMARK("lookup(name)")
     {
       return run([&m](int i) -> int64_t { return m.lookup(fixture->names[i]) != Metrics::NOT_FOUND; });

--- a/tools/benchmark/benchmark_Metrics.cc
+++ b/tools/benchmark/benchmark_Metrics.cc
@@ -1,0 +1,199 @@
+/** @file
+
+  Micro benchmark tool for ts::Metrics
+
+  The metric values are lock free atomics, but reaching one from an id is not free, and the read
+  paths that get there have very different costs. Four cases, all scaled by thread count because
+  contention is the interesting axis:
+
+    increment(id)     what TSStatIntIncrement does: valid() then lookup(id) then fetch_add
+    increment(ptr)    what core, cripts and a few plugins do: a bare fetch_add on a cached pointer
+    lookup(id)        the lock free id resolution on its own
+    lookup(name)      the same resolution by name, which still takes Storage's mutex
+
+  increment(id) against increment(ptr) is the cost a plugin pays for having only an id. lookup(id)
+  against lookup(name) isolates the mutex: the two do comparable work, so a gap that widens with
+  thread count is contention rather than instructions.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_session.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include "tsutil/Metrics.h"
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+using ts::Metrics;
+
+namespace
+{
+// Args
+struct Conf {
+  int nthreads = 1;
+  int nops     = 1000;
+  int nmetrics = 64;
+};
+
+Conf conf;
+
+/// The metrics every case operates on, created once so no case pays for creation.
+struct Fixture {
+  std::vector<Metrics::IdType>                ids;
+  std::vector<Metrics::Counter::AtomicType *> ptrs;
+  std::vector<std::string>                    names;
+
+  Fixture()
+  {
+    auto &m = Metrics::instance();
+
+    ids.reserve(conf.nmetrics);
+    ptrs.reserve(conf.nmetrics);
+    names.reserve(conf.nmetrics);
+
+    for (int i = 0; i < conf.nmetrics; ++i) {
+      names.push_back("benchmark.metrics." + std::to_string(i));
+
+      // createPtr is what core and cripts do: create once at init and keep the pointer. It also
+      // registers the name, so the id and name lookups below resolve to the same metric.
+      ptrs.push_back(Metrics::Counter::createPtr(names.back()));
+      ids.push_back(m.lookup(names.back()));
+    }
+  }
+};
+
+Fixture *fixture = nullptr;
+
+/** Run @a op on every thread, @c nops times each, and return a value derived from the results.
+ *
+ * The return value exists so nothing can be optimized away; it is not meaningful.
+ */
+template <typename F>
+int64_t
+run(F &&op)
+{
+  std::vector<std::thread> threads;
+  std::atomic<int64_t>     sink{0};
+
+  threads.reserve(conf.nthreads);
+
+  for (int t = 0; t < conf.nthreads; ++t) {
+    threads.emplace_back([t, &sink, &op]() {
+      int64_t local = 0;
+
+      for (int i = 0; i < conf.nops; ++i) {
+        // Stride the starting point per thread so they are not all hammering one metric, which
+        // would measure cacheline ping-pong on that one atomic rather than the lookup path.
+        local += op((t + i) % conf.nmetrics);
+      }
+      sink.fetch_add(local, std::memory_order_relaxed);
+    });
+  }
+
+  for (auto &th : threads) {
+    th.join();
+  }
+
+  return sink.load();
+}
+
+} // namespace
+
+TEST_CASE("Micro benchmark of ts::Metrics", "")
+{
+  auto &m = Metrics::instance();
+
+  SECTION("increment by id")
+  {
+    // The TSStatIntIncrement path: validation, then id resolution, then the add.
+    BENCHMARK("increment(id)")
+    {
+      return run([&m](int i) -> int64_t {
+        auto id = fixture->ids[i];
+
+        return m.valid(id) ? m.increment(id, 1) : 0;
+      });
+    };
+  }
+
+  SECTION("increment by cached pointer")
+  {
+    // What core does. This is the floor: no resolution at all.
+    BENCHMARK("increment(ptr)")
+    {
+      return run([](int i) -> int64_t {
+        Metrics::Counter::increment(fixture->ptrs[i], 1);
+
+        return 1;
+      });
+    };
+  }
+
+  SECTION("lookup by id")
+  {
+    // Lock free resolution.
+    BENCHMARK("lookup(id)")
+    {
+      return run([&m](int i) -> int64_t { return m.lookup(fixture->ids[i]) != nullptr; });
+    };
+  }
+
+  SECTION("lookup by name")
+  {
+    // The same resolution, but through the mutex guarded name map.
+    BENCHMARK("lookup(name)")
+    {
+      return run([&m](int i) -> int64_t { return m.lookup(fixture->names[i]) != Metrics::NOT_FOUND; });
+    };
+  }
+}
+
+int
+main(int argc, char *argv[])
+{
+  Catch::Session session;
+
+  using namespace Catch::Clara;
+
+  // clang-format off
+  auto cli = session.cli() |
+    Opt(conf.nthreads, "")["--ts-nthreads"]("number of threads (default: 1)") |
+    Opt(conf.nops, "")["--ts-nops"]("operations per thread per run (default: 1000)") |
+    Opt(conf.nmetrics, "")["--ts-nmetrics"]("distinct metrics to spread across (default: 64)");
+  // clang-format on
+
+  session.cli(cli);
+
+  int returnCode = session.applyCommandLine(argc, argv);
+  if (returnCode != 0) {
+    return returnCode;
+  }
+
+  Fixture f;
+  fixture = &f;
+
+  return session.run();
+}


### PR DESCRIPTION
Follow-ups to #13567, which reverted the locking that #13310 had added to the `ts::Metrics::Storage`
read paths. That revert restored the performance but left the data race #13310 was closing, plus
some pre-existing bounds problems in the same functions. This closes the race without a lock, and
fixes the bounds.

### One gate for id validation

`valid()`, `lookup(IdType)`, `name()` and `rename()` each carried their own copy of the same range
test, and the copies disagreed. `valid()` rejected an offset past `MAX_SIZE`; the other three did
not. `_splitID` passes the low 16 bits of an id through unmasked and the offset check only applied
when the id named the current blob, so an id such as `0x0000FFFF` indexed well past the end of a
blob's 1024 entry arrays once a second blob existed. Ids reaching these accessors come from plugins
through the `TSStat*` API, so they are untrusted.

All four now go through `Storage::_is_allocated()`. It also fixes an off-by-one: `create()` returns
the id and then advances, so the next free slot was being accepted as allocated. An increment there
landed on the slot `create()` would hand out next, and since `create()` writes only the name and
never the value, the next plugin to call `TSStatCreate()` received a metric already carrying someone
else's count.

Nothing depended on the loose bound: `end()` builds an id at the allocation point that is compared
but never dereferenced, `iterator::next()` keeps the offset in range, and `find()` returns `end()`
on a miss.

### One published position

`_cur_blob` and `_cur_off` are gone, replaced by a single atomic holding the blob index above the
offset, packed as `_makeId` packs one.

Two atomics cannot be read as a coherent pair. `addBlob()` reset the offset before advancing the
blob, so a reader between the two stores saw the old blob index with a zero offset and rejected
every id in the just-completed blob. That is not a dropped increment: with the default
`ENABLE_FAST_SDK=OFF`, `TSStatInt*` feeds the result to `sdk_assert` and aborts through
`_TSReleaseAssert`. Ordering the two stores the other way only trades it for accepting ids in a blob
nothing has been written to yet.

One value removes the window rather than relocating it: crossing a blob is a single release store,
sequenced after the blob pointer it publishes. The position only ever increases, since `(N+1)<<16`
exceeds `N<<16 + offset` for any `offset < MAX_SIZE`, so an id is allocated exactly when it packs
below the bound and `_is_allocated()` is one acquire load and one compare. Acquiring the bound
acquires the blob install, so `_blobs` needs no check of its own. The offset test stays: `_splitID`
takes the low 16 bits, so an id in an earlier blob can name an offset past `MAX_SIZE` and still pack
under the bound. The packed value is also the id of the next free slot, which is exactly what
`end()` wants, so iteration's bound stops being reconstructed from two fields.

Thanks to @moonchen for finding the rollover window and the `rename()` race in review.

### `createSpan` and `rename` removed

It was the only path that could leave a blob partly filled: when a span did not fit it skipped to a
fresh blob, abandoning tail slots that were never handed out but that pack below the bound. With it
gone, blobs fill contiguously and "packs below the bound" means exactly "was handed out", with no
special case. It also has no callers outside the tests.

Two test consumers adapted: a span/rename section became rename-only, and `test_RecRegister.cc` was
using `createSpan(1)` as a cheap anonymous registration while hammering lookups, which `create()`
does as well. The test case covering `createSpan`'s blob boundary goes with it.

`rename()` goes for a different reason: it mutated a slot's name while `name()` and
`lookup(id, &out_name)` read that same `std::string` without the mutex and hand out `string_view`s
into it. Locking `rename()` does not close that — the readers are the lock free paths this PR exists
to keep — and giving names immutable storage with its own lifetime rules is a lot of machinery for a
function nothing outside the tests calls. Removing it leaves the useful invariant: a name is written
once, before the store that publishes it, and never changes, so the unlocked readers are correct by
construction and the `string_view` keys in `_lookups` are stable for the life of the process.

Both are removals from an installed header, so they belong in the 11.0.0 release notes. Neither has
a caller in tree, and `createSpan` handed out unnamed slots that only `rename()` could have named.

### `_extractType` on a negative id

It shifted a signed `IdType`, so `_extractType(NOT_FOUND)` sign extended to `-4` — a `MetricType`
outside its enumeration, returned by `Metrics::type()`. Shifting unsigned is not sufficient on its
own: the sign bit sits above the type field, so `NOT_FOUND` still yields `4`. Masking to the single
bit `_makeId` writes makes the function total for any input.

Two smaller ones: `rename()` computed a reference into the name storage before taking the mutex,
which read nothing but made the critical section look wider than it is, and `Metrics.h` had been
relying on `swoc/MemSpan.h` for `<limits>`.

### Testing

A new test resolves ids from several threads while another registers metrics across a few blob
boundaries. Under the `tsan` preset, making either allocation counter non-atomic again reports a data
race there. It does **not** catch a downgrade of the release/acquire pairs to relaxed — atomics are
race free at any ordering, so TSAN stays quiet and the assertions still hold. The memory orders are
reviewed, not tested, and the test says so.

Two ways that test could pass without testing anything, both found in review and both fixed. Readers
only published their tally on exit and nothing made them run before the writer finished, so on one
CPU every reader could see `stop` and resolve nothing while `resolved > 0` still held; each
resolution is now published as it happens and the writer waits for one before stopping. And an id
that `lookup()` clamps resolves to the `bad_id` slot, whose name is not empty, so the name check
could not detect a clamp; it now compares against the name that id must have.

`tools/benchmark/benchmark_Metrics.cc` is new; nothing in tree measured these paths, which is how a
global mutex on the hottest one went unnoticed. Four cases scaled by thread count, on a 10 core
machine at 20k ops/thread:

| threads | `increment(ptr)` | `increment(id)` | `lookup(id)` | `lookup(name)` |
|---|---|---|---|---|
| 1 | 0.12 ms | 1.81 ms | 1.05 ms | 2.34 ms |
| 4 | 0.24 ms | 2.20 ms | 1.15 ms | 37.6 ms |
| 16 | 4.71 ms | 7.04 ms | 2.09 ms | 80.4 ms |
| 64 | 19.6 ms | 24.0 ms | 6.13 ms | 317 ms |

`lookup(name)` is a deliberate control: it still takes the mutex, so it must degrade with thread
count. It goes 2.3 ms to 317 ms while `lookup(id)` goes 1.05 to 6.13 ms, which is the evidence that
the harness loads the machine rather than the lock free numbers being flat for want of load. Above
10 threads the machine is oversubscribed, so treat the shape as meaningful and the magnitudes as
not.

Comparing a build with and without the atomics commit put every case within noise, the only
consistent signal being 4-8% on `lookup(id)` — two `ldaprh` rather than two `ldrh` on ARM64, and
plain loads on x86. Set against what the mutex costs, it is not a trade worth considering.

Those numbers predate the packed position, so the packing was measured separately, as an A/B of
`bc333f401e` (two atomics, two acquire loads and a null blob test in `_is_allocated`) against the tip
of this branch. Same binary, same machine, `RelWithDebInfo`, 20k ops/thread, seven runs per point,
mean +- sd. This is a 16 logical core machine, so these absolute numbers are not comparable with the
table above.

| threads | case | two atomics | packed | delta |
|---|---|---|---|---|
| 1 | `increment(ptr)` | 33.6 +- 2.1 us | 32.7 +- 0.5 us | -2.9% |
| 1 | `increment(id)` | 63.0 +- 2.3 us | 50.2 +- 3.3 us | **-20.2%** |
| 1 | `lookup(id)` | 47.1 +- 3.7 us | 43.3 +- 3.5 us | **-8.0%** |
| 1 | `lookup(name)` | 318.0 +- 18.0 us | 305.3 +- 6.8 us | -4.0% |
| 4 | `increment(ptr)` | 177.6 +- 9.5 us | 175.9 +- 5.3 us | -1.0% |
| 4 | `increment(id)` | 176.2 +- 9.0 us | 154.4 +- 1.7 us | **-12.4%** |
| 4 | `lookup(id)` | 81.3 +- 18.8 us | 74.4 +- 1.7 us | **-8.5%** |
| 4 | `lookup(name)` | 4396.7 +- 96.0 us | 4457.0 +- 51.2 us | +1.4% |

`increment(ptr)` and `lookup(name)` are the controls: neither calls `_is_allocated`, and both stay
within 4%, which sets the noise floor. The two id paths move well outside it, and by a ratio that
falls out of the code: the benchmark's `increment(id)` case is `valid(id) ? increment(id, 1) : 0`,
which enters `_is_allocated` twice, and its delta is about twice `lookup(id)`'s. So the saving is
localized to the check, which is what removing one acquire load and one null test should do.

At 16 and 64 threads every case lands within noise, controls included — contention on the metric
atomics dominates, with `increment(ptr)` going from 33 us to 19 ms. The packing is a win where the
check is measurable and free where it is not.

### Provenance

The bounds and memory-order findings came out of a review of this code prompted by a production
`perf` profile, in which the `#13310` locking accounted for roughly half of all CPU in futex
contention. I do not have a public link for that review to cite. The parts of it this PR does not
implement — deleting the `sdk_assert` from the `TSStat*` entry points, and an opaque handle API for
plugins — were either out of proportion to the measured benefit or need an upstream decision first.
Removing `rename()` was on that list too, and review showed it was not optional.

Per-blob published counts were the other candidate for the rollover window, and would additionally
have excluded `createSpan`'s abandoned tail slots. Deleting `createSpan` achieves that instead, and
leaves the check at one load rather than two dependent ones.

`addBlob`'s bound assert was part of the same review and landed earlier in #13505.
