### PR TITLE
SSL: return nullptr from SSLNetVCAccess for non-SSL handles

### DIFF
--- a/src/iocore/net/SNIActionPerformer.cc
+++ b/src/iocore/net/SNIActionPerformer.cc
@@ -415,7 +415,11 @@ SNI_IpAllow::SNIAction(SSL &ssl, ActionItem::Context const & /* ctx ATS_UNUSED *
     return SSL_TLSEXT_ERR_OK;
   }
 
-  auto            ssl_vc    = SSLNetVCAccess(&ssl);
+  auto ssl_vc = SSLNetVCAccess(&ssl);
+  if (ssl_vc == nullptr) {
+    return SSL_TLSEXT_ERR_OK;
+  }
+
   const sockaddr *client_ip = nullptr;
   for (int i = 0; i < IpAllow::Subject::MAX_SUBJECTS; ++i) {
     if (IpAllow::Subject::PEER == IpAllow::subjects[i]) {

--- a/src/iocore/net/SSLClientUtils.cc
+++ b/src/iocore/net/SSLClientUtils.cc
@@ -209,7 +209,7 @@ ssl_client_cert_callback(SSL *ssl, void * /*arg*/)
 {
   SSLNetVConnection *netvc = SSLNetVCAccess(ssl);
   SSL_CTX           *ctx   = SSL_get_SSL_CTX(ssl);
-  if (ctx) {
+  if (ctx != nullptr && netvc != nullptr) {
     // Do not need to free either the cert or the ssl_ctx
     // both are internal pointers
     X509 *cert = SSL_CTX_get0_certificate(ctx);

--- a/src/iocore/net/SSLUtils.cc
+++ b/src/iocore/net/SSLUtils.cc
@@ -198,7 +198,8 @@ ssl_verify_client_callback(int preverify_ok, X509_STORE_CTX *ctx)
   }
 
   if (tbs->verify_certificate(ctx) == 1) { // hook moved the handshake state to terminal
-    Warning("TS_EVENT_SSL_VERIFY_CLIENT plugin failed the client certificate check for %s.", netvc->options.sni_servername.get());
+    const char *sni = (netvc != nullptr) ? netvc->options.sni_servername.get() : "<unknown>";
+    Warning("TS_EVENT_SSL_VERIFY_CLIENT plugin failed the client certificate check for %s.", sni);
     return false;
   }
 
@@ -2004,12 +2005,8 @@ SSLNetVCDetach(SSL *ssl)
 SSLNetVConnection *
 SSLNetVCAccess(const SSL *ssl)
 {
-  SSLNetVConnection *netvc;
-  netvc = static_cast<SSLNetVConnection *>(SSL_get_ex_data(ssl, ssl_vc_index));
-
-  ink_assert(dynamic_cast<SSLNetVConnection *>(static_cast<NetVConnection *>(SSL_get_ex_data(ssl, ssl_vc_index))));
-
-  return netvc;
+  auto *base = static_cast<NetVConnection *>(SSL_get_ex_data(ssl, ssl_vc_index));
+  return dynamic_cast<SSLNetVConnection *>(base);
 }
 
 std::string


### PR DESCRIPTION
`SSLNetVCAttach()` (`src/iocore/net/SSLUtils.cc:1994`) is called from exactly one
place, `SSLNetVConnection::SSLNetVConnection`
(`src/iocore/net/SSLNetVConnection.cc:145`). Nothing on the QUIC side attaches,
so an `SSL` handle belonging to a QUIC connection has no `ssl_vc_index` ex_data.

`SSLNetVCAccess()` then did:

```c
netvc = static_cast<SSLNetVConnection *>(SSL_get_ex_data(ssl, ssl_vc_index));
ink_assert(dynamic_cast<SSLNetVConnection *>(static_cast<NetVConnection *>(SSL_get_ex_data(ssl, ssl_vc_index))));
return netvc;
```

The `dynamic_cast` was only evaluated inside `ink_assert`, so in a release build
the unchecked value was returned as-is. Three callbacks that a QUIC handshake
also reaches then used it without a null check:

- `SNI_IpAllow::SNIAction()` -- `src/iocore/net/SNIActionPerformer.cc:418`
- `ssl_client_cert_callback()` -- `src/iocore/net/SSLClientUtils.cc:211`
- `ssl_verify_client_callback()` -- `src/iocore/net/SSLUtils.cc:200`

This makes the `dynamic_cast` the return value, so the accessor reports a handle
that is not an `SSLNetVConnection` instead of handing back something unchecked,
and adds the corresponding guard at those three call sites.

The cast is well defined: `SSLNetVConnection` derives from
`UnixNetVConnection`, which derives from `NetVConnection`, leftmost at both
levels, so `NetVConnection` is the primary base subobject at offset 0 and the
`void *` recovered from ex_data needs no adjustment. The `ink_assert` being
removed already performed this exact cast.

### Test

No new test. Reaching the null case requires a QUIC handshake to drive an
`SSL_CTX` callback shared with the TLS path, which the existing autest harness
does not set up directly.

Existing coverage run against this change, 8/8 pass:

- `tls_sni_ip_allow` -- exercises `SNI_IpAllow::SNIAction()` directly
- `tls_client_verify`, `tls_client_verify2`, `tls_client_verify3` --
  `ssl_verify_client_callback()`
- `tls_client_cert`, `tls_client_cert_override` -- `ssl_client_cert_callback()`
- `h3_sni_check`, `h3_proxy_verifier` -- the QUIC path

These confirm the non-null path through all three callbacks is unchanged.
