### PR TITLE
Preserve full width of SETTINGS frame identifiers

### DIFF
--- a/src/proxy/http3/Http3Frame.cc
+++ b/src/proxy/http3/Http3Frame.cc
@@ -456,7 +456,7 @@ Http3SettingsFrame::_parse()
       this->_error_reason = reinterpret_cast<const char *>("invalid SETTINGS frame");
       break;
     }
-    uint16_t id  = QUICIntUtil::read_QUICVariableInt(buf + len, this->_length - len);
+    uint64_t id  = QUICIntUtil::read_QUICVariableInt(buf + len, this->_length - len);
     len         += id_len;
 
     size_t value_len = QUICVariableInt::size(buf + len);

--- a/src/proxy/http3/test/test_Http3Frame.cc
+++ b/src/proxy/http3/test/test_Http3Frame.cc
@@ -166,6 +166,43 @@ TEST_CASE("Load SETTINGS Frame", "[http3]")
   }
 }
 
+// A SETTINGS identifier is a full QUIC variable-length integer (up to 62 bits).
+// Parsing must compare the decoded identifier against the known-ID set at full
+// width; narrowing the decoded value into a smaller integer type can cause an
+// identifier outside the known set to be misinterpreted as a known one.
+// Here, encoding 0x10001 as a 4-byte QUIC varint (0x80 0x01 0x00 0x01) shares
+// its low 16 bits with HEADER_TABLE_SIZE (0x01). The parser must treat the
+// identifier as unknown and skip the setting rather than store it under
+// HEADER_TABLE_SIZE.
+TEST_CASE("Load SETTINGS Frame ignores wide unknown identifier", "[http3][http3-settings-id-width]")
+{
+  uint8_t buf[] = {
+    0x04,                   // Type
+    0x05,                   // Length
+    0x80, 0x01, 0x00, 0x01, // Identifier: QUIC varint encoding of 0x10001
+    0x2a,                   // Value (1-byte QUIC varint = 42)
+  };
+  MIOBuffer *input = new_MIOBuffer(BUFFER_SIZE_INDEX_128);
+  input->write(buf, sizeof(buf));
+  IOBufferReader *input_reader = input->alloc_reader();
+
+  std::shared_ptr<Http3Frame> frame = Http3FrameFactory::create(*input_reader);
+  frame->update();
+  REQUIRE(frame->type() == Http3FrameType::SETTINGS);
+
+  std::shared_ptr<Http3SettingsFrame> settings_frame = std::dynamic_pointer_cast<Http3SettingsFrame>(frame);
+  REQUIRE(settings_frame);
+  REQUIRE(settings_frame->is_valid());
+
+  CHECK_FALSE(settings_frame->contains(Http3SettingsId::HEADER_TABLE_SIZE));
+
+  // ~Http3Frame deallocates the reader it holds, so drop the frames before the
+  // MIOBuffer that reader belongs to.
+  settings_frame.reset();
+  frame.reset();
+  free_MIOBuffer(input);
+}
+
 TEST_CASE("Store SETTINGS Frame", "[http3]")
 {
   SECTION("Normal")

--- a/src/proxy/http3/test/test_Http3Frame.cc
+++ b/src/proxy/http3/test/test_Http3Frame.cc
@@ -59,6 +59,10 @@ TEST_CASE("Load DATA Frame", "[http3]")
     CHECK(data_reader->read_avail() == 4);
     CHECK(memcmp(data_reader->start(), "\x11\x22\x33\x44", 4) == 0);
 
+    // ~Http3Frame deallocates the reader through its MIOBuffer, so release the
+    // frames before freeing that buffer.
+    data_frame.reset();
+    frame1.reset();
     free_MIOBuffer(input);
   }
 }
@@ -162,25 +166,29 @@ TEST_CASE("Load SETTINGS Frame", "[http3]")
     CHECK(settings_frame->get(Http3SettingsId::MAX_FIELD_SECTION_SIZE) == 0x0400);
     CHECK(settings_frame->get(Http3SettingsId::NUM_PLACEHOLDERS) == 0x0f);
 
+    settings_frame.reset();
+    frame.reset();
     free_MIOBuffer(input);
   }
 }
 
