### PR TITLE
records: bound regex backtracking in record lookup

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -49,8 +49,9 @@ enum REFlags {
 ///
 /// @internal As with REFlags, these values are copied from pcre2.h, to avoid having to include it.
 enum REErrors {
-  RE_ERROR_NOMATCH = -1, ///< No match found.
-  RE_ERROR_NULL    = -51 ///< NULL code or subject was passed.
+  RE_ERROR_NOMATCH    = -1,  ///< No match found.
+  RE_ERROR_MATCHLIMIT = -47, ///< Match limit exhausted; the match has no verdict.
+  RE_ERROR_NULL       = -51  ///< NULL code or subject was passed.
 };
 
 /// @brief Wrapper for PCRE2 match data.

--- a/src/records/CMakeLists.txt
+++ b/src/records/CMakeLists.txt
@@ -55,6 +55,7 @@ if(BUILD_TESTING)
     unit_tests/test_ReloadDirectives.cc
     unit_tests/test_RecDumpRecords.cc
     unit_tests/test_RecHiddenMetricLookup.cc
+    unit_tests/test_RecLookupMatchingRecords.cc
   )
   target_link_libraries(test_records PRIVATE records configmanager inkevent Catch2::Catch2 ts::tscore libswoc::libswoc)
   add_catch2_test(NAME test_records COMMAND test_records)

--- a/src/records/RecCore.cc
+++ b/src/records/RecCore.cc
@@ -41,6 +41,7 @@
 #include "tscore/Layout.h"
 #include "tsutil/ts_errata.h"
 #include "tsutil/Metrics.h"
+#include "tsutil/Regex.h"
 
 using ts::Metrics;
 
@@ -582,11 +583,34 @@ RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(
     return REC_ERR_FAIL;
   }
 
