### PR TITLE
HTTP/3: reject an unknown ALPN instead of aborting

### DIFF
--- a/include/proxy/http3/Http3SessionAccept.h
+++ b/include/proxy/http3/Http3SessionAccept.h
@@ -26,6 +26,8 @@
 #include "tscore/ink_platform.h"
 #include "iocore/net/Net.h"
 
+#include <string_view>
+
 #include "proxy/http/HttpSessionAccept.h"
 
 // HTTP/QUIC Session Accept.
@@ -38,11 +40,22 @@
 class Http3SessionAccept : public HttpSessionAcceptBase
 {
 public:
+  /// The HTTP application selected from a negotiated ALPN tag.
+  enum class AppType {
+    HTTP_09, ///< HTTP/0.9 over QUIC (interop only).
+    HTTP_3,  ///< HTTP/3.
+    UNKNOWN, ///< Missing or unrecognized ALPN; the connection must be rejected.
+  };
+
   explicit Http3SessionAccept(OptionsHandle options, HttpProxyPort *proxy_port = nullptr);
   ~Http3SessionAccept();
 
   bool accept(NetVConnection *, MIOBuffer *, IOBufferReader *) override;
   int  mainEvent(int event, void *netvc) override;
+
+  /// Map a negotiated ALPN tag to the HTTP application to run.
+  /// @return @c AppType::UNKNOWN for an empty or unrecognized @a alpn.
+  static AppType select_app_type(std::string_view alpn);
 
 private:
   Http3SessionAccept(const Http3SessionAccept &);

--- a/src/iocore/net/QUICNetVConnection.cc
+++ b/src/iocore/net/QUICNetVConnection.cc
@@ -514,9 +514,13 @@ QUICNetVConnection::negotiated_version() const
 std::string_view
 QUICNetVConnection::negotiated_application_name() const
 {
-  const uint8_t *name;
+  const uint8_t *name     = nullptr;
   size_t         name_len = 0;
   quiche_conn_application_proto(this->_quiche_con, &name, &name_len);
+
+  if (name == nullptr) {
+    return std::string_view{""};
+  }
 
   return std::string_view(reinterpret_cast<const char *>(name), name_len);
 }

--- a/src/proxy/http3/Http3SessionAccept.cc
+++ b/src/proxy/http3/Http3SessionAccept.cc
@@ -50,6 +50,21 @@ Http3SessionAccept::Http3SessionAccept(OptionsHandle options, HttpProxyPort *pro
 
 Http3SessionAccept::~Http3SessionAccept() {}
 
+Http3SessionAccept::AppType
+Http3SessionAccept::select_app_type(std::string_view alpn)
+{
+  if (alpn.empty()) {
+    return AppType::UNKNOWN;
+  }
+  if (IP_PROTO_TAG_HTTP_QUIC.compare(alpn) == 0 || IP_PROTO_TAG_HTTP_QUIC_D29.compare(alpn) == 0) {
+    return AppType::HTTP_09;
+  } else if (IP_PROTO_TAG_HTTP_3.compare(alpn) == 0 || IP_PROTO_TAG_HTTP_3_D29.compare(alpn) == 0 ||
+             IP_PROTO_TAG_H3QX.compare(alpn) == 0) {
+    return AppType::HTTP_3;
+  }
+  return AppType::UNKNOWN;
+}
+
 bool
 Http3SessionAccept::accept(NetVConnection *netvc, MIOBuffer * /* iobuf ATS_UNUSED */, IOBufferReader * /* reader ATS_UNUSED */)
 {
@@ -79,11 +94,12 @@ Http3SessionAccept::accept(NetVConnection *netvc, MIOBuffer * /* iobuf ATS_UNUSE
   }
   std::string_view alpn = qc->negotiated_application_name();
 
-  if (IP_PROTO_TAG_HTTP_QUIC.compare(alpn) == 0 || IP_PROTO_TAG_HTTP_QUIC_D29.compare(alpn) == 0) {
+  switch (select_app_type(alpn)) {
+  case AppType::HTTP_09:
     Dbg(dbg_ctl_http3, "[%s] start HTTP/0.9 app (ALPN=%.*s)", qc->cids().data(), static_cast<int>(alpn.length()), alpn.data());
     new Http09App(netvc, qc, std::move(session_acl), this);
-  } else if (IP_PROTO_TAG_HTTP_3.compare(alpn) == 0 || IP_PROTO_TAG_HTTP_3_D29.compare(alpn) == 0 ||
-             IP_PROTO_TAG_H3QX.compare(alpn) == 0) {
+    break;
+  case AppType::HTTP_3: {
     Dbg(dbg_ctl_http3, "[%s] start HTTP/3 app (ALPN=%.*s)", qc->cids().data(), static_cast<int>(alpn.length()), alpn.data());
 
     Http3App *app = new Http3App(netvc, qc, std::move(session_acl), this);
@@ -103,8 +119,17 @@ Http3SessionAccept::accept(NetVConnection *netvc, MIOBuffer * /* iobuf ATS_UNUSE
 #endif
 
     app->start();
-  } else {
-    ink_abort("Negotiated App Name is unknown");
+    break;
+  }
+  case AppType::UNKNOWN:
+  default: {
+    // QUIC/TLS can complete without an ALPN extension, leaving the negotiated
+    // name empty, and a client may also offer an unrecognized tag.
+    ip_port_text_buffer ipb;
+    Dbg(dbg_ctl_http3, "[%s] unknown or missing ALPN (ALPN=%.*s) from %s, closing connection", qc->cids().data(),
+        static_cast<int>(alpn.length()), alpn.data(), ats_ip_nptop(client_ip, ipb, sizeof(ipb)));
+    return false;
+  }
   }
 
   return true;


### PR DESCRIPTION
`Http3SessionAccept::accept()` dispatched on the negotiated ALPN with an
if/else-if chain ending in:

```c
} else {
  ink_abort("Negotiated App Name is unknown");
}
```

An absent or empty ALPN lands in that final arm, so a QUIC handshake that
completes without an ALPN extension aborts the process rather than closing the
connection. `08d1896d6a64` ("Reject TLS if client offers alpn with no match",
#7981) removed the earlier `alpn.empty()` arm that used to catch this case
before it reached the abort.

That the empty state is expected elsewhere in the same path is visible in both
`_start_application()` implementations, which already have null-ALPN fallbacks.

### Change

- `Http3SessionAccept.h` / `.cc`: add an `AppType` enum and a static
  `select_app_type(std::string_view)` helper, and turn the dispatch into a
  `switch`. The `UNKNOWN` arm logs and returns `false`;
  `Http3SessionAccept::mainEvent()` already converts a `false` return into
  `netvc->do_io_close()`, so no new teardown path is introduced.
- `QUICNetVConnection.cc`: `negotiated_application_name()` declared
  `const uint8_t *name;` uninitialised and passed it to
  `quiche_conn_application_proto()`, which leaves it untouched when no protocol
  was negotiated -- so the `std::string_view` was constructed over an
  indeterminate pointer. Initialise to `nullptr` and return an empty
  `string_view` in that case. This also makes `alpn.data()` non-null for the
  `%.*s` in the new log line.

Extracting `select_app_type()` keeps the tag-to-application mapping in one place
and makes it directly unit-testable, though no unit test is added here (see
below).

### Test

Honest summary: **no existing test fails without this change, and a targeted new
test is not portable.**

An unrecognised tag such as `banana` never reaches `accept()` -- the TLS layer
answers `no_application_protocol` first, which is what
`tests/gold_tests/tls/tls_bad_alpn.test.py` already covers over TCP. The empty
ALPN case only completes a handshake on a backend that does not enforce
RFC 9001 s8.1, so a gold test for it would pass or skip inconsistently across
BoringSSL, QUICTLS and the OpenSSL QUIC-TLS-callbacks shim. Rather than add a
backend-dependent test, this is submitted as hardening.

What was run, 9/9 pass: `h3_active_timeout`, `h3_flow_control`, `h3_go_client`,
`h3_proxy_verifier`, `h3_python_client`, `h3_sni_check`, `h3_stream_lifetime`,
`quic_no_activity_timeout`, `tls_bad_alpn`. Three of those assert on the exact
`start HTTP/3 app (ALPN=h3)` debug line, so they confirm the switch conversion
did not disturb the happy path.

Built on both QUIC backends. Under `ENABLE_QUICHE=ON`,
`src/iocore/net/QUICNetVConnection.cc` compiles clean -- that file is only built
under `elseif(TS_HAS_QUICHE)` in `src/iocore/net/CMakeLists.txt`, so the
OpenSSL-QUIC build does not cover it. The quiche configuration was
compile-verified only; the autests above ran against the OpenSSL-QUIC build.
