### PR TITLE
Add ENABLE_UBSAN build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ auto_option(UNWIND FEATURE_VAR TS_USE_REMOTE_UNWINDING PACKAGE_DEPENDS unwind)
 
 option(ENABLE_ASAN "Use address sanitizer (default OFF)")
 option(ENABLE_TSAN "Use thread sanitizer (default OFF)")
+option(ENABLE_UBSAN "Use undefined behavior sanitizer (default OFF)")
 option(ENABLE_FUZZING "Enable fuzzing (default OFF)")
 option(ENABLE_FIPS "Enable fips compliance (default OFF)")
 option(ENABLE_EVENT_TRACKER "Enable event tracking (default OFF)")
@@ -447,6 +448,23 @@ elseif(ENABLE_TSAN)
   endif()
   add_compile_options(-g -fsanitize=thread -fno-omit-frame-pointer)
   add_link_options(-g -fsanitize=thread)
+endif()
+
+# UndefinedBehaviorSanitizer. Deliberately not part of the either/or chain above:
+# UBSan instruments arithmetic, shifts, and type loads rather than replacing the
+# allocator or the thread runtime, so it composes with an asan build
+# (-fsanitize=address,undefined) as well as standing on its own.
+#
+# vptr is excluded. It needs a matching type_info at every polymorphic access, and
+# a plugin loaded with dlopen does not reliably share type identity with the main
+# image, so the check reports the plugin boundary rather than a real bug.
+#
+# Findings are non-fatal by default so a single run reports every distinct site
+# instead of stopping at the first. Set UBSAN_OPTIONS=halt_on_error=1 at runtime
+# to abort instead, which is what a gating job would want.
+if(ENABLE_UBSAN)
+  add_compile_options(-g -fsanitize=undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
+  add_link_options(-g -fsanitize=undefined -fno-sanitize=vptr)
 endif()
 
 # Clang Thread Safety Analysis. The TS_* annotations (tsutil/ts_thread_safety.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,8 +452,10 @@ endif()
 
 # UndefinedBehaviorSanitizer. Deliberately not part of the either/or chain above:
 # UBSan instruments arithmetic, shifts, and type loads rather than replacing the
-# allocator or the thread runtime, so it composes with an asan build
-# (-fsanitize=address,undefined) as well as standing on its own.
+# allocator or the thread runtime, so it composes with either of them as well as
+# standing on its own: asan gives -fsanitize=address,undefined and tsan gives
+# -fsanitize=thread,undefined. Only the asan pairing has a preset, since that is
+# the combination developers ask for, but the option itself does not restrict it.
 #
 # vptr is excluded. It needs a matching type_info at every polymorphic access, and
 # a plugin loaded with dlopen does not reliably share type identity with the main
@@ -466,16 +468,17 @@ endif()
 # Set UBSAN_OPTIONS=halt_on_error=1 at runtime to stop on the first finding, which
 # is what a gating job would want.
 if(ENABLE_UBSAN)
-  # The checks are instrumentation, but they call into a runtime library that some
-  # distributions package separately from the compiler (libubsan for GCC). Without it
-  # the build gets a bare "cannot find libubsan.so" from the linker after compiling
-  # hundreds of objects, so establish it here and name what is missing.
+  # This can fail two ways: the toolchain does not know -fsanitize=undefined at all,
+  # or it knows the flag but cannot link the runtime library, which some distributions
+  # package separately from the compiler. Without the check the second case surfaces as
+  # a bare "cannot find libubsan.so" from the linker after compiling hundreds of
+  # objects, so establish it here and let the message cover both.
   include(CheckLinkerFlag)
-  check_linker_flag(CXX -fsanitize=undefined HAS_UBSAN_RUNTIME)
-  if(NOT HAS_UBSAN_RUNTIME)
+  check_linker_flag(CXX -fsanitize=undefined HAS_UBSAN_SUPPORT)
+  if(NOT HAS_UBSAN_SUPPORT)
     message(
       FATAL_ERROR
-        "ENABLE_UBSAN needs the undefined behavior sanitizer runtime, which this toolchain cannot link. On GCC that runtime is the libubsan package."
+        "ENABLE_UBSAN was requested, but this toolchain cannot link -fsanitize=undefined. Either the compiler does not support the flag, or it does and the sanitizer runtime is missing. If the compiler is GCC, that runtime is the libubsan package."
     )
   endif()
   add_compile_options(-g -fsanitize=undefined -fno-sanitize=vptr -fsanitize-recover=undefined -fno-omit-frame-pointer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ if(ENABLE_UBSAN)
   if(NOT HAS_UBSAN_SUPPORT)
     message(
       FATAL_ERROR
-        "ENABLE_UBSAN was requested, but this toolchain cannot link -fsanitize=undefined. Either the compiler does not support the flag, or it does and the sanitizer runtime is missing. If the compiler is GCC, that runtime is the libubsan package."
+        "ENABLE_UBSAN was requested, but this toolchain cannot link -fsanitize=undefined. Either the compiler does not support the flag, or it does and the sanitizer runtime is missing. GCC ships that runtime in a package separate from the compiler on most distributions, under a name that varies by distribution."
     )
   endif()
   add_compile_options(-g -fsanitize=undefined -fno-sanitize=vptr -fsanitize-recover=undefined -fno-omit-frame-pointer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,9 +459,12 @@ endif()
 # a plugin loaded with dlopen does not reliably share type identity with the main
 # image, so the check reports the plugin boundary rather than a real bug.
 #
-# Findings are non-fatal by default so a single run reports every distinct site
-# instead of stopping at the first. Set UBSAN_OPTIONS=halt_on_error=1 at runtime
-# to abort instead, which is what a gating job would want.
+# Findings recover, so a single run reports every distinct site instead of stopping
+# at the first. That is the default for most checks, but which checks recover by
+# default varies between compilers, so ask for it explicitly rather than inherit it.
+# A few checks cannot recover by construction (unreachable, return) and still abort.
+# Set UBSAN_OPTIONS=halt_on_error=1 at runtime to stop on the first finding, which
+# is what a gating job would want.
 if(ENABLE_UBSAN)
   # The checks are instrumentation, but they call into a runtime library that some
   # distributions package separately from the compiler (libubsan for GCC). Without it
@@ -475,8 +478,10 @@ if(ENABLE_UBSAN)
         "ENABLE_UBSAN needs the undefined behavior sanitizer runtime, which this toolchain cannot link. On GCC that runtime is the libubsan package."
     )
   endif()
-  add_compile_options(-g -fsanitize=undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
-  add_link_options(-g -fsanitize=undefined -fno-sanitize=vptr)
+  add_compile_options(-g -fsanitize=undefined -fno-sanitize=vptr -fsanitize-recover=undefined -fno-omit-frame-pointer)
+  # Only -fsanitize=undefined matters at link time, to pull in the runtime. The vptr
+  # and recover flags are compile time instrumentation controls and do nothing here.
+  add_link_options(-g -fsanitize=undefined)
 endif()
 
 # Clang Thread Safety Analysis. The TS_* annotations (tsutil/ts_thread_safety.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,18 @@ endif()
 # instead of stopping at the first. Set UBSAN_OPTIONS=halt_on_error=1 at runtime
 # to abort instead, which is what a gating job would want.
 if(ENABLE_UBSAN)
+  # The checks are instrumentation, but they call into a runtime library that some
+  # distributions package separately from the compiler (libubsan for GCC). Without it
+  # the build gets a bare "cannot find libubsan.so" from the linker after compiling
+  # hundreds of objects, so establish it here and name what is missing.
+  include(CheckLinkerFlag)
+  check_linker_flag(CXX -fsanitize=undefined HAS_UBSAN_RUNTIME)
+  if(NOT HAS_UBSAN_RUNTIME)
+    message(
+      FATAL_ERROR
+        "ENABLE_UBSAN needs the undefined behavior sanitizer runtime, which this toolchain cannot link. On GCC that runtime is the libubsan package."
+    )
+  endif()
   add_compile_options(-g -fsanitize=undefined -fno-sanitize=vptr -fno-omit-frame-pointer)
   add_link_options(-g -fsanitize=undefined -fno-sanitize=vptr)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -103,6 +103,13 @@
       }
     },
     {
+      "name": "ubsan",
+      "hidden": true,
+      "cacheVariables": {
+        "ENABLE_UBSAN": "ON"
+      }
+    },
+    {
       "name": "hardened",
       "hidden": true,
       "cacheVariables": {
@@ -115,6 +122,18 @@
       "displayName": "dev with asan",
       "description": "Development Presets with ASAN sanitizer",
       "inherits": ["dev", "asan"]
+    },
+    {
+      "name": "dev-ubsan",
+      "displayName": "dev with ubsan",
+      "description": "Development Presets with UndefinedBehaviorSanitizer",
+      "inherits": ["dev", "ubsan"]
+    },
+    {
+      "name": "dev-asan-ubsan",
+      "displayName": "dev with asan and ubsan",
+      "description": "Development Presets with both AddressSanitizer and UndefinedBehaviorSanitizer",
+      "inherits": ["dev", "asan", "ubsan"]
     },
     {
       "name": "ci",


### PR DESCRIPTION
Adds UndefinedBehaviorSanitizer as a build option next to `ENABLE_ASAN` and `ENABLE_TSAN`, with a hidden `ubsan` preset plus `dev-ubsan` and `dev-asan-ubsan`.

It sits outside the asan/tsan either-or chain on purpose. ASAN replaces the allocator and TSAN the thread runtime, so those two are exclusive, but UBSan only instruments arithmetic, shifts, and type loads, so it composes with either.

`vptr` is excluded: it needs a matching `type_info` at every polymorphic access, and a plugin loaded with `dlopen` does not reliably share type identity with the main image, so it reports the plugin boundary rather than a real defect.

Recovery is requested explicitly so a run reports every site instead of stopping at the first, since which checks recover by default varies between compilers. `UBSAN_OPTIONS=halt_on_error=1` aborts instead, which is what a gating job would want.

Configuration fails up front when the runtime cannot be linked. Some distributions package it separately from the compiler, and without the check that surfaces as a bare `cannot find libubsan.so` after hundreds of objects, with nothing tying it to the option.

No CI job turns this on; enabling it anywhere would be a separate change.

### Testing

Configured and built with clang 22 on Fedora 44 using `dev-ubsan` with autest and experimental plugins enabled. Build and install clean, `ctest` 179/179, and the binary links the UBSan runtime handlers. On the current tree it finds real defects (a misaligned polymorphic hasher buffer on the URL hash path, and a `TSPluginInit` signature mismatch); those fixes are separate PRs.

<!-- merge-description-updated:2026-09-15T18:15:22Z -->