+  // The pattern comes from the admin_lookup_records RPC and is run against every record name,
+  // and that RPC is served inline on a single thread, so an unbounded pattern stalls it: 19s per
+  // request across a stock server's 1328 names, against 123ms at this limit.
+  //
+  // Raising the limit costs run time linearly, while the longest name a pattern can still resolve
+  // grows only as its square root, since proving no match costs about L^2/2 steps. 50,000 resolves
+  // names up to ~310 characters, 4.7x the 66 character longest a stock build registers. The 1750
+  // used elsewhere in the tree reaches only ~59 and cannot resolve what ships.
+  static constexpr uint32_t REC_REGEX_MATCH_LIMIT = 50000;
+
+  RegexMatchContext match_context;
+  match_context.set_match_limit(REC_REGEX_MATCH_LIMIT);
+  RegexMatches matches;
+
+  // Exhausting the limit is the only failure this bound provokes, and it is not a verdict, so count
+  // those names and report once per lookup instead of silently dropping records from the caller's
+  // results. Any other negative return keeps the pre-existing treat-as-no-match behavior.
+  unsigned indeterminate = 0;
+
   if ((rec_type & (RECT_PROCESS | RECT_NODE | RECT_PLUGIN))) {
     // First find the new metrics, this is a bit of a hack, because we still use the old
     // librecords callback with a "pseudo" record.
     for (auto &&[name, type, val] : ts::Metrics::instance()) {
-      if (regex.exec(name.data())) {
+      int const rc = regex.exec(name.data(), matches, 0, &match_context);
+
+      if (rc == RE_ERROR_MATCHLIMIT) {
+        ++indeterminate;
+      } else if (rc >= 0) {
         RecRecord tmp{};
 
         tmp.rec_type = RECT_PROCESS;
@@ -599,7 +623,11 @@ RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(
     }
     // Finally check string metrics
     ts::Metrics::StaticString::instance().for_each([&](const std::string &name, const std::string &value) {
-      if (regex.exec(name)) {
+      int const rc = regex.exec(name, matches, 0, &match_context);
+
+      if (rc == RE_ERROR_MATCHLIMIT) {
+        ++indeterminate;
+      } else if (rc >= 0) {
         RecRecord tmp{};
 
         tmp.rec_type = RECT_PROCESS;
@@ -626,7 +654,11 @@ RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(
     for (; it != hidden.end(); ++it) {
       auto &&[name, type, val] = *it;
 
-      if (regex.exec(name.data())) {
+      int const rc = regex.exec(name.data(), matches, 0, &match_context);
+
+      if (rc == RE_ERROR_MATCHLIMIT) {
+        ++indeterminate;
+      } else if (rc >= 0) {
         RecRecord tmp{};
 
         // Tag both bits so that a caller asking only for RECT_HIDDEN_METRIC passes the rec_type
@@ -652,13 +684,25 @@ RecLookupMatchingRecords(unsigned rec_type, const char *match, void (*callback)(
       continue;
     }
 
-    if (!regex.exec(r->name)) {
+    int const rc = regex.exec(r->name, matches, 0, &match_context);
+
+    if (rc == RE_ERROR_MATCHLIMIT) {
+      ++indeterminate;
+      continue;
+    }
+    if (rc < 0) {
       continue;
     }
 
     rec_mutex_acquire(&(r->lock));
     callback(r, data);
     rec_mutex_release(&(r->lock));
+  }
+
+  if (indeterminate > 0) {
+    // The caller supplied pattern is deliberately not echoed into the log.
+    Warning("record lookup pattern exceeded the %u step match limit on %u name(s); results are incomplete", REC_REGEX_MATCH_LIMIT,
+            indeterminate);
   }
 
   return REC_ERR_OKAY;

--- a/src/records/unit_tests/test_RecLookupMatchingRecords.cc
+++ b/src/records/unit_tests/test_RecLookupMatchingRecords.cc
@@ -1,0 +1,157 @@
+/** @file
+
+   Catch-based tests for RecLookupMatchingRecords regex handling.
+
+   @section license License
+
+   Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+   See the NOTICE file distributed with this work for additional information regarding copyright
+   ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance with the License.  You may obtain a
+   copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software distributed under the License
+   is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+   or implied. See the License for the specific language governing permissions and limitations under
+   the License.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <string>
+
+#include "records/RecCore.h"
+#include "tsutil/Metrics.h"
+#include "test_Diags.h"
+
+namespace
+{
+void
+count_callback(const RecRecord * /* record ATS_UNUSED */, void *data)
+{
+  ++*static_cast<int *>(data);
+}
+
+} // namespace
+
+// Bounded and unbounded both end in "no match" here, so only elapsed time separates them. At
+// PCRE2's 10,000,000 default a name costs about 20ms, so RECORD_COUNT is sized to put the unbounded
+// path several times past the threshold while the bounded one stays near 6ms. Lower it and the
+// unbounded path also finishes in time, leaving the test guarding nothing.
+TEST_CASE("RecLookupMatchingRecords bounds regex backtracking", "[librecords][RecCore][match-limit]")
+{
+  constexpr int  RECORD_COUNT   = 300;
+  constexpr auto TIME_THRESHOLD = std::chrono::seconds{2};
+
+  // A long 'a' run followed by a character that cannot satisfy the anchor is what drives "(a+)+$"
+  // into exponential backtracking.
+  const std::string suffix = std::string(40, 'a') + "z";
+
+  for (int i = 0; i < RECORD_COUNT; ++i) {
+    const std::string name = "proxy.config.test.matchlimit." + std::to_string(i) + "." + suffix;
+    REQUIRE(RecRegisterConfigInt(RECT_CONFIG, name.c_str(), 0, RECU_DYNAMIC, RECC_NULL, nullptr, REC_SOURCE_NULL) == REC_ERR_OKAY);
+  }
+
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags());
+  cdiag->messages.clear();
+
+  int  matches = 0;
+  auto start   = std::chrono::steady_clock::now();
+  REQUIRE(RecLookupMatchingRecords(RECT_CONFIG, "(a+)+$", count_callback, &matches) == REC_ERR_OKAY);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  CHECK(matches == 0);
+  CHECK(elapsed < TIME_THRESHOLD);
+
+  // Unlike the timing check above, this holds regardless of machine speed, so it is what actually
+  // pins the reporting behaviour.
+  REQUIRE(cdiag->messages.size() == 1);
+  CHECK(cdiag->messages[0].find("results are incomplete") != std::string::npos);
+}
+
+// Metrics are two more exec() sites, reached only for RECT_PROCESS, RECT_NODE and RECT_PLUGIN. The
+// RECT_CONFIG case above walks the record table instead, so it never enters them.
+TEST_CASE("RecLookupMatchingRecords bounds regex backtracking for metrics", "[librecords][RecCore][match-limit]")
+{
+  const std::string suffix = std::string(40, 'a') + "z";
+
+  ts::Metrics::Counter::createPtr("proxy.process.test.matchlimit.counter." + suffix);
+  ts::Metrics::StaticString::createString("proxy.process.test.matchlimit.string." + suffix, "value");
+
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags());
+  cdiag->messages.clear();
+
+  int matches = 0;
+
+  REQUIRE(RecLookupMatchingRecords(RECT_PROCESS, "(a+)+$", count_callback, &matches) == REC_ERR_OKAY);
+
+  // Only the two crafted names can exhaust the limit, so the count is what shows both loops ran
+  // rather than just one.
+  REQUIRE(cdiag->messages.size() == 1);
+  CHECK(cdiag->messages[0].find("on 2 name(s)") != std::string::npos);
+}
+
+// The fourth exec() site, reached only when RECT_HIDDEN_METRIC is requested, since hidden metrics
+// are excluded even from RECT_ALL, see RecDefs.h. No case above sets that bit.
+TEST_CASE("RecLookupMatchingRecords bounds regex backtracking for hidden metrics", "[librecords][RecCore][match-limit]")
+{
+  const std::string suffix = std::string(40, 'a') + "z";
+  auto             *m      = ts::Metrics::Gauge::createHiddenPtr("proxy.process.test.matchlimit.hidden." + suffix);
+
+  REQUIRE(m != nullptr);
+
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags());
+  cdiag->messages.clear();
+
+  int matches = 0;
+
+  REQUIRE(RecLookupMatchingRecords(RECT_HIDDEN_METRIC, "(a+)+$", count_callback, &matches) == REC_ERR_OKAY);
+
+  // The hidden store holds only what this file registers, so the crafted name is the only entry
+  // able to exhaust the limit.
+  REQUIRE(cdiag->messages.size() == 1);
+  CHECK(cdiag->messages[0].find("on 1 name(s)") != std::string::npos);
+}
+
+// The limit must also be loose enough for real lookups, or it silently drops records. Two
+// sequential ".*" proving no match is the most expensive shape a legitimate caller is likely to
+// write, at about L^2/2 steps for length L.
+//
+// The 250 character name below, far longer than the 66 character longest in a stock build, needs
+// about 25,400 steps: half of the 50,000 limit, so it is insensitive to step-accounting differences
+// between PCRE2 versions, yet 2.5x above 10,000, so reverting the limit to that or to 1750 fails
+// here rather than quietly truncating in production.
+TEST_CASE("RecLookupMatchingRecords does not truncate legitimate lookups", "[librecords][RecCore]")
+{
+  const std::string prefix = "proxy.config.test.longname.";
+  const std::string name   = prefix + std::string(250 - prefix.size(), 'x');
+
+  REQUIRE(RecRegisterConfigInt(RECT_CONFIG, name.c_str(), 0, RECU_DYNAMIC, RECC_NULL, nullptr, REC_SOURCE_NULL) == REC_ERR_OKAY);
+
+  CatchDiags *cdiag = static_cast<CatchDiags *>(diags());
+  cdiag->messages.clear();
+
+  // Anchoring on the prefix keeps every other registered name to a couple of steps, so this
+  // measures the long name and nothing else.
+  int matches = 0;
+
+  REQUIRE(RecLookupMatchingRecords(RECT_CONFIG, "^proxy\\.config\\.test\\.longname\\..*.*[~=]", count_callback, &matches) ==
+          REC_ERR_OKAY);
+
+  CHECK(matches == 0);
+  CHECK(cdiag->messages.empty());
+}
+
+TEST_CASE("RecLookupMatchingRecords still matches ordinary patterns", "[librecords][RecCore]")
+{
+  REQUIRE(RecRegisterConfigInt(RECT_CONFIG, "proxy.config.test.lookup.plain", 7, RECU_DYNAMIC, RECC_NULL, nullptr,
+                               REC_SOURCE_NULL) == REC_ERR_OKAY);
+
+  int matches = 0;
+  REQUIRE(RecLookupMatchingRecords(RECT_CONFIG, "proxy\\.config\\.test\\.lookup\\.plain", count_callback, &matches) ==
+          REC_ERR_OKAY);
+  CHECK(matches == 1);
+}

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -38,6 +38,7 @@ static_assert(RE_ANCHORED == PCRE2_ANCHORED, "Update RE_ANCHORED for current PCR
 static_assert(RE_NOTEMPTY == PCRE2_NOTEMPTY, "Update RE_NOTEMPTY for current PCRE2 version.");
 
 static_assert(RE_ERROR_NOMATCH == PCRE2_ERROR_NOMATCH, "Update RE_ERROR_NOMATCH for current PCRE2 version.");
+static_assert(RE_ERROR_MATCHLIMIT == PCRE2_ERROR_MATCHLIMIT, "Update RE_ERROR_MATCHLIMIT for current PCRE2 version.");
 static_assert(RE_ERROR_NULL == PCRE2_ERROR_NULL, "Update RE_ERROR_NULL for current PCRE2 version.");
 
 // PCRE2 10.30 added PCRE2_ENDANCHORED. Older PCRE2 (e.g., CentOS 7 ships 10.23) lacks it.

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_config_match_limit.test.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_config_match_limit.test.py
@@ -1,0 +1,61 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import sys
+
+# To include util classes
+sys.path.insert(0, f'{Test.TestDirectory}')
+
+from traffic_ctl_test_utils import Make_traffic_ctl
+
+Test.Summary = '''
+Test that a catastrophic regex given to traffic_ctl config match cannot stall the RPC server.
+'''
+
+Test.ContinueOnFail = True
+
+# Record names are letters and dots, so "([a-z.]+)+" can partition any of them a great many ways,
+# and the trailing class holds characters no name contains, so the match can never complete. No
+# crafted records are needed: against the 1328 names a stock server carries this costs roughly 20s
+# of CPU unbounded, against about 120ms once the match limit applies.
+#
+# Two details are load bearing. The tail must be a character class rather than a literal, because
+# for an absent literal PCRE2's required-code-unit check rejects each name up front and no
+# backtracking happens, leaving the test to pass with or without the fix. And it must be
+# unsatisfiable rather than merely unlikely; an earlier "[0-9]\z" tail matched
+# proxy.config.ssl.TLSv1, as lookups are case insensitive. The "(a+)+$" commonly cited is
+# useless here, no real name holds two consecutive 'a' characters to backtrack over.
+BACKTRACKING_PATTERN = '^([a-z.]+)+[~=]'
+
+records_yaml = '''
+    diags:
+      debug:
+        enabled: 0
+    '''
+
+traffic_ctl = Make_traffic_ctl(Test, records_yaml)
+
+# Every name is abandoned at the limit, so nothing matches; that the command returns promptly is
+# the point, not the empty result.
+traffic_ctl.config().match(f"'{BACKTRACKING_PATTERN}'").validate_with_text("")
+
+# An ordinary lookup afterwards shows the RPC server was left responsive rather than wedged.
+traffic_ctl.config().match("proxy.config.diags.debug.enabled") \
+    .validate_with_text("proxy.config.diags.debug.enabled: 0")
+
+# Truncating silently would hand the caller a short answer with no sign of it. Unlike a timing
+# check, this assertion does not depend on machine speed.
+traffic_ctl.ts.Disk.diags_log.Content += Testers.IncludesExpression(
+    "results are incomplete", "the truncated lookup should be reported, not silently returned as a short answer")

--- a/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
+++ b/tests/gold_tests/traffic_ctl/traffic_ctl_test_utils.py
@@ -504,6 +504,11 @@ class TrafficCtl(Config, Server):
             self._ts.Disk.records_config.update(records_yaml)
         self._tests = []
 
+    @property
+    def ts(self):
+        """The ATS process under test, for tests that also assert on its logs."""
+        return self._ts
+
     def __get_index(self):
         return self._current_test_number
 


### PR DESCRIPTION
`RecLookupMatchingRecords()` compiles a caller-supplied pattern and runs it
against every record and metric name with no complexity bound. It backs the
`admin_lookup_records` JSONRPC method, which is served inline on the RPC
server's single thread, so a pattern that backtracks heavily stalls that thread
for the duration.

Measured on a stock server carrying 1328 names: roughly 19s of CPU per request
unbounded, against about 123ms with the limit in this change.

### Change

- `include/tsutil/Regex.h`: add `RE_ERROR_MATCHLIMIT` (-47) to `REErrors`,
  alongside the existing `RE_ERROR_NOMATCH` and `RE_ERROR_NULL`.
- `src/tsutil/Regex.cc`: add the matching `static_assert` against
  `PCRE2_ERROR_MATCHLIMIT`, following the pattern already used for the other two.
- `src/records/RecCore.cc`: give all four `regex.exec()` call sites in
  `RecLookupMatchingRecords()` a `RegexMatchContext` with a 50,000 step match
  limit.

Exhausting the limit is not a match verdict, so those names are counted and
reported once per lookup via `Warning()` rather than silently dropped from the
caller's results. Any other negative return keeps the existing
treat-as-no-match behaviour. The pattern itself is deliberately not echoed into
the log.

On the choice of 50,000: raising the limit costs run time linearly, while the
longest name a pattern can still resolve grows only as its square root, since
proving no match costs about L^2/2 steps. 50,000 resolves names up to ~310
characters, 4.7x the 66 character longest name a stock build registers. The 1750
used elsewhere in the tree reaches only ~59 characters and cannot resolve what
ships.

### Tests

**Unit** -- `src/records/unit_tests/test_RecLookupMatchingRecords.cc`, three
cases covering config records, metrics (counter and static string) and hidden
metrics. `test_records` goes from 317 assertions in 44 cases on master to 636 in
49.

**Autest** -- `tests/gold_tests/traffic_ctl/traffic_ctl_config_match_limit.test.py`
drives `traffic_ctl config match` with `^([a-z.]+)+[~=]` and asserts three
things: the command returns promptly with no matches, an ordinary lookup
afterwards still answers (so the RPC server was not left wedged), and the diags
log carries the incomplete-results warning rather than silently returning a
short answer.

Two details in that pattern are load bearing, and are commented in the test. The
tail must be a character class rather than a literal, because for an absent
literal PCRE2's required-code-unit check rejects each name up front and no
backtracking happens -- the test would then pass with or without the change. And
it must be unsatisfiable rather than merely unlikely: an earlier `[0-9]\z` tail
matched `proxy.config.ssl.TLSv1`, since lookups are case insensitive. The
commonly cited `(a+)+$` is useless here, as no real record name holds two
consecutive `a` characters to backtrack over.

Asserting on the warning rather than on elapsed time keeps the test independent
of machine speed.
