### PR TITLE
HRW: Adds a NORM normalization modifier for strings

### DIFF
--- a/doc/admin-guide/configuration/hrw4u.en.rst
+++ b/doc/admin-guide/configuration/hrw4u.en.rst
@@ -639,6 +639,7 @@ MID           Match substring
 SUF           Match the end of a string
 PRE           Match the beginning of a string
 NOCASE        Case insensitive match
+NORM          Normalize the value first, currently percent-decoding
 ============= ===============================================
 
 These can be used with both sets and equality checks, using the ``with`` keyword:
@@ -652,6 +653,18 @@ These can be used with both sets and equality checks, using the ``with`` keyword
    if inbound.url.path in ["mp3", "mp4"] with EXT,NOCASE {
      ...
    }
+
+``NORM`` acts on the value rather than on the comparison, so it also applies to
+regular expression matches, and it is the one modifier allowed on an interpolated
+value:
+
+.. code-block:: none
+
+   if inbound.url.path ~ /private-/ with NORM {
+     ...
+   }
+
+   inbound.req.X-Decoded-Path = "{inbound.url.path with NORM}";
 
 Running and Debugging
 =====================

--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -1030,12 +1030,38 @@ the brackets:
    MID    Make a substring match on a string comparison.
    EXT    The substring match only applies to the file extension following a dot.
           This is generally mostly useful for the ``URL:PATH`` part.
+   NORM   Normalize the value before using it, which today means percent-decoding
+          it. Only the value read from the transaction is decoded, not the operand
+          in the rule, and the request itself is left unchanged.
    ====== ========================================================================
 
 .. note::
     At most, one of ``[PRE]``, ``[SUF]``, ``[MID]``, or ``[EXT]`` may be
     used at any time. They can however be used together with ``[NOCASE]`` and the
     other flags.
+
+Use ``[NORM]`` where a client could otherwise evade a match by escaping the
+pattern, since ``pr%69vate`` is not ``private``. It composes with every
+match type, regular expressions included::
+
+    cond %{CLIENT-URL:PATH} /private-/ [NORM]
+
+It is also the one flag that applies to a ``%{...}`` expansion in an operator
+value, written inside the braces so that it affects only that expansion::
+
+    set-header X-Decoded-Path %{CLIENT-URL:PATH [NORM]}
+
+Decoding happens exactly once, as :rfc:`3986` section 2.4 requires: decoding an
+already decoded string would misread a literal ``%`` in the data as the start of
+an escape. So ``pr%2569vate`` yields ``pr%69vate``, not ``private``, and a value
+that arrives multiply encoded stays partly encoded.
+
+``[NORM]`` therefore does not promise a value free of ``%``. A single decode of
+``50%25-off`` is ``50%-off``, where the ``%`` is data. If a rule needs to care
+about what is left, test for it, which also catches the multiply encoded case::
+
+    cond %{CLIENT-URL:PATH} /%/ [NORM]
+      set-status 400
 
 Operators
 ---------

--- a/plugins/header_rewrite/condition.cc
+++ b/plugins/header_rewrite/condition.cc
@@ -88,12 +88,15 @@ Condition::normalize(std::string &s, size_t start)
   size_t len     = s.size() - pos;
   size_t written = 0;
 
-  // Decoding only shrinks, so it's safe in place; the +1 is room for the NUL it appends.
-  if (TSStringPercentDecode(s.data() + pos, len, s.data() + pos, len + 1, &written) == TS_SUCCESS) {
-    s.resize(pos + written);
-  } else {
+  // Decoding shrinks, so in place is safe; the extra byte is for the NUL it appends.
+  s.push_back('\0');
+
+  if (TSStringPercentDecode(s.data() + pos, len, s.data() + pos, len + 1, &written) != TS_SUCCESS) {
+    written = len;
     Dbg(pi_dbg_ctl, "Failed to percent-decode, leaving the value untouched");
   }
+
+  s.resize(pos + written);
 }
 
 void

--- a/plugins/header_rewrite/condition.cc
+++ b/plugins/header_rewrite/condition.cc
@@ -76,6 +76,27 @@ parse_matcher_op(std::string &arg)
 }
 
 void
+Condition::normalize(std::string &s, size_t start)
+{
+  auto pos = s.find('%', start);
+
+  // Percent-decoding is the only normalization so far.
+  if (pos == std::string::npos) {
+    return;
+  }
+
+  size_t len     = s.size() - pos;
+  size_t written = 0;
+
+  // Decoding only shrinks, so it's safe in place; the +1 is room for the NUL it appends.
+  if (TSStringPercentDecode(s.data() + pos, len, s.data() + pos, len + 1, &written) == TS_SUCCESS) {
+    s.resize(pos + written);
+  } else {
+    Dbg(pi_dbg_ctl, "Failed to percent-decode, leaving the value untouched");
+  }
+}
+
+void
 Condition::initialize(Parser &p)
 {
   Statement::initialize(p);
@@ -123,6 +144,10 @@ Condition::initialize(Parser &p)
 
   if (_substr_seen > 1) {
     throw std::runtime_error("Only one substring modifier (EXT, SUF, PRE, MID) may be used.");
+  }
+
+  if (p.consume_mod("NORM")) {
+    _mods |= CondModifiers::MOD_NORM;
   }
 
   if (p.consume_mod("L")) {

--- a/plugins/header_rewrite/condition.h
+++ b/plugins/header_rewrite/condition.h
@@ -123,8 +123,22 @@ public:
   }
 
   // Virtual methods, has to be implemented by each conditional;
-  void         initialize(Parser &p) override;
-  virtual void append_value(std::string &s, const Resources &res) = 0;
+  void initialize(Parser &p) override;
+
+  // Applies any value modifiers (currently only NORM) to what do_append_value() contributed,
+  // so conditions and %{} expansions in values behave alike.
+  void
+  append_value(std::string &s, const Resources &res)
+  {
+    if (!has_modifier(_mods, CondModifiers::MOD_NORM)) {
+      return do_append_value(s, res);
+    }
+
+    size_t start = s.size();
+
+    do_append_value(s, res);
+    normalize(s, start);
+  }
 
 protected:
   // Evaluate the condition
@@ -136,5 +150,10 @@ protected:
   std::unique_ptr<Matcher> _matcher       = nullptr;
 
 private:
+  // Keeps append_value() the only way in, so no caller can skip the modifiers.
+  virtual void do_append_value(std::string &s, const Resources &res) = 0;
+
+  static void normalize(std::string &s, size_t start);
+
   CondModifiers _mods = CondModifiers::NONE;
 };

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -117,7 +117,7 @@ ConditionStatus::eval(const Resources &res)
 }
 
 void
