### PR TITLE
Normalize repeated carriage returns in headers

### DIFF
--- a/src/proxy/hdrs/MIME.cc
+++ b/src/proxy/hdrs/MIME.cc
@@ -2509,7 +2509,8 @@ mime_parser_parse(MIMEParser *parser, HdrHeap *heap, MIMEHdrImpl *mh, const char
       }
       field_name.rtrim_if(&ParseRules::is_ws);
       raw_print_field = false;
-    } else if (parsed.suffix(2) != "\r\n") {
+    } else if (parsed.suffix(2) != "\r\n" || (parsed.size() > 2 && parsed[parsed.size() - 3] == '\r')) {
+      // Do not preserve malformed line endings when forwarding the field.
       raw_print_field = false;
     }
 

--- a/src/proxy/hdrs/unit_tests/test_Hdrs.cc
+++ b/src/proxy/hdrs/unit_tests/test_Hdrs.cc
@@ -2983,6 +2983,32 @@ TEST_CASE("HTTP parser tolerates high-bit bytes without UB", "[proxy][hdrtest]")
   req_hdr.destroy();
 }
 
+TEST_CASE("HTTP parser normalizes repeated carriage returns in header line endings", "[proxy][hdrtest]")
+{
+  constexpr std::string_view message = "GET / HTTP/1.1\r\nHost: example.com\r\nExtra-CRs: \r\r\r\r\n\r\n"sv;
+
+  HTTPParser parser;
+  http_parser_init(&parser);
+
+  HTTPHdr  req_hdr;
+  HdrHeap *heap = new_HdrHeap(HdrHeap::DEFAULT_SIZE + 64);
+  req_hdr.create(HTTPType::REQUEST, HTTP_1_1, heap);
+
+  auto start = message.data();
+  REQUIRE(req_hdr.parse_req(&parser, &start, message.data() + message.size(), true) == ParseResult::DONE);
+
+  std::string serialized(static_cast<size_t>(req_hdr.length_get()), '\0');
+  int         index  = 0;
+  int         offset = 0;
+  req_hdr.print(serialized.data(), static_cast<int>(serialized.size()), &index, &offset);
+  serialized.resize(static_cast<size_t>(index));
+
+  CHECK(serialized.find("Extra-CRs: \r\n") != std::string::npos);
+  CHECK(serialized.find("Extra-CRs: \r\r") == std::string::npos);
+
+  req_hdr.destroy();
+}
+
 TEST_CASE("HTTP response parser tolerates high-bit bytes without UB", "[proxy][hdrtest]")
 {
   struct Test {


### PR DESCRIPTION
## Summary

Fix HTTP header serialization so malformed header line endings containing repeated carriage-return (`CR`) bytes are not forwarded unchanged to the next hop.

This addresses [issue #12195](https://github.com/apache/trafficserver/issues/12195), where ATS was observed forwarding header lines such as `Extra-CRs: \r\r\r\r\n` with the extra carriage returns preserved.

## Problem

ATS intentionally preserves the original input buffer for some valid `CRLF`-terminated fields as a serialization fast path. The parser already trims trailing whitespace, line-feed, and carriage-return characters from the parsed field value, but it could still mark a line with repeated carriage returns as safe for raw-line preservation merely because it ended in `CRLF`.

As a result, the normalized field representation and the serialized wire representation could differ: the parsed value was normalized, while the original malformed line—including the extra `CR` bytes—could be forwarded downstream.

This is undesirable for HTTP intermediaries because downstream components should not receive malformed line endings that ATS has already parsed and normalized.

## Implementation

The parser now disables raw input-line preservation when either of the following is true:

1. The line does not end in the normal `CRLF` sequence; or
2. The byte immediately preceding the final `CRLF` is itself a carriage return, indicating repeated carriage returns at the line ending.

When raw preservation is disabled, ATS serializes the parsed field using its normal canonical format, producing a single `CRLF` terminator. The existing fast path for correctly formed header lines remains unchanged.

## Regression Test

Added a header unit test that:

1. Parses a request containing `Extra-CRs: \r\r\r\r\n`.
2. Serializes the parsed request.
3. Verifies that the output contains the normalized `Extra-CRs: \r\n` form.
4. Verifies that the serialized output does not contain repeated carriage returns.

## Validation

The following checks were completed locally:

- The new focused regression test passed.
- The complete `test_proxy_hdrs` suite passed: **53 test cases and 436,882 assertions**.
- Repository formatting checks passed, including clang-format, yapf, cmake-format, trailing-whitespace, and DOS-line-ending checks.
- `git diff --check` passed.

## Scope and Compatibility

This change is limited to serialization of header fields whose raw line ending contains repeated carriage returns. Properly formed `CRLF` header lines retain the existing behavior. No public API, configuration setting, or wire format for valid HTTP headers is changed.

## Related Issue

Fixes #12195
