### PR TITLE
Remove FreeBSD from the required OS build list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -61,7 +61,6 @@ github:
           - RAT
           - Ubuntu
           - OSX
-          - FreeBSD
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1


### PR DESCRIPTION
Removing freebsd from required list