### PR TITLE
Fix GCP bearer header construction

### DIFF
--- a/plugins/origin_server_auth/origin_server_auth.cc
+++ b/plugins/origin_server_auth/origin_server_auth.cc
@@ -1081,10 +1081,10 @@ S3Request::authorizeAwsV2(S3Config *s3)
 TSHttpStatus
 S3Request::authorizeGcp(S3Config *s3)
 {
-  char auth[2048];
-  int  auth_len = snprintf(auth, sizeof(auth), "Bearer %s", s3->token());
+  String auth{"Bearer "};
+  auth += s3->token();
 
-  if (!set_header(TS_MIME_FIELD_AUTHORIZATION, TS_MIME_LEN_AUTHORIZATION, auth, auth_len)) {
+  if (!set_header(TS_MIME_FIELD_AUTHORIZATION, TS_MIME_LEN_AUTHORIZATION, auth.c_str(), auth.length())) {
     return TS_HTTP_STATUS_INTERNAL_SERVER_ERROR;
   }
   return TS_HTTP_STATUS_OK;

--- a/tests/gold_tests/pluginTest/origin_server_auth/origin_server_auth.test.py
+++ b/tests/gold_tests/pluginTest/origin_server_auth/origin_server_auth.test.py
@@ -23,10 +23,14 @@ Test for successful authentication to origin server
 '''
 Test.ContinueOnFail = True
 
+import os
+
 
 class OriginServerAuthTest:
 
     def __init__(self):
+        self.long_gcp_token = "gcp-token-" + ("0123456789abcdef" * 140) + "-tail-after-stack-buffer"
+        self.long_gcp_replay = os.path.join(Test.RunDirectory, "origin_server_auth_gcp_long_token.replay.yaml")
         self.setUpOriginServer()
         self.setUpTS()
 
@@ -68,6 +72,35 @@ class OriginServerAuthTest:
         # add request/response
         self.server.addResponse("sessionlog.log", request_header, response_header)
 
+        with open(self.long_gcp_replay, "w", encoding="utf-8") as replay:
+            replay.write(
+                f'''meta:
+  version: "1.0"
+
+sessions:
+- transactions:
+  - client-request:
+      method: "GET"
+      url: /long-gcp-token
+      version: "1.1"
+      headers:
+        fields:
+        - [ uuid, long-gcp-token ]
+        - [ Host, www.example.com ]
+        - [ Authorization, {{ value: "Bearer {self.long_gcp_token}", as: equal }} ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Length, 8 ]
+      content:
+        encoding: plain
+        data: success!
+''')
+        self.long_token_server = Test.MakeVerifierServerProcess("long-token-server", self.long_gcp_replay)
+
     def setUpTS(self):
         self.ts = Test.MakeATSProcess("ts")
 
@@ -91,6 +124,13 @@ class OriginServerAuthTest:
                 @pparam=--access_key @pparam=1234567 \
                 @pparam=--session_token @pparam=hkMsi6/bfHyBKrSeM/H0hoXeyx8z1yZ/mJ0c+B/TqYx=tTJDjnQWtul38Z9iVJjeH1HB4VT2c=2o3yE3o=I9kmFs/lJDR85qWjB8e5asY/WbjyRpbAzmDipQpboIcYnUYg55bxrQFidV/q8gZa5A9MpR3n=op1C0lWjeBqcEJxpevNZxteSQTQfeGsi98Cdf+On=/SINVlKrNhMnmMsDOLMGx1YYt9d4UsRg1jtVrwxL4Vd/F7aHCZySAXKv+1rkhACR023wpa3dhp+xirGJxSO9LWwvcrTdM4xJo4RS8B40tGENOJ1NKixUJxwN/6og58Oft/u==uleR89Ja=7zszK2H7tX3DqmEYNvNDYQh/7VBRe5otghQtPwJzWpXAGk+Vme4hPPM5K6axH2LxipXzRiIV=oxNs0upKNu1FvuzbCQmkQdKQVmXl0344vngngrgN7wkEfrYtmKwICmpAS0cbW9jdSClgziVo4NaFc/hsIfok=4UA3hVtxIdw74lFNXD0RR7HKXkFPLIn85M7peOZsqMUCfO4gxr7KCfabszQQf0YcP/mt79XK50=WrSJG7oUyn+clUySPhlegqHAfT9a50uSK5WiQmOnGNGLF4wDO10sqKN1xRgQbYHPtwL+Ye0EMisvmYA3==kScorTSGaQWyibSWXAvxq9+IVGBYShVJ6S7DmTT=u/2d/fGEge+Xmbxlftza=cxJ=Md=k1Q71Lp6Boa56d7wtYRpK6tXHJ9I/2r7rN1E4OtwkFqb7SfWV3UXwyUrXyaaNPTIbqnAHnbgUGtuU6pgICpfREiIxVqvKBf6ErbxHRmMmAuYKxk5E9Mn6nnbxR4WTniweKYeDv2w39zge/tss+36Moeuio9d2eoyRFqXhq=rUGtDwX3fzXV0wV+dUojxOYQ57GQDl7+68PwHPcX794OIXuGOxBk83lNIYIcYz3Vc7qnGy6tFTz7f6S9+EZuSGN7TY5VKkT2eWye46DebrDF9Nwzs/FVpTzbPD/KGDIBtFIbazglhKoWe9txqb1QW8vFNNVOEhYa+cViO3g8ZmY1wG960US2zsnX5Eg8Q5a4h3+sxaJSJ4ONiXZWJuAgKRQzcrszu+M5C0ZVoCOv1goEgfNJeSm/yFc/3rx8wmeWLIJFtq65B7zF72HRKq1nthHAguaxXr20nguHpKkDpNBDVa=WwuJsbeGI \
                 @pparam=--version @pparam=gcpv1')
+
+        self.ts.Disk.remap_config.AddLine(
+            f'map http://www.example.com/long-gcp-token http://127.0.0.1:{self.long_token_server.Variables.http_port}/long-gcp-token '
+            f'@plugin=origin_server_auth.so '
+            f'@pparam=--access_key @pparam=1234567 '
+            f'@pparam=--session_token @pparam={self.long_gcp_token} '
+            f'@pparam=--version @pparam=gcpv1')
 
     def test_s3_origin_remap(self):
         '''
@@ -116,6 +156,22 @@ class OriginServerAuthTest:
         tr.Processes.Default.Streams.stderr.Content += Testers.ContainsExpression("Content-Length: 8", "expected content-length 8")
         tr.StillRunningAfter = self.server
 
+    def test_gcp_long_token_remap(self):
+        '''
+        Test GCP origin server with a bearer token longer than the old stack buffer.
+        '''
+        tr = Test.AddTestRun()
+        tr.MakeCurlCommand(
+            f'-s -v -H "Host: www.example.com" -H "uuid: long-gcp-token" '
+            f'http://127.0.0.1:{self.ts.Variables.port}/long-gcp-token;',
+            ts=self.ts)
+        tr.Processes.Default.ReturnCode = 0
+        tr.Processes.Default.StartBefore(self.long_token_server)
+        tr.Processes.Default.Streams.stderr.Content = Testers.ContainsExpression("200 OK", "expected 200 response")
+        tr.Processes.Default.Streams.stderr.Content += Testers.ContainsExpression(
+            "[Cc]ontent-[Ll]ength: 8", "expected content-length 8")
+        tr.StillRunningAfter = self.long_token_server
+
     def checkLogOutput(self):
         if Condition.CurlUsingUnixDomainSocket():
             self.ts.Disk.traffic_out.Content = "gold/origin_server_auth_parsing_ts_uds.gold"
@@ -126,6 +182,7 @@ class OriginServerAuthTest:
     def runTraffic(self):
         self.test_s3_origin_remap()
         self.test_gcp_origin_remap()
+        self.test_gcp_long_token_remap()
         self.checkLogOutput()
 
     def run(self):


### PR DESCRIPTION
Build the GCP Authorization header dynamically so long bearer tokens do
not reuse the truncated stack buffer length. Add an end-to-end check
that verifies a token longer than the old buffer is forwarded intact.