-// A SETTINGS identifier is a full QUIC variable-length integer (up to 62 bits).
-// Parsing must compare the decoded identifier against the known-ID set at full
-// width; narrowing the decoded value into a smaller integer type can cause an
-// identifier outside the known set to be misinterpreted as a known one.
-// Here, encoding 0x10001 as a 4-byte QUIC varint (0x80 0x01 0x00 0x01) shares
-// its low 16 bits with HEADER_TABLE_SIZE (0x01). The parser must treat the
-// identifier as unknown and skip the setting rather than store it under
-// HEADER_TABLE_SIZE.
-TEST_CASE("Load SETTINGS Frame ignores wide unknown identifier", "[http3][http3-settings-id-width]")
+// A SETTINGS identifier is a full QUIC variable-length integer, and an
+// identifier the implementation does not understand must be ignored
+// (RFC 9114, Section 7.2.4). Comparing a narrowed copy of the decoded
+// identifier against the known-ID set lets an unknown identifier alias a
+// known one.
+//
+// Identifiers of the form 0x1f * N + 0x21 are reserved to exercise that
+// requirement, and endpoints are expected to send one (RFC 9114, Section
+// 7.2.4.1). 0x1f * 33824 + 0x21 == 0x100001, which shares its low 16 bits
+// with HEADER_TABLE_SIZE (0x01).
+TEST_CASE("Load SETTINGS Frame ignores reserved identifier", "[http3]")
 {
   uint8_t buf[] = {
     0x04,                   // Type
     0x05,                   // Length
-    0x80, 0x01, 0x00, 0x01, // Identifier: QUIC varint encoding of 0x10001
-    0x2a,                   // Value (1-byte QUIC varint = 42)
+    0x80, 0x10, 0x00, 0x01, // Identifier: QUIC varint encoding of 0x100001
+    0x2a,                   // Value
   };
   MIOBuffer *input = new_MIOBuffer(BUFFER_SIZE_INDEX_128);
   input->write(buf, sizeof(buf));
@@ -196,8 +204,8 @@ TEST_CASE("Load SETTINGS Frame ignores wide unknown identifier", "[http3][http3-
 
   CHECK_FALSE(settings_frame->contains(Http3SettingsId::HEADER_TABLE_SIZE));
 
-  // ~Http3Frame deallocates the reader it holds, so drop the frames before the
-  // MIOBuffer that reader belongs to.
+  // ~Http3Frame deallocates the reader through its MIOBuffer, so release the
+  // frames before freeing that buffer.
   settings_frame.reset();
   frame.reset();
   free_MIOBuffer(input);

--- a/src/proxy/http3/test/test_Http3Frame.cc
+++ b/src/proxy/http3/test/test_Http3Frame.cc
@@ -166,6 +166,8 @@ TEST_CASE("Load SETTINGS Frame", "[http3]")
     CHECK(settings_frame->get(Http3SettingsId::MAX_FIELD_SECTION_SIZE) == 0x0400);
     CHECK(settings_frame->get(Http3SettingsId::NUM_PLACEHOLDERS) == 0x0f);
 
+    // ~Http3Frame deallocates the reader through its MIOBuffer, so release the
+    // frames before freeing that buffer.
     settings_frame.reset();
     frame.reset();
     free_MIOBuffer(input);


### PR DESCRIPTION
`Http3SettingsFrame::_parse()` decodes each SETTINGS identifier with
`QUICIntUtil::read_QUICVariableInt()`, which returns `uint64_t`, but stored the
result in a `uint16_t` local (`src/proxy/http3/Http3Frame.cc:459`). RFC 9114
defines SETTINGS identifiers as variable-length integers and requires
unrecognized identifiers to be ignored; narrowing the decoded value before the
comparison against the known-ID set means an identifier outside that set can
alias a known one on its low 16 bits.

This widens the local to `uint64_t`. Nothing else changes -- the surrounding
parse loop and the known-ID comparison are untouched.

### Test

Adds `Load SETTINGS Frame ignores reserved identifier` to `test_Http3Frame.cc`,
tagged `[http3]`. RFC 9114, Section 7.2.4.1 reserves identifiers of the form
`0x1f * N + 0x21` to exercise the requirement that unknown identifiers be
ignored, and expects endpoints to send one. The test feeds a SETTINGS frame
whose identifier is the 4-byte varint encoding of
`0x1f * 33824 + 0x21 == 0x100001` -- sharing its low 16 bits with
`HEADER_TABLE_SIZE` (`0x01`) -- and asserts the frame parses as valid while
*not* containing `HEADER_TABLE_SIZE`.

Confirmed this is a regression test and not a tautology: with the `uint16_t`
restored it fails on `CHECK_FALSE(contains(HEADER_TABLE_SIZE))` (expansion
`!true`); with the fix it passes, 4 assertions.

Also run: full `test_http3` (138 assertions / 16 cases, up from 134/15 on
master) and the `h3_proxy_verifier` autest.

`Load DATA Frame` and `Load SETTINGS Frame` now release their frames before
`free_MIOBuffer()`. `~Http3Frame` deallocates its `IOBufferReader` through the
`MIOBuffer` that reader came from, so the previous order let the reader outlive
its buffer.
