### PR TITLE
traffic_ctl: emit JSON null instead of YAML tilde

### DIFF
--- a/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
@@ -74,9 +74,8 @@ Our JSONRPC  protocol implementation uses lib yamlcpp for parsing incoming and o
 this allows the server to accept either JSON or YAML format messages which then will be parsed by the protocol implementation. This seems handy
 for user that want to feed |TS| with existing yaml configuration without the need to translate yaml into json.
 
-Null values on the way out are emitted as literal ``null`` rather than yaml's ``~``, as ``~`` is not accepted by JSON parsers. Both
-spellings resolve to null when read as yaml, so this does not affect messages that are consumed as yaml, nor the ability to send
-yaml to the server.
+The server emits null values as the literal ``null``, not as YAML's ``~``. JSON parsers reject ``~``. YAML resolves ``~`` and
+``null`` to the same value. Clients that read the response as YAML see no change, and the server still accepts YAML input.
 
 .. note::
 

--- a/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
+++ b/doc/developer-guide/jsonrpc/jsonrpc-architecture.en.rst
@@ -74,6 +74,10 @@ Our JSONRPC  protocol implementation uses lib yamlcpp for parsing incoming and o
 this allows the server to accept either JSON or YAML format messages which then will be parsed by the protocol implementation. This seems handy
 for user that want to feed |TS| with existing yaml configuration without the need to translate yaml into json.
 
+Null values on the way out are emitted as literal ``null`` rather than yaml's ``~``, as ``~`` is not accepted by JSON parsers. Both
+spellings resolve to null when read as yaml, so this does not affect messages that are consumed as yaml, nor the ability to send
+yaml to the server.
+
 .. note::
 
    :program:`traffic_ctl` have an option to read files from disc and push them into |TS| through the RPC server. Files should be a

--- a/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
+++ b/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include <yaml-cpp/yaml.h>
+
+#include "tsutil/YamlCfg.h"
 #include "mgmt/rpc/jsonrpc/error/RPCError.h"
 #include "mgmt/rpc/jsonrpc/Defs.h"
 
