### PR TITLE
HTTP/3: bound the DATA payload copy to the frame

### DIFF
--- a/src/proxy/http3/CMakeLists.txt
+++ b/src/proxy/http3/CMakeLists.txt
@@ -64,6 +64,7 @@ if(BUILD_TESTING)
     Http3Config.cc
     Http3Frame.cc
     Http3SettingsHandler.cc
+    Http3StreamDataVIOAdaptor.cc
   )
   target_link_libraries(
     test_http3

--- a/src/proxy/http3/Http3StreamDataVIOAdaptor.cc
+++ b/src/proxy/http3/Http3StreamDataVIOAdaptor.cc
@@ -48,8 +48,13 @@ Http3StreamDataVIOAdaptor::handle_frame(std::shared_ptr<const Http3Frame> frame,
   ink_assert(frame->type() == Http3FrameType::DATA);
   const Http3DataFrame *dframe = dynamic_cast<const Http3DataFrame *>(frame.get());
 
-  // Need to wait for headers to be written
-  int64_t written           = this->_buffer->write(dframe->data());
+  // The frame's reader is bounded to this frame by size_limit, but the default
+  // length for MIOBuffer::write is INT64_MAX, which walks the raw block chain
+  // and copies whatever follows the frame in the stream read buffer. Pass
+  // read_avail(), which honours size_limit, to bound the copy to the payload.
+  IOBufferReader *reader  = dframe->data();
+  int64_t         written = this->_buffer->write(reader, reader->read_avail());
+
   this->_total_data_length += written;
 
   return Http3ErrorUPtr(nullptr);

--- a/src/proxy/http3/test/test_Http3FrameDispatcher.cc
+++ b/src/proxy/http3/test/test_Http3FrameDispatcher.cc
@@ -23,8 +23,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
+#include <string_view>
+
+#include "iocore/eventsystem/VIO.h"
 #include "proxy/http3/Http3FrameDispatcher.h"
 #include "proxy/http3/Http3ProtocolEnforcer.h"
+#include "proxy/http3/Http3StreamDataVIOAdaptor.h"
 #include "Mock.h"
 
 namespace
@@ -383,6 +388,73 @@ TEST_CASE("ignore unknown frames", "[http3]")
     CHECK(nread == 0);
     free_MIOBuffer(buf);
   }
+}
+
+TEST_CASE("Http3StreamDataVIOAdaptor buffers only the current DATA frame payload", "[http3]")
+{
+  // The dispatcher hands each handler a reader whose size_limit covers just
+  // one frame. The adaptor must respect that limit, so the body it collects
+  // is the concatenated payloads and nothing else, no matter how the frames
+  // are split across reads.
+  MIOBuffer      *sink_buffer = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
+  IOBufferReader *sink_reader = sink_buffer->alloc_reader();
+  VIO             sink_vio;
+
+  sink_vio.mutex = new_ProxyMutex();
+  sink_vio.set_writer(sink_buffer);
+
+  Http3FrameDispatcher      http3FrameDispatcher;
+  Http3StreamDataVIOAdaptor adaptor(&sink_vio);
+  http3FrameDispatcher.add_handler(&adaptor);
+
+  MIOBuffer      *buf    = new_MIOBuffer(BUFFER_SIZE_INDEX_512);
+  IOBufferReader *reader = buf->alloc_reader();
+  uint64_t        nread  = 0;
+
+  uint8_t input[] = {// 1st frame (DATA)
+                     0x00, 0x04, 'A', 'A', 'A', 'A',
+                     // 2nd frame (DATA)
+                     0x00, 0x04, 'B', 'B', 'B', 'B'};
+
+  constexpr std::string_view expected_body = "AAAABBBB";
+
+  SECTION("Both frames arrive in a single read")
+  {
+    // The first frame's payload is followed in the same buffer by the second
+    // frame, so an unbounded copy would pull the trailing header and payload
+    // into the body as well.
+    buf->write(input, sizeof(input));
+
+    Http3ErrorUPtr error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::UNKNOWN, *reader, nread);
+    CHECK(!error);
+    CHECK(nread == sizeof(input));
+  }
+
+  SECTION("Frames arrive one byte at a time")
+  {
+    // on_read_ready resets nread on every call, so total it up as we go.
+    uint64_t consumed = 0;
+
+    for (uint8_t *it{input}; it < input + sizeof(input); ++it) {
+      buf->write(it, 1);
+
+      Http3ErrorUPtr error = http3FrameDispatcher.on_read_ready(0, Http3StreamType::UNKNOWN, *reader, nread);
+      CHECK(!error);
+      consumed += nread;
+    }
+    CHECK(consumed == sizeof(input));
+  }
+
+  adaptor.finalize();
+  REQUIRE(sink_reader->read_avail() == static_cast<int64_t>(expected_body.size()));
+
+  std::array<char, expected_body.size()> body;
+
+  sink_reader->memcpy(body.data(), body.size());
+  CHECK(std::string_view(body.data(), body.size()) == expected_body);
+
+  free_MIOBuffer(buf);
+  free_MIOBuffer(sink_buffer);
 }
 
 TEST_CASE("HTTP/2 reserved frame type not allowed", "[http3]")


### PR DESCRIPTION
`Http3FrameDispatcher::on_read_ready()` clones the stream reader per frame and
bounds it to that frame:

```c
auto cloned_reader        = reader.clone();
cloned_reader->size_limit = frame_len;
```
(`src/proxy/http3/Http3FrameDispatcher.cc:112-113`)

`Http3StreamDataVIOAdaptor::handle_frame()` then copied the payload with

```c
int64_t written = this->_buffer->write(dframe->data());
```

`MIOBuffer::write` is declared `write(IOBufferReader *r, int64_t len = INT64_MAX,
int64_t offset = 0)` (`include/iocore/eventsystem/IOBuffer.h:997`), so with no
length it walks the raw block chain and ignores the reader's `size_limit`
entirely. Whatever is already buffered behind the DATA frame -- typically the
next frame's header and payload -- was copied into the response body.

The fix passes `reader->read_avail()`, which clamps to `size_limit`
(`src/iocore/eventsystem/IOBuffer.cc:497-499`), so the copy stops at the frame
payload.

### Test

Adds `Http3StreamDataVIOAdaptor buffers only the current DATA frame payload` to
`test_Http3FrameDispatcher.cc`, and adds `Http3StreamDataVIOAdaptor.cc` to the
`test_http3` target so the adaptor is linked in.

The test writes two back-to-back DATA frames (`AAAA` then `BBBB`) into one
buffer and expects a body of exactly `AAAABBBB`, in two sections: both frames
arriving in a single read, and the same bytes arriving one at a time. It
asserts on the sink VIO, which is the body `HttpSM` goes on to forward.

Confirmed this is a regression test: restoring the unbounded
`write(dframe->data())` fails
`sink_reader->read_avail() == 8` (`test_Http3FrameDispatcher.cc:449`) with
`14 == 8`, because the second frame's `0x00 0x04` header and its payload are
pulled into the body. With the fix, `test_http3` passes 153 assertions in 16
cases, up from 134 in 15 on master.

Also run: `h3_flow_control`, `h3_stream_lifetime`, `h3_proxy_verifier` autests
(3/3 pass; `h3_range_cache` self-skips, the local curl has no http3).