-ConditionStatus::append_value(std::string &s, const Resources &res)
+ConditionStatus::do_append_value(std::string &s, const Resources &res)
 {
   s += std::to_string(res.resp_status);
   Dbg(pi_dbg_ctl, "Appending STATUS(%d) to evaluation value -> %s", res.resp_status, s.c_str());
@@ -148,7 +148,7 @@ ConditionMethod::eval(const Resources &res)
 }
 
 void
-ConditionMethod::append_value(std::string &s, const Resources &res)
+ConditionMethod::do_append_value(std::string &s, const Resources &res)
 {
   TSMBuffer bufp;
   TSMLoc    hdr_loc;
@@ -188,7 +188,7 @@ ConditionRandom::eval(const Resources &res)
 }
 
 void
-ConditionRandom::append_value(std::string &s, const Resources & /* res ATS_UNUSED */)
+ConditionRandom::do_append_value(std::string &s, const Resources & /* res ATS_UNUSED */)
 {
   s += std::to_string(rand_r(&_seed) % _max);
   Dbg(pi_dbg_ctl, "Appending RANDOM(%d) to evaluation value -> %s", _max, s.c_str());
@@ -208,7 +208,7 @@ ConditionAccess::initialize(Parser &p)
 }
 
 void
-ConditionAccess::append_value(std::string &s, const Resources &res)
+ConditionAccess::do_append_value(std::string &s, const Resources &res)
 {
   if (eval(res)) {
     s += "OK";
@@ -255,7 +255,7 @@ ConditionHeader::initialize(Parser &p)
 }
 
 void
-ConditionHeader::append_value(std::string &s, const Resources &res)
+ConditionHeader::do_append_value(std::string &s, const Resources &res)
 {
   TSMBuffer bufp;
   TSMLoc    hdr_loc;
@@ -368,7 +368,7 @@ ConditionUrl::log_error(const Resources &res, const char *message) const
 }
 
 void
-ConditionUrl::append_value(std::string &s, const Resources &res)
+ConditionUrl::do_append_value(std::string &s, const Resources &res)
 {
   TSMLoc    url  = nullptr;
   TSMBuffer bufp = nullptr;
@@ -511,7 +511,7 @@ ConditionDBM::initialize(Parser &p)
 }
 
 void
-ConditionDBM::append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */)
+ConditionDBM::do_append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */)
 {
   // std::string key;
 
@@ -563,7 +563,7 @@ ConditionCookie::initialize(Parser &p)
 }
 
 void
-ConditionCookie::append_value(std::string &s, const Resources &res)
+ConditionCookie::do_append_value(std::string &s, const Resources &res)
 {
   TSMBuffer         bufp    = res.client_bufp;
   TSMLoc            hdr_loc = res.client_hdr_loc;
@@ -705,7 +705,7 @@ ConditionIp::eval(const Resources &res)
 }
 
 void
-ConditionIp::append_value(std::string &s, const Resources &res)
+ConditionIp::do_append_value(std::string &s, const Resources &res)
 {
   bool ip_set = false;
   char ip[INET6_ADDRSTRLEN];
@@ -757,7 +757,7 @@ ConditionTransactCount::eval(const Resources &res)
 }
 
 void
