### PR TITLE
clang-tidy: misc-redundant-expression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,7 @@ Checks: >-
   bugprone-use-after-move,
   google-readability-braces-around-statements,
   google-readability-casting,
+  misc-redundant-expression,
   modernize-deprecated-headers,
   modernize-loop-convert,
   modernize-raw-string-literal,

--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -33,6 +33,7 @@ Checks: >-
   bugprone-unique-ptr-array-mismatch,
   bugprone-unused-raii,
   bugprone-use-after-move,
+  misc-redundant-expression,
   performance-faster-string-find,
   performance-inefficient-algorithm,
   performance-inefficient-vector-operation,

--- a/include/proxy/logging/Log.h
+++ b/include/proxy/logging/Log.h
@@ -234,5 +234,5 @@ LogThrottlingIsValid(int throttling_val)
 static inline bool
 LogRollingEnabledIsValid(int enabled)
 {
-  return (enabled >= Log::NO_ROLLING || enabled < Log::INVALID_ROLLING_VALUE); // lgtm[cpp/constant-comparison]
+  return enabled >= Log::NO_ROLLING && enabled < Log::INVALID_ROLLING_VALUE;
 }

--- a/plugins/esi/combo_handler.cc
+++ b/plugins/esi/combo_handler.cc
@@ -272,7 +272,7 @@ CacheControlHeader::update(TSMBuffer bufp, TSMLoc hdr_loc)
   TSMLoc field_loc = TSMimeHdrFieldFind(bufp, hdr_loc, TS_MIME_FIELD_CACHE_CONTROL, TS_MIME_LEN_CACHE_CONTROL);
   if (field_loc != TS_NULL_MLOC) {
     int n_values = TSMimeHdrFieldValuesCount(bufp, hdr_loc, field_loc);
-    if ((n_values != TS_ERROR) && (n_values > 0)) {
+    if (n_values > 0) {
       for (int i = 0; i < n_values; i++) {
         // Grab this current header value
         int         _val_len = 0;
@@ -996,7 +996,7 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
         if (field_loc != TS_NULL_MLOC) {
           time_t curr_field_expires_time;
           int    n_values = TSMimeHdrFieldValuesCount(resp_data.bufp, resp_data.hdr_loc, field_loc);
-          if ((n_values != TS_ERROR) && (n_values > 0)) {
+          if (n_values > 0) {
             curr_field_expires_time = TSMimeHdrFieldValueDateGet(resp_data.bufp, resp_data.hdr_loc, field_loc);
             if (!got_expires_time) {
               expires_time     = curr_field_expires_time;
@@ -1021,7 +1021,7 @@ prepareResponse(InterceptData &int_data, ByteBlockList &body_blocks, string &res
             const char *value;
             int         value_len;
             int         n_values = TSMimeHdrFieldValuesCount(resp_data.bufp, resp_data.hdr_loc, field_loc);
-            if ((n_values != TS_ERROR) && (n_values > 0)) {
+            if (n_values > 0) {
               for (int k = 0; k < n_values; k++) {
                 value = TSMimeHdrFieldValueStringGet(resp_data.bufp, resp_data.hdr_loc, field_loc, k, &value_len);
                 if (!values_added) {

--- a/plugins/esi/esi.cc
+++ b/plugins/esi/esi.cc
@@ -217,7 +217,7 @@ ContData::checkXformStatus()
 {
   if (!xform_closed) {
     int retval = TSVConnClosedGet(contp);
-    if ((retval == TS_ERROR) || retval) {
+    if (retval != 0) {
       if (retval == TS_ERROR) {
         CONT_DATA_DBG(this, "[%s] Error while getting close status of transformation at state %d", __FUNCTION__, curr_state);
       } else {

--- a/src/iocore/net/NetHandler.cc
+++ b/src/iocore/net/NetHandler.cc
@@ -59,7 +59,8 @@ NetHandler::startIO(NetEvent *ne)
   int res = 0;
 
   PollDescriptor *pd = get_PollDescriptor(this->thread);
-  if (ne->ep.start(pd, ne, this, EVENTIO_READ | EVENTIO_WRITE) < 0) {
+  // The read and write masks intentionally share the epoll edge-trigger flag.
+  if (ne->ep.start(pd, ne, this, EVENTIO_READ | EVENTIO_WRITE) < 0) { // NOLINT(misc-redundant-expression)
     res = errno;
     // EEXIST should be ok, though it should have been cleared before we got back here
     if (errno != EEXIST) {

--- a/src/mgmt/rpc/server/IPCSocketServer.cc
+++ b/src/mgmt/rpc/server/IPCSocketServer.cc
@@ -334,7 +334,8 @@ IPCSocketServer::bind(std::error_code &ec)
   // Defense in depth for filesystems that do not honor the umask on AF_UNIX socket
   // inodes.
   if (chmod(_conf.sockPathName.c_str(), mode) < 0) {
-    if (errno != EINVAL && errno != ENOTSUP && errno != EOPNOTSUPP) {
+    // ENOTSUP and EOPNOTSUPP are distinct on some platforms.
+    if (errno != EINVAL && errno != ENOTSUP && errno != EOPNOTSUPP) { // NOLINT(misc-redundant-expression)
       ec = std::make_error_code(static_cast<std::errc>(errno));
       return;
     }

--- a/src/traffic_layout/engine.cc
+++ b/src/traffic_layout/engine.cc
@@ -297,7 +297,7 @@ LayoutEngine::create_runroot()
   for (const auto &it : original_map) {
     // path handle
     std::string join_path;
-    if (it.second[0] && it.second[0] == '/') {
+    if (it.second.starts_with('/')) {
       join_path = it.second.substr(1);
     } else {
       join_path = it.second;

--- a/src/traffic_logstats/logstats.cc
+++ b/src/traffic_logstats/logstats.cc
@@ -1808,7 +1808,7 @@ process_file(int in_fd, off_t offset, unsigned max_age)
           return 0;
         }
         // ensure that this is a valid logbuffer header
-        if (header->cookie && (LOG_SEGMENT_COOKIE == header->cookie)) {
+        if (LOG_SEGMENT_COOKIE == header->cookie) {
           offset = 0;
           break;
         }


### PR DESCRIPTION
Redundant boolean terms can hide always-true validation and unsafe
assumptions, as the existing rolling-mode and path checks demonstrate.
This patch corrects the findings and enables misc-redundant-expression in
CI and editor configuration to catch future logic mistakes.