### PR TITLE
HTTP/3: compare stream ids at full width in HQSession lookup

### DIFF
--- a/include/proxy/http3/Http3Transaction.h
+++ b/include/proxy/http3/Http3Transaction.h
@@ -61,6 +61,17 @@ public:
   void increment_transactions_stat() override;
   void decrement_transactions_stat() override;
 
+  /** Full-width QUIC stream identifier for this transaction.
+   *
+   *  @c get_transaction_id returns @c int and exists primarily for compact log
+   *  fields and probe arguments; QUIC stream IDs are 62-bit values, so callers
+   *  that route or compare by stream ID must use this accessor to avoid
+   *  truncation.
+   *
+   *  @return The QUIC stream ID owned by this transaction.
+   */
+  QUICStreamId get_quic_stream_id() const;
+
   // VConnection interface
   virtual VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override;
   virtual VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0,

--- a/include/proxy/http3/Http3Transaction.h
+++ b/include/proxy/http3/Http3Transaction.h
@@ -61,17 +61,6 @@ public:
   void increment_transactions_stat() override;
   void decrement_transactions_stat() override;
 
-  /** Full-width QUIC stream identifier for this transaction.
-   *
-   *  @c get_transaction_id returns @c int and exists primarily for compact log
-   *  fields and probe arguments; QUIC stream IDs are 62-bit values, so callers
-   *  that route or compare by stream ID must use this accessor to avoid
-   *  truncation.
-   *
-   *  @return The QUIC stream ID owned by this transaction.
-   */
-  QUICStreamId get_quic_stream_id() const;
-
   // VConnection interface
   virtual VIO *do_io_read(Continuation *c, int64_t nbytes = INT64_MAX, MIOBuffer *buf = 0) override;
   virtual VIO *do_io_write(Continuation *c = nullptr, int64_t nbytes = INT64_MAX, IOBufferReader *buf = 0,
@@ -84,6 +73,17 @@ public:
   virtual int             state_stream_open(int event, Event *data)   = 0;
   virtual int             state_stream_closed(int event, Event *data) = 0;
   NetVConnectionContext_t direction() const;
+
+  /** Full-width QUIC stream identifier for this transaction.
+   *
+   *  @c get_transaction_id returns @c int and exists primarily for compact log
+   *  fields and probe arguments; QUIC stream IDs are 62-bit values, so callers
+   *  that route or compare by stream ID must use this accessor to avoid
+   *  truncation.
+   *
+   *  @return The QUIC stream ID owned by this transaction.
+   */
+  QUICStreamId get_quic_stream_id() const;
 
   // For Queue from tscore/Link.h
   LINK(HQTransaction, link);

--- a/src/proxy/http3/Http3Session.cc
+++ b/src/proxy/http3/Http3Session.cc
@@ -97,7 +97,7 @@ HQTransaction *
 HQSession::get_transaction(QUICStreamId id)
 {
   for (HQTransaction *t = this->_transaction_list.head; t; t = static_cast<HQTransaction *>(t->link.next)) {
-    if (t->get_transaction_id() == static_cast<int>(id)) {
+    if (t->get_quic_stream_id() == id) {
       return t;
     }
   }

--- a/src/proxy/http3/Http3Transaction.cc
+++ b/src/proxy/http3/Http3Transaction.cc
@@ -226,6 +226,13 @@ HQTransaction::transaction_done()
 int
 HQTransaction::get_transaction_id() const
 {
+  // Narrowing is intentional here; see get_quic_stream_id() for the full-width value.
+  return static_cast<int>(this->_stream_id);
+}
+
+QUICStreamId
+HQTransaction::get_quic_stream_id() const
+{
   return this->_stream_id;
 }
 


### PR DESCRIPTION
`HQSession::get_transaction()` (`src/proxy/http3/Http3Session.cc:100`) matched
transactions with:

```c
if (t->get_transaction_id() == static_cast<int>(id)) {
```

`HQTransaction::get_transaction_id()` is declared `int` (it overrides
`ProxyTransaction`'s, and exists mainly for compact log fields and probe
arguments), while `QUICStreamId` is a 62-bit value. So the left side narrows on
return and the right side narrows in the cast, and two live transactions whose
stream ids share the low 32 bits resolve to the same entry.

This adds `HQTransaction::get_quic_stream_id()` and compares against that
instead. It returns `_stream_id`, the `QUICStreamId` the constructor already
caches (`src/proxy/http3/Http3Transaction.cc:68`):

```c
: super(session), _info(info), _stream_id(info.adapter.stream().id())
```

Reading the id back through `_info.adapter.stream()` at call time would
reintroduce the use-after-free that #13213 fixed, which is why the accessor uses
the cached member.

`get_transaction_id()` keeps its `int` return; nothing else compares or routes
by it. Its narrowing is now an explicit `static_cast<int>` with a comment
pointing at the new accessor, so the truncation reads as deliberate.
`QUICStreamId` is already visible in `Http3Transaction.h` via
`iocore/net/quic/QUICStreamVCAdapter.h`, so no new include is needed.

I checked for other sites narrowing a stream id the same way; this was the only
one in `src/proxy/http3/` and `include/proxy/http3/`.

### Test

No new test, and no existing test fails without this change.

The aliasing needs two concurrent transactions whose stream ids differ only
above bit 32. Client-initiated bidirectional stream ids advance by 4, and
`initial_max_streams_bidi_in` defaults to 100, so a stock server never issues an
id above roughly 400 -- reaching the collision requires a configuration no
default deployment uses. I would rather submit this as hardening than add a test
that only passes under a hand-tuned stream limit.

Run as a no-regression check, 8/8 pass: `h3_active_timeout`, `h3_flow_control`,
`h3_go_client`, `h3_proxy_verifier`, `h3_python_client`, `h3_sni_check`,
`h3_stream_lifetime`, `quic_no_activity_timeout`. `test_http3` is unchanged at
134 assertions in 15 cases, as expected -- the lookup is not unit tested.

---

**Updated 2026-09-08**

- `get_transaction_id()` casts explicitly with `static_cast<int>` instead of
  narrowing implicitly on return, and carries a comment pointing at
  `get_quic_stream_id()` for the full-width value.
- `get_quic_stream_id()` is declared in the `// HQTransaction` block next to
  `direction()` rather than under `// Implement ProxyClienTransaction
  interface`, since it is not a `ProxyTransaction` override.

Both are cast explicitness and declaration placement; the lookup change itself
is unchanged from the original push.