-ConditionTransactCount::append_value(std::string &s, Resources const &res)
+ConditionTransactCount::do_append_value(std::string &s, Resources const &res)
 {
   if (res.state.ssnp) {
     char value[32]; // enough for UINT64_MAX
@@ -864,7 +864,7 @@ ConditionNow::set_qualifier(const std::string &q)
 }
 
 void
-ConditionNow::append_value(std::string &s, const Resources &res)
+ConditionNow::do_append_value(std::string &s, const Resources &res)
 {
   s += std::to_string(get_now_qualified(_now_qual, res));
   Dbg(pi_dbg_ctl, "Appending NOW() to evaluation value -> %s", s.c_str());
@@ -937,7 +937,7 @@ ConditionGeo::set_qualifier(const std::string &q)
 }
 
 void
-ConditionGeo::append_value(std::string &s, const Resources &res)
+ConditionGeo::do_append_value(std::string &s, const Resources &res)
 {
   if (is_int_type()) {
     s += std::to_string(get_geo_int(getClientAddr(res.state.txnp, _txn_private_slot), res.geo_handle));
@@ -1009,7 +1009,7 @@ ConditionId::set_qualifier(const std::string &q)
 }
 
 void
-ConditionId::append_value(std::string &s, const Resources &res ATS_UNUSED)
+ConditionId::do_append_value(std::string &s, const Resources &res ATS_UNUSED)
 {
   switch (_id_qual) {
   case ID_QUAL_REQUEST: {
@@ -1108,7 +1108,7 @@ ConditionCidr::eval(const Resources &res)
 }
 
 void
-ConditionCidr::append_value(std::string &s, const Resources &res)
+ConditionCidr::do_append_value(std::string &s, const Resources &res)
 {
   struct sockaddr const *addr = getClientAddr(res.state.txnp, _txn_private_slot);
 
@@ -1309,13 +1309,13 @@ ConditionInbound::eval(const Resources &res)
 }
 
 void
-ConditionInbound::append_value(std::string &s, const Resources &res)
+ConditionInbound::do_append_value(std::string &s, const Resources &res)
 {
-  this->append_value(s, res, _net_qual);
+  do_append_value(s, res, _net_qual);
 }
 
 void
-ConditionInbound::append_value(std::string &s, const Resources &res, NetworkSessionQualifiers qual)
+ConditionInbound::do_append_value(std::string &s, const Resources &res, NetworkSessionQualifiers qual)
 {
   const char *zret = nullptr;
   char        text[INET6_ADDRSTRLEN];
@@ -1436,7 +1436,7 @@ ConditionStringLiteral::ConditionStringLiteral(const std::string &v)
 }
 
 void
-ConditionStringLiteral::append_value(std::string &s, const Resources & /* res ATS_UNUSED */)
+ConditionStringLiteral::do_append_value(std::string &s, const Resources & /* res ATS_UNUSED */)
 {
   s += _literal;
   Dbg(pi_dbg_ctl, "Appending '%s' to evaluation value", _literal.c_str());
@@ -1471,7 +1471,7 @@ ConditionSessionTransactCount::eval(const Resources &res)
 }
 
 void
-ConditionSessionTransactCount::append_value(std::string &s, Resources const &res)
+ConditionSessionTransactCount::do_append_value(std::string &s, Resources const &res)
 {
   char      value[32]; // enough for UINT64_MAX
   int const count  = TSHttpTxnServerSsnTransactionCount(res.state.txnp);
@@ -1516,7 +1516,7 @@ ConditionTcpInfo::eval(const Resources &res)
 }
 
 void
-ConditionTcpInfo::append_value(std::string &s, [[maybe_unused]] Resources const &res)
+ConditionTcpInfo::do_append_value(std::string &s, [[maybe_unused]] Resources const &res)
 {
 #if defined(TCP_INFO) && defined(HAVE_STRUCT_TCP_INFO)
   if (TSHttpTxnIsInternal(res.state.txnp)) {
@@ -1577,7 +1577,7 @@ ConditionCache::eval(const Resources &res)
 }
 
 void
-ConditionCache::append_value(std::string &s, const Resources &res)
+ConditionCache::do_append_value(std::string &s, const Resources &res)
 {
   TSHttpTxn txn = res.state.txnp;
   int       status;
@@ -1622,7 +1622,7 @@ ConditionNextHop::set_qualifier(const std::string &q)
 }
 
 void
-ConditionNextHop::append_value(std::string &s, const Resources &res)
+ConditionNextHop::do_append_value(std::string &s, const Resources &res)
 {
   switch (_next_hop_qual) {
   case NEXT_HOP_HOST: {
@@ -1675,7 +1675,7 @@ ConditionHttpCntl::set_qualifier(const std::string &q)
 }
 
 void
-ConditionHttpCntl::append_value(std::string &s, const Resources &res)
+ConditionHttpCntl::do_append_value(std::string &s, const Resources &res)
 {
   s += TSHttpTxnCntlGet(res.state.txnp, _http_cntl_qual) ? "TRUE" : "FALSE";
   Dbg(pi_dbg_ctl, "Evaluating HTTP-CNTL(%s)", _qualifier.c_str());
@@ -1704,7 +1704,7 @@ ConditionStateFlag::set_qualifier(const std::string &q)
 }
 
 void
-ConditionStateFlag::append_value(std::string &s, const Resources &res)
+ConditionStateFlag::do_append_value(std::string &s, const Resources &res)
 {
   s += eval(res) ? "TRUE" : "FALSE";
   Dbg(pi_dbg_ctl, "Evaluating %s-FLAG(%d)", _scope_label(_scope), _flag_ix);
@@ -1745,7 +1745,7 @@ ConditionStateInt8::set_qualifier(const std::string &q)
 }
 
 void
-ConditionStateInt8::append_value(std::string &s, const Resources &res)
+ConditionStateInt8::do_append_value(std::string &s, const Resources &res)
 {
   uint8_t data = _get_data(res);
 
@@ -1792,7 +1792,7 @@ ConditionStateInt16::set_qualifier(const std::string &q)
 }
 
 void
-ConditionStateInt16::append_value(std::string &s, const Resources &res)
+ConditionStateInt16::do_append_value(std::string &s, const Resources &res)
 {
   uint16_t data = _get_data(res);
 
@@ -1830,7 +1830,7 @@ ConditionLastCapture::set_qualifier(const std::string &q)
 }
 
 void
-ConditionLastCapture::append_value(std::string &s, const Resources &res)
+ConditionLastCapture::do_append_value(std::string &s, const Resources &res)
 {
   if (res.matches().size() > _ix) {
     s.append(res.matches()[_ix]);

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -48,7 +48,7 @@ public:
   void operator=(const ConditionTrue &) = delete;
 
   void
-  append_value(std::string &s, const Resources & /* res ATS_UNUSED */) override
+  do_append_value(std::string &s, const Resources & /* res ATS_UNUSED */) override
   {
     s += "TRUE";
   }
@@ -73,7 +73,7 @@ public:
   void operator=(const ConditionFalse &) = delete;
 
   void
-  append_value(std::string &s, const Resources & /* res ATS_UNUSED */) override
+  do_append_value(std::string &s, const Resources & /* res ATS_UNUSED */) override
   {
     s += "FALSE";
   }
@@ -102,7 +102,7 @@ public:
   void operator=(const SelfType &)  = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -124,7 +124,7 @@ public:
   void operator=(const SelfType &)  = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -145,7 +145,7 @@ public:
   void operator=(const SelfType &)  = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -166,7 +166,7 @@ public:
   void operator=(const ConditionAccess &)  = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -191,7 +191,7 @@ public:
   void operator=(const SelfType &)  = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -267,7 +267,7 @@ public:
   void operator=(const SelfType &)  = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -294,7 +294,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -336,7 +336,7 @@ public:
   void operator=(const SelfType &) = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -356,7 +356,7 @@ class ConditionInternalTxn : public Condition
 
 public:
   void
-  append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */) override
+  do_append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */) override
   {
   }
 
@@ -380,7 +380,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool
@@ -410,7 +410,7 @@ public:
   void operator=(const SelfType &)         = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -432,7 +432,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -463,7 +463,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
   // Make sure we know if the type is an int-type or a string.
   bool
@@ -509,7 +509,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -537,7 +537,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool
@@ -572,7 +572,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
   static constexpr const char *TAG = "INBOUND";
 
@@ -590,7 +590,7 @@ private:
 #if TS_HAS_CRIPTS
   bool _mtls_cert = false;
 #endif
-  void append_value(std::string &s, const Resources &res, NetworkSessionQualifiers qual);
+  void do_append_value(std::string &s, const Resources &res, NetworkSessionQualifiers qual);
 };
 
 class ConditionStringLiteral : public Condition
@@ -606,7 +606,7 @@ public:
   ConditionStringLiteral(const SelfType &) = delete;
   void operator=(const SelfType &)         = delete;
 
-  void append_value(std::string &s, const Resources & /* res ATS_UNUSED */) override;
+  void do_append_value(std::string &s, const Resources & /* res ATS_UNUSED */) override;
 
 protected:
   bool eval(const Resources & /* res ATS_UNUSED */) override;
@@ -630,7 +630,7 @@ public:
   void operator=(const SelfType &)                = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -651,7 +651,7 @@ public:
   void operator=(const SelfType &)   = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -673,7 +673,7 @@ public:
   void operator=(const SelfType &) = delete;
 
   void initialize(Parser &p) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -697,7 +697,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -719,7 +719,7 @@ public:
   void operator=(const SelfType &)    = delete;
 
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -762,7 +762,7 @@ public:
   }
 
   void
-  append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */) override
+  do_append_value(std::string & /* s ATS_UNUSED */, const Resources & /* res ATS_UNUSED */) override
   {
     TSAssert(!"%{GROUP} should never be used as a condition value!");
     TSError("[%s] %%{GROUP} should never be used as a condition value!", PLUGIN_NAME);
@@ -820,7 +820,7 @@ public:
   void operator=(const SelfType &)     = delete;
 
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -863,7 +863,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -915,7 +915,7 @@ public:
 
   void initialize(Parser &p) override;
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;
@@ -959,7 +959,7 @@ public:
   void operator=(const SelfType &)       = delete;
 
   void set_qualifier(const std::string &q) override;
-  void append_value(std::string &s, const Resources &res) override;
+  void do_append_value(std::string &s, const Resources &res) override;
 
 protected:
   bool eval(const Resources &res) override;

--- a/plugins/header_rewrite/matcher.h
+++ b/plugins/header_rewrite/matcher.h
@@ -60,6 +60,7 @@ enum class CondModifiers : int {
   MOD_PRE    = 1 << 6,
   MOD_SUF    = 1 << 7,
   MOD_MID    = 1 << 8, // Essentially a substring
+  MOD_NORM   = 1 << 9, // Normalize the value before use; percent-decoding for now
 };
 
 inline CondModifiers

--- a/plugins/header_rewrite/parser.cc
+++ b/plugins/header_rewrite/parser.cc
@@ -106,6 +106,11 @@ Parser::parse_line(const std::string &original_line)
         _empty = true;
         return false;
       }
+    } else if ((state == PARSER_DEFAULT) && (i > 0) && (line[i - 1] == '%') && (line[i] == '{')) {
+      // A %{} expansion is a single token even with whitespace in it, e.g. %{CLIENT-URL:PATH [NORM]}.
+      state = PARSER_IN_EXPANSION;
+    } else if ((state == PARSER_IN_EXPANSION) && (line[i] == '}')) {
+      state = PARSER_DEFAULT;
     } else if ((state == PARSER_DEFAULT) && ((i == 0 || line[i - 1] != '%') && line[i] == '{')) {
       state            = PARSER_IN_BRACE;
       extracting_token = true;

--- a/plugins/header_rewrite/value.cc
+++ b/plugins/header_rewrite/value.cc
@@ -21,7 +21,10 @@
   limitations under the License.
 */
 
+#include <cctype>
 #include <string>
+
+#include "swoc/TextView.h"
 
 #include "value.h"
 
@@ -51,9 +54,19 @@ Value::set_value(const std::string &val, Statement *owner)
       Condition *tcond_val = nullptr;
 
       if (token.substr(0, 2) == "%{") {
-        std::string cond_token = token.substr(2, token.size() - 3);
+        std::string    cond_token = token.substr(2, token.size() - 3);
+        swoc::TextView cond_name{cond_token};
 
-        if ((tcond_val = condition_factory(cond_token))) {
+        // The factory only wants the condition and its qualifier, so hide any trailing
+        // [MODS] from it. The Parser still sees them, and initialize() consumes them.
+        if (cond_name.ends_with(']')) {
+          if (auto pos = cond_name.rfind('['); pos != swoc::TextView::npos) {
+            cond_name.remove_suffix(cond_name.size() - pos);
+            cond_name.rtrim_if([](char c) { return std::isspace(static_cast<unsigned char>(c)) != 0; });
+          }
+        }
+
+        if ((tcond_val = condition_factory(std::string{cond_name}))) {
           Parser parser;
 
           if (parser.parse_line(cond_token)) {

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
@@ -211,6 +211,21 @@ autest:
             args:
               - "rules/rule_empty_json_body.conf"
 
+      # Dedicated hosts, because the [NORM] rules anchor on the start of the path.
+      - from: "http://norm.ex/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/"
+        plugins:
+          - name: "header_rewrite.so"
+            args:
+              - "rules/norm_modifier.conf"
+
+      - from: "http://norm-block.ex/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/"
+        plugins:
+          - name: "header_rewrite.so"
+            args:
+              - "rules/norm_block.conf"
+
     metric_checks:
       - metric: "proxy.process.plugin.header_rewrite.operators"
         min: 1
@@ -2413,3 +2428,267 @@ sessions:
       headers:
         fields:
         - [ Content-Type, { value: "text/html; charset=utf-8", as: equal } ]
+
+# Test 92: [NORM] on conditions. The paired rules differ only in that flag, so an
+# X-Norm-* header without its X-Raw-* twin was matched only after decoding. Also
+# checks both the bare and quoted spellings of a %{} expansion with [NORM].
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket1/x/pr%69vate-1
+      headers:
+        fields:
+        - [ Host, norm.ex ]
+        - [ uuid, 92 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Norm-Regex, { value: "yes", as: equal } ]
+        - [ X-Raw-Regex, { as: absent } ]
+        - [ X-Norm-Mid, { value: "yes", as: equal } ]
+        - [ X-Raw-Mid, { as: absent } ]
+        - [ X-Norm-Path, { value: "Bucket1/x/private-1", as: equal } ]
+        - [ X-Raw-Path, { value: "Bucket1/x/pr%69vate-1", as: equal } ]
+        - [ X-Norm-Quoted, { value: "path is Bucket1/x/private-1", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200
+
+# Test 93: nothing escaped, so [NORM] is a no-op and both rules of each pair fire.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket1/x/private-1
+      headers:
+        fields:
+        - [ Host, norm.ex ]
+        - [ uuid, 93 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Norm-Regex, { value: "yes", as: equal } ]
+        - [ X-Raw-Regex, { value: "yes", as: equal } ]
+        - [ X-Norm-Mid, { value: "yes", as: equal } ]
+        - [ X-Raw-Mid, { value: "yes", as: equal } ]
+        - [ X-Norm-Path, { value: "Bucket1/x/private-1", as: equal } ]
+        - [ X-Raw-Path, { value: "Bucket1/x/private-1", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200
+
+# Test 94: no match either way, so [NORM] must not manufacture one. Decoding happens exactly
+# once per RFC 3986 section 2.4, so %2569 yields %69 rather than collapsing to 'i'.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket1/x/pr%2569vate-1
+      headers:
+        fields:
+        - [ Host, norm.ex ]
+        - [ uuid, 94 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Norm-Regex, { as: absent } ]
+        - [ X-Raw-Regex, { as: absent } ]
+        - [ X-Norm-Mid, { as: absent } ]
+        - [ X-Raw-Mid, { as: absent } ]
+        - [ X-Norm-Path, { value: "Bucket1/x/pr%69vate-1", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200
+
+# Test 95: the blocklist rule. Escaping the pattern no longer evades the 403, and
+# ATS never talks to the origin.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket123/foo/pr%69vate-1
+      headers:
+        fields:
+        - [ Host, norm-block.ex ]
+        - [ uuid, 95 ]
+
+    proxy-request:
+      expect: absent
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 403
+
+# Test 96: the same rule still blocks the unescaped form.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /alpha-v12-beta/Bucket123/foo/private-1
+      headers:
+        fields:
+        - [ Host, norm-block.ex ]
+        - [ uuid, 96 ]
+
+    proxy-request:
+      expect: absent
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 403
+
+# Test 97: an unrelated path is not blocked.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket123/foo/public-1
+      headers:
+        fields:
+        - [ Host, norm-block.ex ]
+        - [ uuid, 97 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ uuid, { value: "97", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200
+
+# Test 98: malformed escapes. These drive the unescaper's backtracking paths, which write
+# from str[-1]/str[-2] and so are the ones that would corrupt an in-place decode. Both
+# sequences are invalid, so the value must come through byte-for-byte unchanged.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket1/x/a%zzb%4zc-1
+      headers:
+        fields:
+        - [ Host, norm.ex ]
+        - [ uuid, 98 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Norm-Path, { value: "Bucket1/x/a%zzb%4zc-1", as: equal } ]
+        - [ X-Raw-Path, { value: "Bucket1/x/a%zzb%4zc-1", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200
+
+# Test 99: a legitimately encoded percent sign. %25 is how a literal '%' is sent, so the
+# decoded value keeps it as data. [NORM] does not promise a value free of '%'.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket1/x/50%25-off
+      headers:
+        fields:
+        - [ Host, norm.ex ]
+        - [ uuid, 99 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Norm-Regex, { as: absent } ]
+        - [ X-Norm-Path, { value: "Bucket1/x/50%-off", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200
+
+# Test 100: exactly one pass, pinned. %2550%25-off decodes to %50%-off; a second pass would
+# turn that into P%-off, so this fails if decoding ever iterates.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /Bucket1/x/%2550%25-off
+      headers:
+        fields:
+        - [ Host, norm.ex ]
+        - [ uuid, 100 ]
+
+    proxy-request:
+      headers:
+        fields:
+        - [ X-Norm-Path, { value: "Bucket1/x/%50%-off", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Server, microserver ]
+        - [ Content-Length, "0" ]
+
+    proxy-response:
+      status: 200

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/norm_block.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/norm_block.conf
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# A blocklist regex, which without [NORM] a client evades by escaping any
+# character of the pattern (pr%69vate-).
+#
+cond %{REMAP_PSEUDO_HOOK}
+    cond %{CLIENT-URL:PATH} /^(alpha(-v\d+)?-beta\/)?Bucket[0-9]*\/.*\/private-/ [NORM]
+        set-status 403

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/norm_modifier.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/norm_modifier.conf
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The [NORM] modifier: the paired rules below differ only in that flag, so any
+# X-Norm-* header present without its X-Raw-* twin was matched only after
+# percent-decoding.
+#
+cond %{REMAP_PSEUDO_HOOK}
+    cond %{CLIENT-URL:PATH} /private-/ [NORM]
+        set-header X-Norm-Regex "yes"
+
+cond %{REMAP_PSEUDO_HOOK}
+    cond %{CLIENT-URL:PATH} /private-/
+        set-header X-Raw-Regex "yes"
+
+cond %{REMAP_PSEUDO_HOOK}
+    cond %{CLIENT-URL:PATH} ="PRIVATE-" [MID,NOCASE,NORM]
+        set-header X-Norm-Mid "yes"
+
+cond %{REMAP_PSEUDO_HOOK}
+    cond %{CLIENT-URL:PATH} ="PRIVATE-" [MID,NOCASE]
+        set-header X-Raw-Mid "yes"
+
+cond %{REMAP_PSEUDO_HOOK}
+    set-header X-Norm-Path %{CLIENT-URL:PATH [NORM]}
+    set-header X-Raw-Path %{CLIENT-URL:PATH}
+
+# The quoted spelling is what hrw4u generates, so it has to work too.
+cond %{REMAP_PSEUDO_HOOK}
+    set-header X-Norm-Quoted "path is %{CLIENT-URL:PATH [NORM]}"

--- a/tools/hrw4u/grammar/u4wrh.g4
+++ b/tools/hrw4u/grammar/u4wrh.g4
@@ -33,6 +33,7 @@ SUF_MOD       : 'SUF';
 PRE_MOD       : 'PRE';
 EXT_MOD       : 'EXT';
 MID_MOD       : 'MID';
+NORM_MOD      : 'NORM';
 
 REGEX         : '/' ( '\\/' | ~[/\r\n] )* '/' ;
 STRING        : '"' ( '\\' . | ~["\\\r\n] )* '"' ;
@@ -218,6 +219,7 @@ modItem
     | PRE_MOD
     | EXT_MOD
     | MID_MOD
+    | NORM_MOD
     ;
 
 // -----------------------------

--- a/tools/hrw4u/schema/sandbox.schema.json
+++ b/tools/hrw4u/schema/sandbox.schema.json
@@ -125,6 +125,7 @@
               "SUF",
               "EXT",
               "MID",
+              "NORM",
               "I",
               "L",
               "QSA"

--- a/tools/hrw4u/src/common.py
+++ b/tools/hrw4u/src/common.py
@@ -43,18 +43,51 @@ class RegexPatterns:
     SUBSTITUTE_PATTERN: Final = re.compile(
         r"""(?P<escaped>\{\{.*?\}\})
             |
-            (?<!%)\{\s*(?P<func>[a-zA-Z_][a-zA-Z0-9_-]*)\s*\((?P<args>[^)]*)\)\s*\}
+            (?<!%)\{\s*(?P<func>[a-zA-Z_][a-zA-Z0-9_-]*)\s*\((?P<args>[^)]*)\)
+                (?:\s+with\s+(?P<fmods>[A-Za-z][A-Za-z0-9,\s]*?))?\s*\}
             |
             (?<!%)\{(?P<var>[^{}()]+)\}
         """,
         re.VERBOSE | re.DOTALL,
     )
 
+    # An interpolated symbol may carry modifiers, spelled as on a condition: {inbound.url.path with NORM}
+    INTERPOLATION_MODS: Final = re.compile(r'^\s*(?P<name>\S+?)\s+with\s+(?P<mods>[A-Za-z][A-Za-z0-9,\s]*?)\s*$')
+
+    # Trailing [MODS] inside a %{} block, which u4wrh turns back into a "with" clause
+    PERCENT_MODS: Final = re.compile(r'^(?P<body>.*?)\s+\[(?P<mods>[A-Za-z][A-Za-z0-9,\s]*)\]$')
+
     # Additional performance patterns
     IDENTIFIER: Final = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
     WHITESPACE: Final = re.compile(r'\s+')
     COMMENT_BLOCK: Final = re.compile(r'/\*.*?\*/', re.DOTALL)
     STRING_INTERPOLATION: Final = re.compile(r'\{([a-zA-Z_][a-zA-Z0-9_.-]*(?:\([^)]*\))?)\}', re.MULTILINE)
+
+
+def split_interpolation_mods(text: str) -> tuple[str, list[str]]:
+    """Split '<symbol> with MOD,MOD' into the symbol and its modifiers."""
+    if match := RegexPatterns.INTERPOLATION_MODS.match(text):
+        return match.group("name"), [mod.strip().upper() for mod in match.group("mods").split(",") if mod.strip()]
+    return text.strip(), []
+
+
+def apply_percent_mods(percent: str, mods: list[str]) -> str:
+    """Write modifiers into a %{} block the way header_rewrite spells them: %{TAG:PAYLOAD [MODS]}."""
+    if not mods or not (percent.startswith("%{") and percent.endswith("}")):
+        return percent
+    return f"{percent[:-1]} [{','.join(mods)}]}}"
+
+
+def split_percent_mods(percent: str) -> tuple[str, list[str]]:
+    """Inverse of apply_percent_mods()."""
+    if not (percent.startswith("%{") and percent.endswith("}")):
+        return percent, []
+
+    if match := RegexPatterns.PERCENT_MODS.match(percent[2:-1]):
+        mods = [mod.strip().upper() for mod in match.group("mods").split(",") if mod.strip()]
+        return f'%{{{match.group("body")}}}', mods
+
+    return percent, []
 
 
 class SystemDefaults:

--- a/tools/hrw4u/src/hrw_symbols.py
+++ b/tools/hrw4u/src/hrw_symbols.py
@@ -26,7 +26,7 @@ from hrw4u.validation import Validator
 import hrw4u.types as types
 import hrw4u.tables as tables
 from hrw4u.states import SectionType
-from hrw4u.common import split_percent_mods
+from hrw4u.common import apply_percent_mods, split_percent_mods
 from hrw4u.symbols_base import SymbolResolverBase
 
 
@@ -412,11 +412,15 @@ class InverseSymbolResolver(SymbolResolverBase):
         stripped, mods = split_percent_mods(percent)
         expr, is_func = self._percent_to_ident_or_func(stripped, section)
 
-        # An unresolved block comes back verbatim, so re-attaching mods would duplicate them.
-        if mods and expr != stripped:
-            expr = f"{expr} with {','.join(mods)}"
+        if not mods:
+            return expr, is_func
 
-        return expr, is_func
+        # A block with no DSL equivalent comes back as %{...}, where the modifiers belong
+        # inside the braces rather than in a "with" clause.
+        if expr == stripped:
+            return apply_percent_mods(expr, mods), is_func
+
+        return f"{expr} with {','.join(mods)}", is_func
 
     def _percent_to_ident_or_func(self, percent: str, section: SectionType | None) -> tuple[str, bool]:
         match = Validator._PERCENT_RE.match(percent)

--- a/tools/hrw4u/src/hrw_symbols.py
+++ b/tools/hrw4u/src/hrw_symbols.py
@@ -26,6 +26,7 @@ from hrw4u.validation import Validator
 import hrw4u.types as types
 import hrw4u.tables as tables
 from hrw4u.states import SectionType
+from hrw4u.common import split_percent_mods
 from hrw4u.symbols_base import SymbolResolverBase
 
 
@@ -408,6 +409,16 @@ class InverseSymbolResolver(SymbolResolverBase):
 
     def percent_to_ident_or_func(self, percent: str, section: SectionType | None) -> tuple[str, bool]:
         """Convert percent block to identifier or function call."""
+        stripped, mods = split_percent_mods(percent)
+        expr, is_func = self._percent_to_ident_or_func(stripped, section)
+
+        # An unresolved block comes back verbatim, so re-attaching mods would duplicate them.
+        if mods and expr != stripped:
+            expr = f"{expr} with {','.join(mods)}"
+
+        return expr, is_func
+
+    def _percent_to_ident_or_func(self, percent: str, section: SectionType | None) -> tuple[str, bool]:
         match = Validator._PERCENT_RE.match(percent)
         if not match:
             raise SymbolResolutionError(percent, "Invalid %{...} reference")

--- a/tools/hrw4u/src/interning.py
+++ b/tools/hrw4u/src/interning.py
@@ -41,7 +41,7 @@ class StringInterning:
     }
 
     MODIFIERS: Final[dict[str, str]] = {
-        mod: sys.intern(mod) for mod in ['AND', 'OR', 'NOT', 'NOCASE', 'PRE', 'SUF', 'EXT', 'MID', 'I', 'L', 'QSA']
+        mod: sys.intern(mod) for mod in ['AND', 'OR', 'NOT', 'NOCASE', 'PRE', 'SUF', 'EXT', 'MID', 'NORM', 'I', 'L', 'QSA']
     }
 
     LSP_STRINGS: Final[dict[str, str]] = {

--- a/tools/hrw4u/src/lsp/documentation.py
+++ b/tools/hrw4u/src/lsp/documentation.py
@@ -1211,6 +1211,18 @@ LSP_MODIFIER_DOCUMENTATION: Final[dict[str, DocumentationInfo]] = {
                 "inbound.url.path == \".html\" with EXT",
                 "if (inbound.url.path == \".CC\" with EXT,NOCASE) {\n    // Case-insensitive extension match\n}"
             ]),
+    "NORM":
+        DocumentationInfo(
+            name="Normalized Value",
+            description="Normalizes the value before it is used, which today means percent-decoding it, so that an "
+            "escaped string such as pr%69vate matches the pattern private.",
+            context="Value Modifier",
+            usage="Used where a client could evade a match by escaping the pattern. Also allowed on interpolated values.",
+            examples=[
+                "if (inbound.url.path ~ /private-/ with NORM) {\n    // Also matches pr%69vate-\n}",
+                "if (inbound.url.path == \"PRIVATE-\" with MID,NOCASE,NORM) {\n    // Composes with the other modifiers\n}",
+                "inbound.req.X-Decoded-Path = \"{inbound.url.path with NORM}\";"
+            ]),
 }
 
 

--- a/tools/hrw4u/src/sandbox.py
+++ b/tools/hrw4u/src/sandbox.py
@@ -36,7 +36,7 @@ class SandboxDenialError(SymbolResolutionError):
 
 _VALID_CATEGORY_KEYS = frozenset({"sections", "functions", "conditions", "operators", "language", "modifiers"})
 _VALID_LANGUAGE_CONSTRUCTS = frozenset({"break", "variables", "in", "else", "elif"})
-_VALID_MODIFIERS = frozenset({"AND", "OR", "NOT", "NOCASE", "PRE", "SUF", "EXT", "MID", "I", "L", "QSA"})
+_VALID_MODIFIERS = frozenset({"AND", "OR", "NOT", "NOCASE", "PRE", "SUF", "EXT", "MID", "NORM", "I", "L", "QSA"})
 
 
 def _load_set(data: dict[str, Any], key: str, prefix: str) -> frozenset[str]:

--- a/tools/hrw4u/src/states.py
+++ b/tools/hrw4u/src/states.py
@@ -74,7 +74,8 @@ CONDITION_MODIFIERS = frozenset(
         intern_modifier("PRE"),
         intern_modifier("SUF"),
         intern_modifier("EXT"),
-        intern_modifier("MID")
+        intern_modifier("MID"),
+        intern_modifier("NORM")
     })
 
 OPERATOR_MODIFIERS = frozenset({intern_modifier("I"), intern_modifier("L"), intern_modifier("QSA")})
@@ -86,10 +87,15 @@ WITH_MODIFIER_ORDER = [
     intern_modifier("NOCASE"),
     intern_modifier("PRE"),
     intern_modifier("MID"),
-    intern_modifier("SUF")
+    intern_modifier("SUF"),
+    intern_modifier("NORM")
 ]
 
 WITH_MODIFIERS = frozenset(WITH_MODIFIER_ORDER)
+
+# Modifiers that mean something on an interpolated value rather than on a match. The rest
+# (NOCASE, PRE, ...) only affect how a condition compares, so they are rejected there.
+VALUE_MODIFIERS = frozenset({intern_modifier("NORM")})
 
 
 class ModifierType(str, Enum):
@@ -121,11 +127,12 @@ class CondState:
     and_or: bool = False  # False == AND (default)
     not_: bool = False
     nocase: bool = False
+    norm: bool = False
     substr: SubstringMode = SubstringMode.NONE
     last: bool = False  # For condition logic (last in AND/OR chain)
 
     def reset(self) -> None:
-        self.and_or = self.not_ = self.nocase = self.last = False
+        self.and_or = self.not_ = self.nocase = self.norm = self.last = False
         self.substr = SubstringMode.NONE
 
     def copy(self) -> Self:
@@ -141,6 +148,8 @@ class CondState:
             self.not_ = True
         elif mod_upper == intern_modifier("NOCASE"):
             self.nocase = True
+        elif mod_upper == intern_modifier("NORM"):
+            self.norm = True
         elif mod_upper in SubstringMode.__members__:
             if self.substr != SubstringMode.NONE:
                 raise SymbolResolutionError(mod, f"Multiple substring modifiers (already {self.substr.name})")
@@ -158,6 +167,8 @@ class CondState:
             parts.append("NOCASE")
         if self.substr is not SubstringMode.NONE:
             parts.append(self.substr.name)
+        if self.norm:
+            parts.append("NORM")
         return parts
 
     def to_with_modifiers(self) -> list[str]:
@@ -166,6 +177,8 @@ class CondState:
             mods.append("NOCASE")
         if self.substr is not SubstringMode.NONE:
             mods.append(self.substr.name)
+        if self.norm:
+            mods.append("NORM")
         mods.sort(key=lambda m: WITH_MODIFIER_ORDER.index(m) if m in WITH_MODIFIER_ORDER else 999)
         return mods
 

--- a/tools/hrw4u/src/visitor.py
+++ b/tools/hrw4u/src/visitor.py
@@ -32,8 +32,8 @@ from hrw4u.hrw4uParser import hrw4uParser
 from hrw4u.hrw4uLexer import hrw4uLexer
 from hrw4u.symbols import SymbolResolver, SymbolResolutionError
 from hrw4u.errors import hrw4u_error, Hrw4uSyntaxError, ThrowingErrorListener
-from hrw4u.states import CondState, SectionType
-from hrw4u.common import RegexPatterns, SystemDefaults
+from hrw4u.states import CondState, SectionType, VALUE_MODIFIERS
+from hrw4u.common import RegexPatterns, SystemDefaults, apply_percent_mods, split_interpolation_mods
 from hrw4u.visitor_base import BaseHRWVisitor
 from hrw4u.validation import Validator
 from hrw4u.procedures import resolve_use_path
@@ -195,6 +195,17 @@ class HRW4UVisitor(hrw4uVisitor, BaseHRWVisitor):
 
         return args
 
+    def _value_mods(self, raw: str | None) -> list[str]:
+        if not raw:
+            return []
+
+        mods = [mod.strip().upper() for mod in raw.split(",") if mod.strip()]
+
+        for mod in mods:
+            if mod not in VALUE_MODIFIERS:
+                raise SymbolResolutionError(mod, f"Not a value modifier, expected one of {', '.join(sorted(VALUE_MODIFIERS))}")
+        return mods
+
     def _substitute_strings(self, s: str, ctx) -> str:
         inner = s[1:-1]
 
@@ -218,14 +229,18 @@ class HRW4UVisitor(hrw4uVisitor, BaseHRWVisitor):
                 if m.group("func"):
                     func_name = m.group("func").strip()
                     arg_str = m.group("args").strip()
+                    mods = self._value_mods(m.group("fmods"))
                     args = self._parse_function_args(arg_str) if arg_str else []
-                    replacement = self.symbol_resolver.resolve_function(func_name, args, strip_quotes=False)
+                    replacement = apply_percent_mods(
+                        self.symbol_resolver.resolve_function(func_name, args, strip_quotes=False), mods)
                     self._drain_resolver_warnings(ctx)
                     self.debug(f"substitute: {{{func_name}({arg_str})}} -> {replacement}")
                     return replacement
                 if m.group("var"):
-                    var_name = m.group("var").strip()
-                    replacement, _ = self.symbol_resolver.resolve_condition(var_name, self.current_section)
+                    var_name, mods = split_interpolation_mods(m.group("var"))
+                    mods = self._value_mods(",".join(mods))
+                    resolved, _ = self.symbol_resolver.resolve_condition(var_name, self.current_section)
+                    replacement = apply_percent_mods(resolved, mods)
                     self._drain_resolver_warnings(ctx)
                     self.debug(f"substitute: {{{var_name}}} -> {replacement}")
                     return replacement

--- a/tools/hrw4u/tests/data/conds/norm-modifier.input.txt
+++ b/tools/hrw4u/tests/data/conds/norm-modifier.input.txt
@@ -1,0 +1,9 @@
+REMAP {
+    if inbound.url.path ~ /private-/ with NORM {
+        inbound.status = 403;
+    }
+
+    if inbound.url.path == "PRIVATE-" with NOCASE,MID,NORM {
+        inbound.req.X-Private = "yes";
+    }
+}

--- a/tools/hrw4u/tests/data/conds/norm-modifier.output.txt
+++ b/tools/hrw4u/tests/data/conds/norm-modifier.output.txt
@@ -1,0 +1,7 @@
+cond %{REMAP_PSEUDO_HOOK} [AND]
+cond %{CLIENT-URL:PATH} /private-/ [NORM]
+    set-status 403
+
+cond %{REMAP_PSEUDO_HOOK} [AND]
+cond %{CLIENT-URL:PATH} ="PRIVATE-" [NOCASE,MID,NORM]
+    set-header X-Private "yes"

--- a/tools/hrw4u/tests/data/ops/norm-expansion.input.txt
+++ b/tools/hrw4u/tests/data/ops/norm-expansion.input.txt
@@ -1,0 +1,5 @@
+SEND_RESPONSE {
+    inbound.resp.X-Decoded-Path = "{inbound.url.path with NORM}";
+    inbound.resp.X-Raw-Path = "{inbound.url.path}";
+    inbound.resp.X-Both = "raw {inbound.url.path} decoded {inbound.url.path with NORM}";
+}

--- a/tools/hrw4u/tests/data/ops/norm-expansion.output.txt
+++ b/tools/hrw4u/tests/data/ops/norm-expansion.output.txt
@@ -1,0 +1,4 @@
+cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+    set-header X-Decoded-Path "%{CLIENT-URL:PATH [NORM]}"
+    set-header X-Raw-Path "%{CLIENT-URL:PATH}"
+    set-header X-Both "raw %{CLIENT-URL:PATH} decoded %{CLIENT-URL:PATH [NORM]}"

--- a/tools/hrw4u/tests/data/ops/norm_bad_value_mod.fail.error.txt
+++ b/tools/hrw4u/tests/data/ops/norm_bad_value_mod.fail.error.txt
@@ -1,0 +1,5 @@
+tests/data/ops/norm_bad_value_mod.fail.input.txt:2:2: error: symbol error in {}: Not a value modifier, expected one of NORM
+   2 |   inbound.req.X-Path = "{inbound.url.path with NOCASE}";
+     |   ^
+     | String interpolation context: "{inbound.url.path with NOCASE}"...
+     | Current section: REMAP

--- a/tools/hrw4u/tests/data/ops/norm_bad_value_mod.fail.input.txt
+++ b/tools/hrw4u/tests/data/ops/norm_bad_value_mod.fail.input.txt
@@ -1,0 +1,3 @@
+REMAP {
+  inbound.req.X-Path = "{inbound.url.path with NOCASE}";
+}

--- a/tools/hrw4u/tests/test_coverage.py
+++ b/tools/hrw4u/tests/test_coverage.py
@@ -278,6 +278,15 @@ class TestInverseSymbolResolver:
         r = self._resolver()
         assert r.negate_expression('foo != "bar"') == 'foo != "bar"'
 
+    def test_percent_mods_become_with_clause(self):
+        r = self._resolver()
+        assert r.percent_to_ident_or_func("%{CLIENT-URL:PATH [NORM]}", None) == ("inbound.url.path with NORM", False)
+
+    def test_percent_mods_kept_on_unmapped_block(self):
+        # A tag with no DSL equivalent comes back verbatim; the mods have to survive with it.
+        r = self._resolver()
+        assert r.percent_to_ident_or_func("%{READ_RESPONSE_HDR_HOOK [NORM]}", None) == ("%{READ_RESPONSE_HDR_HOOK [NORM]}", False)
+
     def test_negate_regex(self):
         r = self._resolver()
         assert r.negate_expression("x ~ /pat/") == "x !~ /pat/"


### PR DESCRIPTION
A client can evade a string or regex condition by escaping any character of the pattern, so [NORM] normalizes the condition's value before it is matched. Normalization is percent-decoding for now, but the name leaves room for more. 

Applying it in a non-virtual append_value() wrapper means it also covers regexes and %{} expansions inside operator values, neither of which the matcher-level modifiers (PRE/SUF/MID/EXT) reach.