### PR TITLE
Track coalesced origin connections

### DIFF
--- a/include/proxy/http/ConnectingEntry.h
+++ b/include/proxy/http/ConnectingEntry.h
@@ -35,6 +35,11 @@ class ConnectingEntry : public Continuation
 public:
   ConnectingEntry() = default;
   ~ConnectingEntry() override;
+  /** Retain a connection-tracker reservation until the connection completes.
+   *
+   * @param group Reserved outbound connection group owned by this entry.
+   */
+  void                    enable_outbound_connection_tracking(std::shared_ptr<ConnectionTracker::Group> group);
   void                    remove_entry();
   int                     state_http_server_open(int event, void *data);
   static PoolableSession *create_server_session(HttpSM *root_sm, NetVConnection *netvc, MIOBuffer *netvc_read_buffer,
@@ -51,9 +56,10 @@ public:
   bool               is_no_plugin_tunnel = false;
 
 private:
-  MIOBuffer      *_netvc_read_buffer = nullptr;
-  IOBufferReader *_netvc_reader      = nullptr;
-  Action         *_pending_action    = nullptr;
+  std::shared_ptr<ConnectionTracker::Group> _conn_track_group;
+  MIOBuffer                                *_netvc_read_buffer = nullptr;
+  IOBufferReader                           *_netvc_reader      = nullptr;
+  Action                                   *_pending_action    = nullptr;
 };
 
 struct IpHelper {

--- a/src/proxy/http/ConnectingEntry.cc
+++ b/src/proxy/http/ConnectingEntry.cc
@@ -37,10 +37,20 @@ DbgCtl dbg_ctl_http_connect{"http_connect"};
 
 ConnectingEntry::~ConnectingEntry()
 {
+  if (_conn_track_group) {
+    _conn_track_group->release();
+  }
   if (_netvc_read_buffer != nullptr) {
     free_MIOBuffer(_netvc_read_buffer);
     _netvc_read_buffer = nullptr;
   }
+}
+
+void
+ConnectingEntry::enable_outbound_connection_tracking(std::shared_ptr<ConnectionTracker::Group> group)
+{
+  ink_assert(!_conn_track_group);
+  _conn_track_group = std::move(group);
 }
 
 int
@@ -85,8 +95,11 @@ ConnectingEntry::state_http_server_open(int event, void *data)
       auto prime_iter = connect_sms.rbegin();
       ink_release_assert(prime_iter != connect_sms.rend());
       PoolableSession *new_session = (*prime_iter)->create_server_session(*netvc, _netvc_read_buffer, _netvc_reader);
-      netvc                        = nullptr;
-      _netvc_read_buffer           = nullptr;
+      if (_conn_track_group) {
+        new_session->enable_outbound_connection_tracking(std::move(_conn_track_group));
+      }
+      netvc              = nullptr;
+      _netvc_read_buffer = nullptr;
 
       // Did we end up with a multiplexing session?
       int count = 0;

--- a/src/proxy/http/HttpSM.cc
+++ b/src/proxy/http/HttpSM.cc
@@ -6014,6 +6014,7 @@ HttpSM::do_http_server_open(bool raw, bool only_direct)
       new_entry->sni                 = this->get_outbound_sni();
       new_entry->cert_name           = this->get_outbound_cert();
       new_entry->is_no_plugin_tunnel = plugin_tunnel_type == HttpPluginTunnel_t::NONE;
+      new_entry->enable_outbound_connection_tracking(t_state.outbound_conn_track_state.drop());
       this->t_state.set_connect_fail(EIO);
       new_entry->connect_sms.insert(this);
       ethread->connecting_pool->m_ip_pool.insert(std::make_pair(new_entry->ipaddr, new_entry));


### PR DESCRIPTION
Connection coalescing could assign an origin socket to a queued
transaction that did not own its connection-tracker reservation. The live
connection was then absent from per-server limits and metrics.

This patch keeps the reservation with the in-progress connection and
transfers it to the established session. Failed connection attempts
release the reservation from the coalescing entry.

Fixes: #13605