@@ -268,8 +270,7 @@ public:
   encode(const specs::RPCResponseInfo &resp)
   {
     YAML::Emitter json;
-    json.SetNullFormat(YAML::LowerNull);
-    json << YAML::DoubleQuoted << YAML::Flow;
+    ts::Yaml::configure_json_emitter(json);
     encode(resp, json);
 
     return json.c_str();
@@ -285,8 +286,7 @@ public:
   encode(const specs::RPCResponse &response)
   {
     YAML::Emitter json;
-    json.SetNullFormat(YAML::LowerNull);
-    json << YAML::DoubleQuoted << YAML::Flow;
+    ts::Yaml::configure_json_emitter(json);
     {
       if (response.is_batch()) {
         json << YAML::BeginSeq;

--- a/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
+++ b/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
@@ -29,10 +29,10 @@
 namespace rpc::json_codecs
 {
 ///
-/// @note The overall design is to make this classes @c yamlcpp_json_decoder and @c yamlcpp_json_encoder plugables into the Json Rpc
-/// encode/decode logic. yamlcpp defaults to emitting null as ~, which is valid yaml but not valid json, so every emitter here sets
-/// @c YAML::LowerNull to spell it literal null. Both spellings resolve back to null when parsed as yaml, so accepting yaml input
-/// is unaffected.
+/// @note The design keeps @c yamlcpp_json_decoder and @c yamlcpp_json_encoder replaceable in the JSONRPC encode/decode logic.
+/// yaml-cpp emits null as @c ~ by default, which JSON parsers reject. Every emitter here calls
+/// @c ts::Yaml::configure_json_emitter, which writes the literal @c null instead. YAML resolves @c ~ and @c null to the same
+/// value, so the server still accepts YAML input.
 ///
 
 ///

--- a/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
+++ b/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
@@ -28,9 +28,9 @@ namespace rpc::json_codecs
 {
 ///
 /// @note The overall design is to make this classes @c yamlcpp_json_decoder and @c yamlcpp_json_encoder plugables into the Json Rpc
-/// encode/decode logic. yamlcpp does not give us all the behavior we need, such as the way it handles the null values. Json needs
-/// to use literal null and yamlcpp uses ~. If this becomes a problem, then we may need to change the codec implementation, we just
-/// follow the api and it should work with minimum changes.
+/// encode/decode logic. yamlcpp defaults to emitting null as ~, which is valid yaml but not valid json, so every emitter here sets
+/// @c YAML::LowerNull to spell it literal null. Both spellings resolve back to null when parsed as yaml, so accepting yaml input
+/// is unaffected.
 ///
 
 ///
@@ -251,8 +251,8 @@ class yamlcpp_json_encoder
     if (!resp.id.empty()) {
       json << YAML::Key << "id" << YAML::Value << resp.id;
     }
-    // else: We do not insert null as it will break the json, we need literal null and not ~ (as per yaml)
-    // json << YAML::Null;
+    // else: the field is omitted rather than set to null. Emitting it would be valid json now that LowerNull is set, but the
+    // omission is deliberate, see the id note in mgmt/rpc/schema/jsonrpc_response_schema.json.
 
     json << YAML::EndMap;
   }
@@ -268,6 +268,7 @@ public:
   encode(const specs::RPCResponseInfo &resp)
   {
     YAML::Emitter json;
+    json.SetNullFormat(YAML::LowerNull);
     json << YAML::DoubleQuoted << YAML::Flow;
     encode(resp, json);
 
@@ -284,6 +285,7 @@ public:
   encode(const specs::RPCResponse &response)
   {
     YAML::Emitter json;
+    json.SetNullFormat(YAML::LowerNull);
     json << YAML::DoubleQuoted << YAML::Flow;
     {
       if (response.is_batch()) {

--- a/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
+++ b/include/mgmt/rpc/jsonrpc/json/YAMLCodec.h
@@ -253,7 +253,7 @@ class yamlcpp_json_encoder
     if (!resp.id.empty()) {
       json << YAML::Key << "id" << YAML::Value << resp.id;
     }
-    // else: the field is omitted rather than set to null. Emitting it would be valid json now that LowerNull is set, but the
+    // else: the field is omitted rather than set to null. Emitting it would be valid JSON now that LowerNull is set, but the
     // omission is deliberate, see the id note in mgmt/rpc/schema/jsonrpc_response_schema.json.
 
     json << YAML::EndMap;

--- a/include/shared/rpc/yaml_codecs.h
+++ b/include/shared/rpc/yaml_codecs.h
@@ -22,6 +22,8 @@
 #include <string_view>
 #include <yaml-cpp/yaml.h>
 
+#include "tsutil/YamlCfg.h"
+
 #include "shared/rpc/RPCRequests.h"
 
 /// JSONRPC 2.0 Client API request/response codecs only. If you need to define your own specific codecs they should then be defined
@@ -202,8 +204,7 @@ public:
   encode(shared::rpc::JSONRPCRequest const &req)
   {
     YAML::Emitter json;
-    json.SetNullFormat(YAML::LowerNull);
-    json << YAML::DoubleQuoted << YAML::Flow;
+    ts::Yaml::configure_json_emitter(json);
     json << YAML::BeginMap;
 
     if (!req.id.empty()) {

--- a/include/shared/rpc/yaml_codecs.h
+++ b/include/shared/rpc/yaml_codecs.h
@@ -202,6 +202,7 @@ public:
   encode(shared::rpc::JSONRPCRequest const &req)
   {
     YAML::Emitter json;
+    json.SetNullFormat(YAML::LowerNull);
     json << YAML::DoubleQuoted << YAML::Flow;
     json << YAML::BeginMap;
 

--- a/include/tsutil/YamlCfg.h
+++ b/include/tsutil/YamlCfg.h
@@ -41,11 +41,15 @@ namespace Yaml
 
   // Put an emitter into JSON output mode.
   //
-  // yaml-cpp has no JSON mode. The nearest equivalent is flow style with every scalar double quoted, which is valid
-  // JSON for every node type except null: yaml-cpp writes ~, and no JSON parser accepts that. LowerNull writes the
-  // literal null. YAML reads ~ and null as the same value, so output stays readable as YAML either way.
+  // yaml-cpp has no JSON output mode. The nearest equivalent is flow style with every scalar double quoted. For the
+  // node shapes the callers here emit -- maps, sequences, scalars and nulls, carrying no tags, anchors or aliases --
+  // that is JSON-compatible except for null: yaml-cpp writes `~`, which JSON parsers reject. LowerNull writes the
+  // literal `null` instead. YAML resolves `~` and `null` to the same value, so the output still reads as YAML.
   //
-  // Every emitter whose output reaches a JSON consumer must go through here. Setting two of the three manipulators
+  // This is not a general YAML to JSON converter. A node that carries a tag, an anchor or an alias still emits YAML
+  // syntax that JSON does not accept.
+  //
+  // Every emitter whose output reaches a JSON consumer must go through here. Setting only some of the manipulators
   // gives output that looks like JSON and parses correctly until some node is null.
   //
   inline void

--- a/include/tsutil/YamlCfg.h
+++ b/include/tsutil/YamlCfg.h
@@ -39,6 +39,22 @@ namespace Yaml
   constexpr std::string_view YAML_BOOL_TAG_URI{"tag:yaml.org,2002:bool"};
   constexpr std::string_view YAML_NULL_TAG_URI{"tag:yaml.org,2002:null"};
 
+  // Put an emitter into JSON output mode.
+  //
+  // yaml-cpp has no JSON mode. The nearest equivalent is flow style with every scalar double quoted, which is valid
+  // JSON for every node type except null: yaml-cpp writes ~, and no JSON parser accepts that. LowerNull writes the
+  // literal null. YAML reads ~ and null as the same value, so output stays readable as YAML either way.
+  //
+  // Every emitter whose output reaches a JSON consumer must go through here. Setting two of the three manipulators
+  // gives output that looks like JSON and parses correctly until some node is null.
+  //
+  inline void
+  configure_json_emitter(YAML::Emitter &emitter)
+  {
+    emitter.SetNullFormat(YAML::LowerNull);
+    emitter << YAML::DoubleQuoted << YAML::Flow;
+  }
+
   // A class that is a wrapper for a YAML::Node that corresponds to a map in a YAML input file.
   // It's purpose is to make sure all keys in the map are processed.
   //

--- a/include/tsutil/YamlCfg.h
+++ b/include/tsutil/YamlCfg.h
@@ -43,8 +43,13 @@ namespace Yaml
   //
   // yaml-cpp has no JSON output mode. The nearest equivalent is flow style with every scalar double quoted. For the
   // node shapes the callers here emit -- maps, sequences, scalars and nulls, carrying no tags, anchors or aliases --
-  // that is JSON-compatible except for null: yaml-cpp writes `~`, which JSON parsers reject. LowerNull writes the
+  // that parses as JSON except for null: yaml-cpp writes `~`, which JSON parsers reject. LowerNull writes the
   // literal `null` instead. YAML resolves `~` and `null` to the same value, so the output still reads as YAML.
+  //
+  // Parses as JSON is the whole guarantee. It is not type-faithful JSON: `DoubleQuoted` quotes every scalar, so
+  // numbers and booleans arrive as strings -- `"12"` rather than `12`, `"true"` rather than `true`. A consumer
+  // validating against a schema that declares `integer` or `boolean` will reject that, and no manipulator here
+  // changes it. Preserving scalar types needs a real JSON serializer, not a yaml-cpp emitter.
   //
   // This is not a general YAML to JSON converter. A node that carries a tag, an anchor or an alias still emits YAML
   // syntax that JSON does not accept.

--- a/src/config/ssl_multicert.cc
+++ b/src/config/ssl_multicert.cc
@@ -34,6 +34,7 @@
 #include "swoc/swoc_file.h"
 #include "swoc/TextView.h"
 #include "tsutil/ts_diag_levels.h"
+#include "tsutil/YamlCfg.h"
 
 namespace
 {
@@ -360,7 +361,7 @@ std::string
 SSLMultiCertMarshaller::to_json(SSLMultiCertConfig const &config)
 {
   YAML::Emitter json;
-  json << YAML::DoubleQuoted << YAML::Flow;
+  ts::Yaml::configure_json_emitter(json);
   json << YAML::BeginMap;
   json << YAML::Key << KEY_SSL_MULTICERT << YAML::Value << YAML::BeginSeq;
 

--- a/src/config/storage.cc
+++ b/src/config/storage.cc
@@ -37,6 +37,7 @@
 #include "swoc/swoc_file.h"
 #include "tscore/ParseRules.h"
 #include "tsutil/ts_diag_levels.h"
+#include "tsutil/YamlCfg.h"
 
 namespace
 {
@@ -828,7 +829,7 @@ std::string
 StorageMarshaller::to_json(StorageConfig const &config)
 {
   YAML::Emitter out;
-  out << YAML::DoubleQuoted << YAML::Flow;
+  ts::Yaml::configure_json_emitter(out);
   out << YAML::BeginMap;
   out << YAML::Key << KEY_CACHE << YAML::Value << YAML::BeginMap;
 

--- a/src/mgmt/rpc/handlers/hostdb/HostDB.cc
+++ b/src/mgmt/rpc/handlers/hostdb/HostDB.cc
@@ -82,7 +82,7 @@ template <> struct convert<HostDBCache> {
   static Node
   encode(const HostDBCache *const hostDB, std::string_view hostname)
   {
-    Node partitions;
+    Node partitions{YAML::NodeType::Sequence};
     for (size_t i = 0; i < hostDB->refcountcache->partition_count(); i++) {
       auto                                 &partition = hostDB->refcountcache->get_partition(i);
       std::vector<RefCountCacheHashEntry *> partition_entries;

--- a/src/mgmt/rpc/handlers/plugins/Plugins.cc
+++ b/src/mgmt/rpc/handlers/plugins/Plugins.cc
@@ -100,7 +100,7 @@ get_plugin_list(std::string_view const & /* id ATS_UNUSED */, YAML::Node const &
 
     data["source"] = summary.source;
 
-    YAML::Node plugins;
+    YAML::Node plugins{YAML::NodeType::Sequence};
     for (const auto &e : summary.entries) {
       YAML::Node plugin;
 

--- a/src/traffic_ctl/CtrlPrinters.cc
+++ b/src/traffic_ctl/CtrlPrinters.cc
@@ -102,8 +102,7 @@ void
 BasePrinter::write_output_json(YAML::Node const &node) const
 {
   YAML::Emitter out;
-  out.SetNullFormat(YAML::LowerNull);
-  out << YAML::DoubleQuoted << YAML::Flow;
+  ts::Yaml::configure_json_emitter(out);
   out << node;
   std::cout << out.c_str() << '\n';
 }

--- a/src/traffic_ctl/CtrlPrinters.cc
+++ b/src/traffic_ctl/CtrlPrinters.cc
@@ -102,6 +102,7 @@ void
 BasePrinter::write_output_json(YAML::Node const &node) const
 {
   YAML::Emitter out;
+  out.SetNullFormat(YAML::LowerNull);
   out << YAML::DoubleQuoted << YAML::Flow;
   out << node;
   std::cout << out.c_str() << '\n';

--- a/src/traffic_ctl/CtrlPrinters.cc
+++ b/src/traffic_ctl/CtrlPrinters.cc
@@ -24,6 +24,7 @@
 
 #include <swoc/swoc_meta.h>
 #include "tsutil/ts_bw_format.h"
+#include "tsutil/YamlCfg.h"
 
 #include "CtrlPrinters.h"
 #include "jsonrpc/ctrl_yaml_codecs.h"

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_json_null.test.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_json_null.test.py
@@ -55,7 +55,7 @@ traffic_ctl.hostdb().status().validate_is_valid_json()
 
 # ... and it must be an empty array, not null. hostdb_status_schema.json
 # declares partitions as "type": "array".
-traffic_ctl.hostdb().status().validate_json_contains(partitions='[]')
+traffic_ctl.hostdb().status().validate_json_contains(partitions=[])
 
 # -f json goes through the full envelope. Same emitter, different entry point.
 traffic_ctl.hostdb().status().as_json().validate_is_valid_json()

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_json_null.test.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_json_null.test.py
@@ -75,7 +75,17 @@ traffic_ctl.rpc().invoke(handler="get_hostdb_status", params='"hostname: \\"\\""
 # plugin list ignores the format flag today and prints a human table, so only
 # the RPC path is assertable. Once plugin list honours -f json, add:
 #   traffic_ctl.plugin().list().as_json().validate_is_valid_json()
-traffic_ctl.rpc().invoke(handler="admin_plugin_get_list").validate_is_valid_json()
+#
+# Assert the shape rather than mere parseability: `plugins` has to be `[]`,
+# matching what the hostdb case above asserts for `partitions`. The field sits
+# at result.data.plugins, which validate_json_contains cannot reach, so this
+# compares the whole result, as the connection tracker cases in
+# traffic_ctl_server_output.test.py do. Before the fix the field emitted `~`,
+# which fails this comparison as surely as it fails a JSON parser. Nothing
+# forces plugin.config to be empty here, and nothing needs to: should a
+# default ever load a plugin, this assertion fails rather than going quiet.
+traffic_ctl.rpc().invoke(
+    handler="admin_plugin_get_list").validate_result_with_text('{"data": {"source": "plugin.config", "plugins": []}}')
 
 ######
 # Commands that were already valid JSON -- guard against the shared emitter

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_json_null.test.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_json_null.test.py
@@ -1,0 +1,84 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import sys
+
+# To include util classes
+sys.path.insert(0, f'{Test.TestDirectory}')
+
+from traffic_ctl_test_utils import Make_traffic_ctl
+
+Test.Summary = '''
+traffic_ctl JSON output must be parseable JSON, including when a node is null.
+
+yaml-cpp emits null as `~`, which is valid YAML but rejected by every JSON
+parser. Emitters that produce JSON must set YAML::LowerNull, and container
+nodes that may stay empty must be constructed as sequences so they emit `[]`
+rather than null.
+
+The trigger for both regressions is the *empty* case, so this test
+deliberately runs against a freshly started server with an empty HostDB and no
+plugins loaded. A test that populates either one first would pass against the
+bug.
+'''
+
+Test.ContinueOnFail = True
+
+records_yaml = '''
+  exec_thread:
+    autoconfig:
+      enabled: 0
+    limit: 4
+    '''
+
+traffic_ctl = Make_traffic_ctl(Test, records_yaml)
+
+######
+# hostdb status -- `partitions` is empty on a fresh server.
+#
+# Flagless output goes through BasePrinter::write_output_json (the client
+# printer). Before the fix this emitted `"partitions": ~`.
+traffic_ctl.hostdb().status().validate_is_valid_json()
+
+# ... and it must be an empty array, not null. hostdb_status_schema.json
+# declares partitions as "type": "array".
+traffic_ctl.hostdb().status().validate_json_contains(partitions='[]')
+
+# -f json goes through the full envelope. Same emitter, different entry point.
+traffic_ctl.hostdb().status().as_json().validate_is_valid_json()
+
+# The server-side encoder (yamlcpp_json_encoder) is a third, independent
+# emitter. rpc invoke exercises it directly.
+#
+# The params are required: get_hostdb_status without them fails with "invalid
+# node; this may result from using a map iterator as a sequence iterator", and
+# an error envelope is valid JSON no matter what the emitter does -- the
+# assertion would pass against the bug.
+traffic_ctl.rpc().invoke(handler="get_hostdb_status", params='"hostname: \\"\\""').validate_is_valid_json()
+
+######
+# plugin list -- `plugins` is empty when plugin.config loads nothing.
+#
+# plugin list ignores the format flag today and prints a human table, so only
+# the RPC path is assertable. Once plugin list honours -f json, add:
+#   traffic_ctl.plugin().list().as_json().validate_is_valid_json()
+traffic_ctl.rpc().invoke(handler="admin_plugin_get_list").validate_is_valid_json()
+
+######
+# Commands that were already valid JSON -- guard against the shared emitter
+# change regressing them.
+traffic_ctl.server().status().validate_is_valid_json()
+traffic_ctl.rpc().invoke(handler="show_registered_handlers").validate_is_valid_json()

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -117,7 +117,19 @@ def _check_is_valid_json(path):
 
 
 def _check_json_fields(path, expected):
-    """Tester callback: every expected field must match its value in the parsed output."""
+    """Tester callback: every expected field must match its value in the parsed output.
+
+    The expectation is compared against `str()` of the parsed value, so write
+    it the way Python renders that value rather than the way JSON spells it.
+    `[]` and `'[]'` are both fine because they agree, but a JSON boolean reads
+    as `'true'`, not `True`, and a list of strings reads as `"['a']"`, not
+    `'["a"]'`. `validate_result_with_text` does take JSON-spelled text, so the
+    two are not interchangeable.
+
+    A missing key and a JSON `null` both render as `'None'` and cannot be told
+    apart here, which means `field=None` passes for a misspelled `field` too.
+    Asserting a null needs its own `key in doc` check.
+    """
     desc = "Check that the JSON output contains the expected fields"
     raw = _read_stdout(path)
     try:
@@ -125,7 +137,7 @@ def _check_json_fields(path, expected):
     except ValueError as ex:
         return (False, desc, f"Output is not JSON: {ex}\nOutput was:\n{raw}")
 
-    failed = [f"{key} = {doc.get(key)} (expected {value})" for key, value in expected.items() if str(doc.get(key)) != value]
+    failed = [f"{key} = {doc.get(key)} (expected {value})" for key, value in expected.items() if str(doc.get(key)) != str(value)]
     if failed:
         return (False, desc, "FAIL: " + "; ".join(failed) + f"\nOutput was:\n{raw}")
     return (True, desc, "All expected fields matched")

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -124,9 +124,10 @@ def _check_json_fields(path, expected):
     `validate_result_with_text` does take JSON-spelled text, so the two
     helpers are not interchangeable.
 
-    A missing key and a JSON `null` both render as `'None'` and cannot be told
-    apart here, which means `field=None` passes for a misspelled `field` too.
-    Asserting a null needs its own `key in doc` check.
+    A key the output does not carry is reported as missing rather than
+    compared, so a misspelled field name fails instead of quietly matching an
+    expectation of `None`. Asserting that a field is present and null is
+    therefore written `field=None`, which only passes when the key is there.
     """
     desc = "Check that the JSON output contains the expected fields"
     raw, decode_error = _read_stdout(path)
@@ -141,7 +142,10 @@ def _check_json_fields(path, expected):
 
     failed = []
     for key, want in expected.items():
-        actual = doc.get(key)
+        if key not in doc:
+            failed.append(f"{key} is missing (expected {want})")
+            continue
+        actual = doc[key]
         if str(actual) != str(want):
             failed.append(f"{key} = {actual} (expected {want})")
     if failed:

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -64,27 +64,44 @@ def MakeGoldFileWithText(content, dir, test_number, add_new_line=True):
     return gold_filepath
 
 
+# Names autest injects into every test file's globals, which this module needs.
+_INJECTED_NAMES = ('Testers', 'All')
+
+
 def _test_file_globals():
     """Return the globals of the calling test file.
 
-    autest injects `Testers` and `All` into each test file's globals rather
-    than exposing them for import, so a helper module has to reach up the
-    stack to find them. The search walks outward until it reaches a frame
-    that carries the injected names, rather than assuming the immediate
+    autest injects the names in `_INJECTED_NAMES` into each test file's
+    globals rather than exposing them for import, so a helper module has to
+    reach up the stack to find them. The search walks outward until it
+    reaches a frame carrying all of them, rather than assuming the immediate
     caller is the test file. That way it works from inside this module and
-    from any intermediate helper module.
+    from any intermediate helper module, and a frame that carries only some
+    of the names cannot satisfy the search and fail later on the rest.
     """
     frame = sys._getframe(1)
-    while frame is not None and 'Testers' not in frame.f_globals:
+    while frame is not None and not all(name in frame.f_globals for name in _INJECTED_NAMES):
         frame = frame.f_back
     if frame is None:
-        raise RuntimeError('No autest test file frame found. These helpers only work when called from a test file.')
+        raise RuntimeError(
+            f"No autest test file frame found. These helpers only work when called from a test file, "
+            f"whose globals carry {', '.join(_INJECTED_NAMES)}.")
     return frame.f_globals
 
 
 def _read_stdout(path):
-    """Read a captured stream file, tolerating output that is not valid UTF-8."""
-    with open(path, errors='replace') as stream:
+    """Read a captured stream file as UTF-8.
+
+    JSON is defined to be UTF-8, and naming the encoding keeps the decode
+    from following the runner's locale: under `LC_ALL=C` the default is
+    US-ASCII, so identical output bytes would decode differently there.
+
+    Undecodable bytes are replaced rather than raising. autest treats an
+    exception from a tester callback as fatal, setting KillOnFailure and
+    abandoning the rest of the test run, whereas a replaced byte simply
+    fails the JSON parse and is reported with the output attached.
+    """
+    with open(path, encoding='utf-8', errors='replace') as stream:
         return stream.read()
 
 

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -19,8 +19,10 @@ import json
 import os
 import shlex
 import shutil
-import sys
 import tempfile
+
+import autest.testers as Testers
+from autest.testers import All
 
 _gold_tmpdir = None
 
@@ -64,51 +66,39 @@ def MakeGoldFileWithText(content, dir, test_number, add_new_line=True):
     return gold_filepath
 
 
-# Names autest injects into every test file's globals, which this module needs.
-_INJECTED_NAMES = ('Testers', 'All')
-
-
-def _test_file_globals():
-    """Return the globals of the calling test file.
-
-    autest injects the names in `_INJECTED_NAMES` into each test file's
-    globals rather than exposing them for import, so a helper module has to
-    reach up the stack to find them. The search walks outward until it
-    reaches a frame carrying all of them, rather than assuming the immediate
-    caller is the test file. That way it works from inside this module and
-    from any intermediate helper module, and a frame that carries only some
-    of the names cannot satisfy the search and fail later on the rest.
-    """
-    frame = sys._getframe(1)
-    while frame is not None and not all(name in frame.f_globals for name in _INJECTED_NAMES):
-        frame = frame.f_back
-    if frame is None:
-        raise RuntimeError(
-            f"No autest test file frame found. These helpers only work when called from a test file, "
-            f"whose globals carry {', '.join(_INJECTED_NAMES)}.")
-    return frame.f_globals
-
-
 def _read_stdout(path):
-    """Read a captured stream file as UTF-8.
+    """Read a captured stream file as strict UTF-8, as `(text, error)`.
 
-    JSON is defined to be UTF-8, and naming the encoding keeps the decode
-    from following the runner's locale: under `LC_ALL=C` the default is
-    US-ASCII, so identical output bytes would decode differently there.
+    JSON has to be UTF-8, so output that does not decode is not valid JSON
+    either and the callers report it as a failure. Replacing the bad bytes
+    instead would hide exactly that: U+FFFD is a legal character inside a
+    JSON string, so undecodable output would go on to parse cleanly and pass
+    a check whose whole job is to reject output that is not JSON.
 
-    Undecodable bytes are replaced rather than raising. autest treats an
-    exception from a tester callback as fatal, setting KillOnFailure and
-    abandoning the rest of the test run, whereas a replaced byte simply
-    fails the JSON parse and is reported with the output attached.
+    No command wrapped here reaches that branch today. yaml-cpp substitutes
+    U+FFFD itself when writing a double quoted scalar, so traffic_ctl cannot
+    put undecodable bytes on stdout on any of these paths. Decoding strictly
+    states the requirement rather than resting on that staying true.
+
+    The failure comes back as a value rather than an exception because autest
+    treats an exception from a tester callback as fatal, setting KillOnFailure
+    and abandoning the rest of the test run. On failure the text is still
+    rendered, lossily, so the caller can show what arrived.
     """
-    with open(path, encoding='utf-8', errors='replace') as stream:
-        return stream.read()
+    with open(path, 'rb') as stream:
+        raw = stream.read()
+    try:
+        return raw.decode('utf-8'), None
+    except UnicodeDecodeError as ex:
+        return raw.decode('utf-8', errors='replace'), str(ex)
 
 
 def _check_is_valid_json(path):
     """Tester callback: the captured output must parse as JSON."""
     desc = "Check that the output parses as JSON"
-    raw = _read_stdout(path)
+    raw, decode_error = _read_stdout(path)
+    if decode_error:
+        return (False, desc, f"Output is not valid UTF-8, so it is not JSON: {decode_error}\nOutput was:\n{raw}")
     try:
         json.loads(raw)
     except ValueError as ex:
@@ -139,11 +129,15 @@ def _check_json_fields(path, expected):
     Asserting a null needs its own `key in doc` check.
     """
     desc = "Check that the JSON output contains the expected fields"
-    raw = _read_stdout(path)
+    raw, decode_error = _read_stdout(path)
+    if decode_error:
+        return (False, desc, f"Output is not valid UTF-8, so it is not JSON: {decode_error}\nOutput was:\n{raw}")
     try:
         doc = json.loads(raw)
     except ValueError as ex:
         return (False, desc, f"Output is not JSON: {ex}\nOutput was:\n{raw}")
+    if not isinstance(doc, dict):
+        return (False, desc, f"Output is a JSON {type(doc).__name__}, not an object, so it has no fields\nOutput was:\n{raw}")
 
     failed = []
     for key, want in expected.items():
@@ -209,11 +203,8 @@ class Common():
                 "Set proxy.config.diags.debug.enabled"
             )
         """
-        caller_globals = _test_file_globals()
-        _Testers = caller_globals['Testers']
-        _All = caller_globals['All']
-        testers = [_Testers.IncludesExpression(s, f"should contain: {s}") for s in strings]
-        self._tr.Processes.Default.Streams.stdout = _All(*testers)
+        testers = [Testers.IncludesExpression(s, f"should contain: {s}") for s in strings]
+        self._tr.Processes.Default.Streams.stdout = All(*testers)
         self._finish()
         return self
 
@@ -247,8 +238,7 @@ class Common():
                 initialized_done='true', is_draining='false'
             )
         """
-        _Testers = _test_file_globals()['Testers']
-        self._tr.Processes.Default.Streams.stdout = _Testers.Lambda(
+        self._tr.Processes.Default.Streams.stdout = Testers.Lambda(
             lambda info, tester: _check_json_fields(tester.GetContent(info), field_checks))
         self._finish()
         return self
@@ -269,8 +259,7 @@ class Common():
         Example:
             traffic_ctl.hostdb().status().validate_is_valid_json()
         """
-        _Testers = _test_file_globals()['Testers']
-        self._tr.Processes.Default.Streams.stdout = _Testers.Lambda(
+        self._tr.Processes.Default.Streams.stdout = Testers.Lambda(
             lambda info, tester: _check_is_valid_json(tester.GetContent(info)))
         self._finish()
         return self

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -121,10 +121,18 @@ def _check_json_fields(path, expected):
 
     The expectation is compared against `str()` of the parsed value, so write
     it the way Python renders that value rather than the way JSON spells it.
-    `[]` and `'[]'` are both fine because they agree, but a JSON boolean reads
-    as `'true'`, not `True`, and a list of strings reads as `"['a']"`, not
-    `'["a"]'`. `validate_result_with_text` does take JSON-spelled text, so the
-    two are not interchangeable.
+    `[]` and `'[]'` agree, but a list of strings renders as `"['a']"`, not
+    `'["a"]'`.
+
+    Booleans need care, because the emitters these tests cover set
+    `YAML::DoubleQuoted` and so encode every scalar as a JSON string.
+    `get_server_status` sends `"is_draining": "false"`, which parses to the
+    string `'false'` and is matched by `is_draining='false'`. A genuine JSON
+    boolean would instead parse to Python `True` or `False` and render as
+    `'True'` or `'False'`.
+
+    `validate_result_with_text` does take JSON-spelled text, so the two
+    helpers are not interchangeable.
 
     A missing key and a JSON `null` both render as `'None'` and cannot be told
     apart here, which means `field=None` passes for a misspelled `field` too.
@@ -137,7 +145,11 @@ def _check_json_fields(path, expected):
     except ValueError as ex:
         return (False, desc, f"Output is not JSON: {ex}\nOutput was:\n{raw}")
 
-    failed = [f"{key} = {doc.get(key)} (expected {value})" for key, value in expected.items() if str(doc.get(key)) != str(value)]
+    failed = []
+    for key, want in expected.items():
+        actual = doc.get(key)
+        if str(actual) != str(want):
+            failed.append(f"{key} = {actual} (expected {want})")
     if failed:
         return (False, desc, "FAIL: " + "; ".join(failed) + f"\nOutput was:\n{raw}")
     return (True, desc, "All expected fields matched")

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -165,6 +165,30 @@ class Common():
         self._finish()
         return self
 
+    def validate_is_valid_json(self):
+        """
+        Validate that stdout parses as JSON. Performs no field checks.
+
+        Use this as a regression guard on any command documented to emit JSON.
+        A gold file cannot do this job: yaml-cpp spells null as `~`, which a
+        gold file matches happily but no JSON parser accepts.
+
+        The raw output is echoed to stderr so it survives in the stream files
+        even though the pipeline consumes stdout.
+
+        Example:
+            traffic_ctl.hostdb().status().validate_is_valid_json()
+        """
+        self._cmd = (
+            f'{self._cmd} | python3 -c "'
+            f"import sys, json; "
+            f"raw = sys.stdin.read(); "
+            f"sys.stderr.write(raw); "
+            f"json.loads(raw)"
+            f'"')
+        self._finish()
+        return self
+
 
 class ConfigReload(Common):
     """
@@ -467,6 +491,48 @@ class RPC(Common):
         return self
 
 
+class HostDB(Common):
+    """
+        Handy class to map traffic_ctl hostdb options.
+    """
+
+    def __init__(self, dir, tr, tn):
+        super().__init__(tr)
+        self._cmd = "traffic_ctl hostdb "
+        self._dir = dir
+        self._tn = tn
+
+    def status(self, hostname: str = ""):
+        """Get HostDB info (traffic_ctl hostdb status [HOSTNAME])"""
+        self._cmd = f'{self._cmd} status {hostname} '
+        return self
+
+    def as_json(self):
+        self._cmd = f'{self._cmd} -f json'
+        return self
+
+
+class Plugin(Common):
+    """
+        Handy class to map traffic_ctl plugin options.
+    """
+
+    def __init__(self, dir, tr, tn):
+        super().__init__(tr)
+        self._cmd = "traffic_ctl plugin "
+        self._dir = dir
+        self._tn = tn
+
+    def list(self):
+        """Show globally loaded plugins and their status (traffic_ctl plugin list)"""
+        self._cmd = f'{self._cmd} list '
+        return self
+
+    def as_json(self):
+        self._cmd = f'{self._cmd} -f json'
+        return self
+
+
 '''
 
 Handy wrapper around traffic_ctl, ATS and the autest output validation mechanism.
@@ -533,6 +599,14 @@ class TrafficCtl(Config, Server):
     def rpc(self):
         self.add_test()
         return RPC(self._Test.TestDirectory, self._tests[self.__get_index()], self._testNumber)
+
+    def hostdb(self):
+        self.add_test()
+        return HostDB(self._Test.TestDirectory, self._tests[self.__get_index()], self._testNumber)
+
+    def plugin(self):
+        self.add_test()
+        return Plugin(self._Test.TestDirectory, self._tests[self.__get_index()], self._testNumber)
 
 
 def Make_traffic_ctl(test, records_yaml=None, retcode=0):

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -109,17 +109,19 @@ def _check_is_valid_json(path):
 def _check_json_fields(path, expected):
     """Tester callback: every expected field must match its value in the parsed output.
 
-    The expectation is compared against `str()` of the parsed value, so write
-    it the way Python renders that value rather than the way JSON spells it.
-    `[]` and `'[]'` agree, but a list of strings renders as `"['a']"`, not
-    `'["a"]'`.
+    The expectation is compared to the parsed value with `==`, so write it as
+    the Python value the JSON parses to: `[]` for a JSON array, `'[]'` only
+    for the JSON string `"[]"`. Comparing `str()` of both sides instead would
+    equate those two and let a field regress from an array to a string
+    without failing, which is the class of bug these tests exist to catch.
 
-    Booleans need care, because the emitters these tests cover set
-    `YAML::DoubleQuoted` and so encode every scalar as a JSON string.
-    `get_server_status` sends `"is_draining": "false"`, which parses to the
-    string `'false'` and is matched by `is_draining='false'`. A genuine JSON
-    boolean would instead parse to Python `True` or `False` and render as
-    `'True'` or `'False'`.
+    Scalars and sequences therefore read differently. The emitters these
+    tests cover set `YAML::DoubleQuoted`, which encodes every *scalar* as a
+    JSON string: `get_server_status` sends `"is_draining": "false"`, matched
+    by `is_draining='false'`. A genuine JSON boolean would parse to Python
+    `True` or `False` and needs `is_draining=False`. A sequence is not a
+    scalar and is untouched by `DoubleQuoted`, so `hostdb status` sends a
+    real `"partitions": []`, matched by `partitions=[]`.
 
     `validate_result_with_text` does take JSON-spelled text, so the two
     helpers are not interchangeable.
@@ -143,11 +145,11 @@ def _check_json_fields(path, expected):
     failed = []
     for key, want in expected.items():
         if key not in doc:
-            failed.append(f"{key} is missing (expected {want})")
+            failed.append(f"{key} is missing (expected {want!r})")
             continue
         actual = doc[key]
-        if str(actual) != str(want):
-            failed.append(f"{key} = {actual} (expected {want})")
+        if actual != want:
+            failed.append(f"{key} = {actual!r} (expected {want!r})")
     if failed:
         return (False, desc, "FAIL: " + "; ".join(failed) + f"\nOutput was:\n{raw}")
     return (True, desc, "All expected fields matched")

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -15,8 +15,11 @@
 #  limitations under the License.
 
 import atexit
+import json
 import os
+import shlex
 import shutil
+import sys
 import tempfile
 
 _gold_tmpdir = None
@@ -59,6 +62,56 @@ def MakeGoldFileWithText(content, dir, test_number, add_new_line=True):
         gold_file.write(content)
 
     return gold_filepath
+
+
+def _test_file_globals():
+    """Return the globals of the calling test file.
+
+    autest injects `Testers` and `All` into each test file's globals rather
+    than exposing them for import, so a helper module has to reach up the
+    stack to find them. The search walks outward until it reaches a frame
+    that carries the injected names, rather than assuming the immediate
+    caller is the test file. That way it works from inside this module and
+    from any intermediate helper module.
+    """
+    frame = sys._getframe(1)
+    while frame is not None and 'Testers' not in frame.f_globals:
+        frame = frame.f_back
+    if frame is None:
+        raise RuntimeError('No autest test file frame found. These helpers only work when called from a test file.')
+    return frame.f_globals
+
+
+def _read_stdout(path):
+    """Read a captured stream file, tolerating output that is not valid UTF-8."""
+    with open(path, errors='replace') as stream:
+        return stream.read()
+
+
+def _check_is_valid_json(path):
+    """Tester callback: the captured output must parse as JSON."""
+    desc = "Check that the output parses as JSON"
+    raw = _read_stdout(path)
+    try:
+        json.loads(raw)
+    except ValueError as ex:
+        return (False, desc, f"Output is not JSON: {ex}\nOutput was:\n{raw}")
+    return (True, desc, "Output parses as JSON")
+
+
+def _check_json_fields(path, expected):
+    """Tester callback: every expected field must match its value in the parsed output."""
+    desc = "Check that the JSON output contains the expected fields"
+    raw = _read_stdout(path)
+    try:
+        doc = json.loads(raw)
+    except ValueError as ex:
+        return (False, desc, f"Output is not JSON: {ex}\nOutput was:\n{raw}")
+
+    failed = [f"{key} = {doc.get(key)} (expected {value})" for key, value in expected.items() if str(doc.get(key)) != value]
+    if failed:
+        return (False, desc, "FAIL: " + "; ".join(failed) + f"\nOutput was:\n{raw}")
+    return (True, desc, "All expected fields matched")
 
 
 class Common():
@@ -115,9 +168,7 @@ class Common():
                 "Set proxy.config.diags.debug.enabled"
             )
         """
-        import sys
-        # Testers and All are injected by autest into the test file's globals
-        caller_globals = sys._getframe(1).f_globals
+        caller_globals = _test_file_globals()
         _Testers = caller_globals['Testers']
         _All = caller_globals['All']
         testers = [_Testers.IncludesExpression(s, f"should contain: {s}") for s in strings]
@@ -142,26 +193,22 @@ class Common():
     def validate_json_contains(self, **field_checks):
         """
         Validate JSON output contains specific field:value pairs. Only checks specified fields.
-        Prints detailed error on failure: "FAIL: field_name = actual_value (expected expected_value)"
-        stream.all.txt will contain the actual output with the failed fields.
+        Every mismatch is reported as "field_name = actual_value (expected expected_value)",
+        followed by the raw output.
+
+        The check runs in the autest process against the captured stdout file. Piping
+        traffic_ctl into a JSON parser instead would hide failures: the exit status of a shell
+        pipeline is the parser's, so a non-zero traffic_ctl exit would never reach the
+        ReturnCode check.
 
         Example:
             traffic_ctl.server().status().validate_json_contains(
                 initialized_done='true', is_draining='false'
             )
         """
-        import json
-        checks_str = ', '.join(f"'{k}': '{v}'" for k, v in field_checks.items())
-        self._cmd = (
-            f'{self._cmd} | python3 -c "'
-            f"import sys, json; "
-            f"d = json.load(sys.stdin); "
-            f"c = {{{checks_str}}}; "
-            f"failed = [(k, v, str(d.get(k))) for k, v in c.items() if str(d.get(k)) != v]; "
-            f"[print(f'FAIL: {{k}} = {{actual}} (expected {{expected}})', file=sys.stderr) "
-            f"for k, expected, actual in failed]; "
-            f"exit(0 if not failed else 1)"
-            f'"')
+        _Testers = _test_file_globals()['Testers']
+        self._tr.Processes.Default.Streams.stdout = _Testers.Lambda(
+            lambda info, tester: _check_json_fields(tester.GetContent(info), field_checks))
         self._finish()
         return self
 
@@ -173,19 +220,17 @@ class Common():
         A gold file cannot do this job: yaml-cpp spells null as `~`, which a
         gold file matches happily but no JSON parser accepts.
 
-        The raw output is echoed to stderr so it survives in the stream files
-        even though the pipeline consumes stdout.
+        The check runs in the autest process against the captured stdout file, so
+        traffic_ctl stays the only process in the test run and the exit status the
+        harness compares against ReturnCode is still traffic_ctl's own. The raw
+        output is reported on failure.
 
         Example:
             traffic_ctl.hostdb().status().validate_is_valid_json()
         """
-        self._cmd = (
-            f'{self._cmd} | python3 -c "'
-            f"import sys, json; "
-            f"raw = sys.stdin.read(); "
-            f"sys.stderr.write(raw); "
-            f"json.loads(raw)"
-            f'"')
+        _Testers = _test_file_globals()['Testers']
+        self._tr.Processes.Default.Streams.stdout = _Testers.Lambda(
+            lambda info, tester: _check_is_valid_json(tester.GetContent(info)))
         self._finish()
         return self
 
@@ -503,8 +548,13 @@ class HostDB(Common):
         self._tn = tn
 
     def status(self, hostname: str = ""):
-        """Get HostDB info (traffic_ctl hostdb status [HOSTNAME])"""
-        self._cmd = f'{self._cmd} status {hostname} '
+        """Get HostDB info (traffic_ctl hostdb status [HOSTNAME])
+
+        The hostname is shell quoted. It is omitted entirely when empty, since
+        passing an empty argument is not the same as passing none.
+        """
+        arg = f' {shlex.quote(hostname)}' if hostname else ''
+        self._cmd = f'{self._cmd} status{arg} '
         return self
 
     def as_json(self):


### PR DESCRIPTION
## What

`traffic_ctl` advertises JSON output but emits YAML. The JSON encoders are
yaml-cpp emitters configured with `YAML::DoubleQuoted << YAML::Flow`, which
produces something that *usually* looks like JSON — until a value is null,
which yaml-cpp spells `~`.

`traffic_ctl hostdb status` hits this on every freshly started server, in both
default and `-f json` mode, and **exits 0** while doing it. A monitoring script
or dashboard sees success, then dies on the parse.

```console
$ traffic_ctl hostdb status
{"metadata": {"timestamp": "...", "version": "..."}, "partitions": ~}
$ echo $?
0

$ traffic_ctl hostdb status | python3 -c 'import json,sys; json.load(sys.stdin)'
json.decoder.JSONDecodeError: Expecting value: line 1 column 160 (char 159)
```

The `-f rpc` wire trace shows the `~` arrives already formed from the server, so
this is not a client-side rendering problem:

```console
$ traffic_ctl hostdb status -f rpc
--> {"id": "...", "jsonrpc": "2.0", "method": "get_hostdb_status", "params": {"hostname": ""}}
<-- {"jsonrpc": "2.0", "result": {"data": {"metadata": {...}, "partitions": ~}}, "id": "..."}
```

`traffic_ctl plugin list` has the same defect when `plugin.config` is empty.

### It also violates its own schema

`src/mgmt/rpc/schema/hostdb_status_schema.json` declares `partitions` as
`"type": "array"`. Validating the live payload against that schema:

```
json.loads      : FAIL -> Expecting value: line 1 column 198 (char 197)
yaml.safe_load  : OK -> partitions=None timestamp='1788196772'
jsonschema      : 2 violation(s)
   /metadata/timestamp : '1788196772' is not of type 'integer'
   /partitions : None is not of type 'array'
```

`yaml.safe_load` succeeding where `json.loads` fails is the whole bug in one
line: this is YAML labelled as JSON.

## Why it happens

Two independent layers.

**Layer 1 — the accumulator node is never initialised as a sequence.** A
default-constructed `YAML::Node` is Null, not an empty Sequence. In
`HostDB.cc`, if every partition is empty the `push_back` loop never runs, so
`partitions` is emitted as null. `Plugins.cc` has the identical shape.

**Layer 2 — there is no JSON serializer.** Six sites each re-implemented "JSON"
as a yaml-cpp emitter with two manipulators, and none of them mapped null to
`null`.

This is a known limitation finally coming due. Standing comment in
`YAMLCodec.h`:

> yamlcpp does not give us all the behavior we need, such as the way it handles
> the null values. Json needs to use literal null and yamlcpp uses ~. If this
> becomes a problem, then we may need to change the codec implementation

A second comment in the same file omits the response `id` rather than emit it
as null, specifically to dodge this. Every other null in every other payload
was still exposed.

## The fix

Three commits.

**1. Emit `null` instead of `~`, and `[]` for empty accumulators.**

- Initialise the two accumulator nodes as sequences, so an empty result is `[]`.
  This is what makes the payload schema-conformant — `null` would still not be
  an array.
- Set `LowerNull` on the JSON emitters, so any *remaining* null anywhere in any
  payload is spelled `null`. This fixes the class of bug, not just the two
  observed instances.

**2. Route every JSON emitter through one helper.**

The first commit set `LowerNull` at the four emitters on the RPC path, but
`SSLMultiCertMarshaller::to_json` and `StorageMarshaller::to_json` build their
own emitters off that path and were missed. Neither can emit a null today, so
nothing was broken, but both were one null away from the same bug.

`ts::Yaml::configure_json_emitter()` in `include/tsutil/YamlCfg.h` is now the
single place that puts an emitter into JSON mode. The invariant is greppable:

```console
$ git grep -n 'SetNullFormat\|YAML::DoubleQuoted' -- src/ include/
include/tsutil/YamlCfg.h:54:    emitter.SetNullFormat(YAML::LowerNull);
include/tsutil/YamlCfg.h:55:    emitter << YAML::DoubleQuoted << YAML::Flow;
```

**3. Review fixes.** Direct include of `tsutil/YamlCfg.h` in `CtrlPrinters.cc`
rather than relying on a transitive one, and corrected comment wording — the
helper comment had overstated the output as valid JSON for every node type but
null, which holds only for the node shapes these callers build. Tags, anchors
and aliases still emit YAML that JSON does not accept.

`LowerNull` and `Emitter::SetNullFormat` exist both in the in-tree yaml-cpp
0.9.0 and in 0.8.0, the minimum `EXTERNAL_YAML_CPP` accepts, so both build
configurations are covered. `SetNullFormat(...)` is used rather than the
`<< YAML::LowerNull` manipulator because the method is `FmtScope::Global` while
the stream form routes through `SetLocalValue` at `FmtScope::Local`.

## Compatibility

**This does not trade YAML support for JSON support.** In YAML, `~` and `null`
are the same value — YAML 1.2 resolves `~`, `null`, `Null`, `NULL` and empty all
to null, and yaml-cpp implements exactly that:

```cpp
bool IsNullString(const char* str, std::size_t size) {
  return size == 0 || same(str, size, "~") || same(str, size, "null") ||
         same(str, size, "Null") || same(str, size, "NULL");
}
```

The two spellings differ only in portability:

| Spelling | Valid YAML | Valid JSON |
| --- | --- | --- |
| `~` | yes | **no** |
| `null` | yes | yes |

`null` is the strict superset, so this moves the output into the intersection of
both formats rather than favouring one. Verified by round-trip: emitting with
`LowerNull` produces `{"a": null}`, which re-parses through yaml-cpp as
`IsNull() == true` — a genuine null, not the string `"null"`.

`LowerNull` changes nothing else. Same node set emitted both ways:

| Field | Before | After |
| --- | --- | --- |
| null node | `~` | **`null`** |
| empty sequence | `[]` | `[]` |
| empty map | `{}` | `{}` |
| string `"~"` | `"~"` | `"~"` |
| string `"null"` | `"null"` | `"null"` |
| number, bool, empty string | unchanged | unchanged |

Specifically unaffected:

- **YAML input.** The architecture doc's yamlcpp rationale is about the server
  *accepting* JSON or YAML. This changes encoders only; the decoder and
  `YAML::Load` path are untouched.
- **`jsonrpc_response_schema.json`.** It places no type constraint on `result`.
  The `id` field keeps its documented deviation — still omitted, not nulled.
- **Existing tests.** No gold file in `tests/` contains a tilde.

The only conceivable breakage is a consumer string-matching `~`, which would be
a consumer hand-parsing invalid JSON. No metric names, config keys, or API
signatures change.

## Testing

| Check | Before | After |
| --- | --- | --- |
| `hostdb status` human | `"partitions": ~`, exit 0 | `"partitions": []` |
| `hostdb status` → `json.load` | `JSONDecodeError` col 160 | parses |
| `hostdb status -f json` → `json.load` | `JSONDecodeError` col 198 | parses |
| wire trace `-f rpc` | `"partitions": ~` | `"partitions": []` |
| jsonschema violations | 2 | 1 (see below) |
| `plugin list`, empty `plugin.config` | `"plugins": ~` | `"plugins": []` |
| `plugin list`, plugins loaded | ok | ok, unregressed |
| `config ssl-multicert show --json` | ok | ok, now via the helper |
| unit test suite | — | 167/167 |
| autests (14, incl. `jsonrpc_api_schema`) | — | 13 pass |
| `format` target | — | clean |

**Both layers were verified independently.** To prove the emitter change on its
own, the sequence-init hunk was reverted and the build rerun, exercising the
untouched uninitialised-node path:

```console
<-- {"jsonrpc": "2.0", "result": {"data": {"source": "plugin.config", "plugins": null}}, "id": "..."}
PARSED OK -> plugins = None
```

`null` rather than `~`, and it parses.

The one autest failure is `basic_plugin_handler`, which fails identically on
unmodified `master` — three plugin init strings never reach `traffic.out` on
macOS. Confirmed by building pristine `d01f3caf6a` and running it there.

## Still to do

No autest asserts that `-f json` output parses. That gap is why the tilde
shipped green: the suite's only JSON parse assertions are
`validate_json_contains` (used twice, both on `server status`) and the JSONRPC
response validator, and none of them exercises a payload containing a null.
`hostdb status` and `plugin list` have no autest coverage at all. A gold file
would not help — it would have matched `~` indefinitely, so the assertion has to
be a real parse on the empty-HostDB and no-plugins cases.

Candidate for **Backport** to 10.2.x, where `hostdb status` first shipped.

## Out of scope

`hostdb status` still emits `"timestamp": "1788196772"` — a string where the
schema declares `integer`. This is the remaining schema violation above.
`YAML::DoubleQuoted` quotes every scalar, so *every* numeric field in *every*
`-f json` payload is a JSON string. Dropping `DoubleQuoted` is not a fix —
yaml-cpp would then emit unquoted strings and break JSON differently. Needs its
own design decision and a separate issue.

`traffic_ctl plugin list -f json` ignores the format flag and prints the
human-readable table. Unrelated to this change; present before and after.
