### PR TITLE
slice_stale_generation.test.py: Accept either abort shape

### DIFF
--- a/tests/gold_tests/pluginTest/slice/slice_stale_generation.test.py
+++ b/tests/gold_tests/pluginTest/slice/slice_stale_generation.test.py
@@ -293,12 +293,15 @@ class SliceMixedGenerationTest(SliceHierarchyTest):
         client = self._replay_phase(tr, 'mixed')
         # Let the reference block go stale so that only it is revalidated.
         tr.Processes.Default.Command = f'sleep {self._expiry_wait}; ' + tr.Processes.Default.Command
-        # Slice aborts the transaction, so the client never reads a response at
-        # all: not a short body, no response header. verifier-client exits 1.
+        # Slice aborts the transaction, so the client never reads a complete
+        # response. How far slice got before aborting decides what the client
+        # sees: either a response header it cannot parse, or a complete header
+        # whose body never arrives. Both are the same failure, and which one
+        # shows up is timing, so accept either. verifier-client exits 1 for both.
         client.ReturnCode = 1
         client.Streams.stdout += Testers.ContainsExpression(
-            'Failed to find a well-formed, completed HTTP response: PARSE_INCOMPLETE',
-            'The client should not receive a parsable response.')
+            'Failed to find a well-formed, completed HTTP response: PARSE_INCOMPLETE'
+            '|Content-Length body underrun for key mixed', 'The client should not receive a complete response.')
         client.Streams.stdout += Testers.ContainsExpression(
             'Failed HTTP/1 transaction with key: mixed', 'The transaction should fail.')
         self._still_running(tr)


### PR DESCRIPTION
The test pinned one Proxy Verifier parse state, PARSE_INCOMPLETE, for a
transaction that slice aborts. How far slice got before aborting decides
what the client sees, so under load the client instead reads a complete
response header whose body never arrives, and Proxy Verifier reports a
Content-Length body underrun.

This patch accepts either shape, since both mean the client received no
complete response, which is what the test checks. The sibling cold child
run already asserts only that the transaction failed.


