### PR TITLE
remap: bound the plugin argument arrays

### DIFF
--- a/src/proxy/http/remap/RemapConfig.cc
+++ b/src/proxy/http/remap/RemapConfig.cc
@@ -900,8 +900,8 @@ remap_load_plugin(const char *const *argv, int argc, url_mapping *mp, char *errb
                   int *plugin_found_at, UrlRewrite *rewrite)
 {
   char       *c, *err;
-  const char *new_argv[1024];
-  char       *pargv[1024];
+  const char *new_argv[BUILD_TABLE_MAX_ARGS + 1];
+  char       *pargv[BUILD_TABLE_MAX_ARGS + 1];
   int         idx  = 0;
   int         parc = 0;
   *plugin_found_at = 0;
@@ -914,7 +914,7 @@ remap_load_plugin(const char *const *argv, int argc, url_mapping *mp, char *errb
   if (jump_to_argc != 0) {
     argc  -= jump_to_argc;
     int i  = 0;
-    while (argv[i + jump_to_argc]) {
+    while (i < argc && i < static_cast<int>(countof(new_argv) - 1)) {
       new_argv[i] = argv[i + jump_to_argc];
       i++;
     }
@@ -1164,6 +1164,11 @@ remap_parse_config_bti(const char *path, BUILD_TABLE_INFO *bti, ConfigContext ct
     tok_count = whiteTok.Initialize(cur_line, (SHARE_TOKS | ALLOW_SPACES));
 
     for (int j = 0; j < tok_count; j++) {
+      if (bti->argc >= BUILD_TABLE_MAX_ARGS || bti->paramc >= BUILD_TABLE_MAX_ARGS) {
+        snprintf(errStrBuf, sizeof(errStrBuf), "too many arguments on line %d in file %s", cln + 1, path);
+        errStr = errStrBuf;
+        goto MAP_ERROR;
+      }
       if ((const_cast<char *>(whiteTok[j]))[0] == '@') {
         if ((const_cast<char *>(whiteTok[j]))[1]) {
           bti->argv[bti->argc++] = ats_strdup(&(((char *)whiteTok[j])[1]));

--- a/tests/gold_tests/remap/remap_plugin_argument_limits.test.py
+++ b/tests/gold_tests/remap/remap_plugin_argument_limits.test.py
@@ -1,0 +1,101 @@
+'''
+Verify how ATS handles remap rules near and beyond the argument limit.
+'''
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+Test.Summary = '''
+A remap rule with close to the maximum number of arguments must load and serve,
+while a rule that exceeds the maximum must be rejected without ATS crashing.
+
+This exercises remap_load_plugin's parameter copy buffers (sized to
+BUILD_TABLE_MAX_ARGS) and the parser's argument count guard.
+'''
+
+# ----------------------------------------------------------------------------
+# Case 1: close to the maximum number of chained-plugin parameters must load
+# and serve. Using a count just under BUILD_TABLE_MAX_ARGS (2048) pins the copy
+# buffers to that size; it would fail if they shrank below it. The total
+# argument count (these plus the plugin/pparam keywords) must stay under 2048,
+# and the repeated override is harmless: only the argument count matters.
+# ----------------------------------------------------------------------------
+ts_ok = Test.MakeATSProcess("ts-ok")
+server = Test.MakeOriginServer("server")
+
+request_header = {"headers": "GET / HTTP/1.1\r\nHost: overflow.example.com\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+response_header = {"headers": "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n", "timestamp": "1469733493.993", "body": ""}
+server.addResponse("sessionfile.log", request_header, response_header)
+
+ts_ok.Disk.records_config.update({
+    'proxy.config.diags.debug.enabled': 0,
+})
+
+num_params = 2040
+trailing_params = ' '.join(['@pparam=proxy.config.diags.debug.enabled=0'] * num_params)
+ts_ok.Disk.remap_config.AddLine(
+    'map http://overflow.example.com http://127.0.0.1:{0} '
+    '@plugin=conf_remap.so @pparam=proxy.config.diags.debug.enabled=0 '
+    '@plugin=conf_remap.so {1}'.format(server.Variables.Port, trailing_params))
+
+ts_ok.Disk.traffic_out.Content = Testers.ExcludesExpression(
+    "failed assertion", "traffic_server must not abort parsing remap.config")
+ts_ok.Disk.traffic_out.Content += Testers.ExcludesExpression(
+    "received signal", "traffic_server must not crash parsing remap.config")
+
+tr = Test.AddTestRun("near-limit rule loads and serves")
+tr.MakeCurlCommand(
+    '--proxy 127.0.0.1:{0} "http://overflow.example.com" -H "Proxy-Connection: keep-alive" --verbose'.format(ts_ok.Variables.port),
+    ts=ts_ok)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.StartBefore(server)
+tr.Processes.Default.StartBefore(ts_ok)
+tr.Processes.Default.Streams.stderr.Content = Testers.ContainsExpression("200 OK", "expected a 200 response from origin")
+tr.StillRunningAfter = ts_ok
+tr.StillRunningAfter = server
+
+# ----------------------------------------------------------------------------
+# Case 2: exceeding BUILD_TABLE_MAX_ARGS arguments on a single line must be
+# reported as an error and fail the load cleanly, never a crash from writing
+# past the parser's argument arrays.
+# ----------------------------------------------------------------------------
+ts_bad = Test.MakeATSProcess("ts-bad")
+
+num_args = 2100
+args = ' '.join(['@pparam=proxy.config.diags.debug.enabled=0'] * num_args)
+ts_bad.Disk.remap_config.AddLine('map http://overflow.example.com http://127.0.0.1:80 {0}'.format(args))
+
+# A malformed line aborts the whole remap load, so ATS is expected to fail to
+# start rather than crash while parsing the oversized line.
+ts_bad.ReturnCode = 33
+ts_bad.Ready = 0
+ts_bad.Disk.diags_log.Content = Testers.ContainsExpression("too many arguments", "the oversized line must be rejected")
+ts_bad.Disk.diags_log.Content += Testers.ExcludesExpression("received signal", "traffic_server must not crash parsing remap.config")
+ts_bad.Disk.traffic_out.Content = Testers.ExcludesExpression(
+    "failed assertion", "traffic_server must not abort parsing remap.config")
+
+tr2 = Test.AddTestRun("oversized rule is rejected")
+
+# Wait for the rejection to be logged. This cannot be the ATS readiness
+# criteria because the process exits, which autest could observe before the log
+# message is written.
+watcher = Test.Processes.Process("watcher")
+watcher.Command = "sleep 30"
+watcher.Ready = When.FileContains(ts_bad.Disk.diags_log.Name, "too many arguments")
+watcher.StartBefore(ts_bad)
+
+tr2.Processes.Default.Command = "echo done"
+tr2.TimeOut = 10
+tr2.Processes.Default.StartBefore(watcher)


### PR DESCRIPTION
`BUILD_TABLE_INFO` sizes its argument arrays at `BUILD_TABLE_MAX_ARGS`, which is
2048 (`include/proxy/http/remap/RemapConfig.h:31,62-63`):

```c
char *paramv[BUILD_TABLE_MAX_ARGS];
char *argv[BUILD_TABLE_MAX_ARGS];
```

`remap_load_plugin()` declared its own locals at half that:

```c
const char *new_argv[1024];
char       *pargv[1024];
```

so a `remap.config` line carrying more than 1024 arguments overflowed them. In a
build with `ink_assert` enabled the existing assertion at
`RemapConfig.cc:912` catches it and aborts; without it the writes simply run off
the end of two stack arrays.

Two further bounds issues in the same path:

- The `jump_to_argc` copy loop was `while (argv[i + jump_to_argc])`, i.e. it
  walked until it found a null entry rather than stopping at `argc`.
- `remap_parse_config_bti()` appended to `bti->argv` / `bti->paramv` inside the
  tokenizer loop but only compared against `BUILD_TABLE_MAX_ARGS` after the loop
  had finished, so `bti->argc` could pass 2048 before anything checked.

### Change

- Size `new_argv` and `pargv` from `BUILD_TABLE_MAX_ARGS + 1`, so they can hold
  the full limit plus the nullptr sentinel the copy loop reserves.
- Bound the copy loop by `argc` and by `countof(new_argv) - 1`.
- Reject an over-long line while tokenizing, with the file and line number in
  the error, instead of after the fact.

### Test

Adds `tests/gold_tests/remap/remap_plugin_argument_limits.test.py`, with a
near-limit rule that must load and serve, and an over-limit rule that must be
rejected. There is no existing test in `tests/gold_tests/remap/` covering the
argument count, and no collision with the 32 entries already there.

Confirmed it is a regression test: against unpatched `RemapConfig.cc` it fails
with

```
Fatal: RemapConfig.cc:912: failed assertion
`static_cast<unsigned>(argc) < countof(new_argv)` : 3
```

so `traffic_server` aborts while parsing `remap.config`. With the change the
test passes.
