### PR TITLE
Skip rate_limit AuTests when plugin not built

### DIFF
--- a/tests/gold_tests/pluginTest/rate_limit/rate_limit.test.py
+++ b/tests/gold_tests/pluginTest/rate_limit/rate_limit.test.py
@@ -21,6 +21,7 @@ Test.Summary = '''
 Test rate_limit plugin: concurrent limit enforcement, queue drain, and independent limiters.
 '''
 
+Test.SkipUnless(Condition.PluginExists('rate_limit.so'))
 Test.ContinueOnFail = True
 
 server = Test.MakeOriginServer("server", delay=3)

--- a/tests/gold_tests/pluginTest/rate_limit/rate_limit_iprep.test.py
+++ b/tests/gold_tests/pluginTest/rate_limit/rate_limit_iprep.test.py
@@ -28,6 +28,7 @@ Test.Summary = '''
 Test rate_limit ip-rep initialization: reserve() vs resize() regression (Finding #108).
 '''
 
+Test.SkipUnless(Condition.PluginExists('rate_limit.so'))
 Test.ContinueOnFail = True
 
 server = Test.MakeOriginServer("server")

--- a/tests/gold_tests/pluginTest/rate_limit/rate_limit_sni.test.py
+++ b/tests/gold_tests/pluginTest/rate_limit/rate_limit_sni.test.py
@@ -27,6 +27,7 @@ Test.Summary = '''
 Test rate_limit SNI queue expiry: active counter underflow regression (Finding #109).
 '''
 
+Test.SkipUnless(Condition.PluginExists('rate_limit.so'))
 Test.ContinueOnFail = True
 
 server = Test.MakeOriginServer("server", delay=4)


### PR DESCRIPTION
The rate_limit plugin is experimental at this time and not guaranteed to be in the build. Most of the rate_limit AuTests already handle this appropriately, but a few were missing the `SkipUnless` directive.