### PR TITLE
header_rewrite: build the matcher for %{LAST-CAPTURE} conditions

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -763,6 +763,12 @@ This condition may be most useful as a value to an operand, such as::
     cond %{HEADER:X-Foo} /foo-(.*)/
       set-header X-Foo %{LAST-CAPTURE:1}
 
+It can also be matched against an operand, like any other condition::
+
+    cond %{HEADER:X-Foo} /foo-(.*)/ [AND]
+    cond %{LAST-CAPTURE:1} ("bar","fie")
+      set-header X-Matched "yes"
+
 METHOD
 ~~~~~~~
 ::

--- a/plugins/header_rewrite/conditions.cc
+++ b/plugins/header_rewrite/conditions.cc
@@ -1812,6 +1812,16 @@ ConditionStateInt16::eval(const Resources &res)
 
 // ConditionLastCapture
 void
+ConditionLastCapture::initialize(Parser &p)
+{
+  Condition::initialize(p);
+  auto match = std::make_unique<MatcherType>(_cond_op);
+
+  match->set(p.get_arg(), mods());
+  _matcher = std::move(match);
+}
+
+void
 ConditionLastCapture::set_qualifier(const std::string &q)
 {
   Condition::set_qualifier(q);

--- a/plugins/header_rewrite/conditions.h
+++ b/plugins/header_rewrite/conditions.h
@@ -960,6 +960,7 @@ public:
 
   void set_qualifier(const std::string &q) override;
   void append_value(std::string &s, const Resources &res) override;
+  void initialize(Parser &p) override;
 
 protected:
   bool eval(const Resources &res) override;

--- a/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
+++ b/tests/gold_tests/pluginTest/header_rewrite/header_rewrite_bundle.replay.yaml
@@ -211,6 +211,13 @@ autest:
             args:
               - "rules/rule_empty_json_body.conf"
 
+      - from: "http://www.example.com/from_23/"
+        to: "http://backend.ex:{SERVER_HTTP_PORT}/to_23/"
+        plugins:
+          - name: "header_rewrite.so"
+            args:
+              - "rules/last_capture.conf"
+
     metric_checks:
       - metric: "proxy.process.plugin.header_rewrite.operators"
         min: 1
@@ -2413,3 +2420,84 @@ sessions:
       headers:
         fields:
         - [ Content-Type, { value: "text/html; charset=utf-8", as: equal } ]
+
+# Test 92: LAST-CAPTURE as a condition - capture is a member of the set.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /from_23/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ X-Capture, "cap_foo_end" ]
+        - [ uuid, 92 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Capture-In-Set, { value: "foo", as: equal } ]
+        - [ X-Capture-No-Prior, { as: absent } ]
+        - [ X-Capture-Empty, { as: absent } ]
+
+# Test 93: LAST-CAPTURE as a condition - capture is not a member of the set.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /from_23/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ X-Capture, "cap_nope_end" ]
+        - [ uuid, 93 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Capture-In-Set, { as: absent } ]
+
+# Test 94: LAST-CAPTURE as a condition with no preceding regex match. The
+# condition has the implicit value of an empty string, which must evaluate
+# rather than crash on an unbuilt matcher.
+- transactions:
+  - client-request:
+      method: "GET"
+      version: "1.1"
+      url: /from_23/
+      headers:
+        fields:
+        - [ Host, www.example.com ]
+        - [ X-No-Capture, "yes" ]
+        - [ uuid, 94 ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Connection, close ]
+
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ X-Capture-In-Set, { as: absent } ]
+        - [ X-Capture-No-Prior, { as: absent } ]
+        - [ X-Capture-Empty, { value: "yes", as: equal } ]

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/last_capture.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/last_capture.conf
@@ -20,15 +20,15 @@
 cond %{SEND_RESPONSE_HDR_HOOK} [AND]
 cond %{CLIENT-HEADER:X-Capture} /^cap_(.+)_end$/ [AND]
 cond %{LAST-CAPTURE:1} ("foo","bar")
-   set-header X-Capture-In-Set "%{LAST-CAPTURE:1}"
+  set-header X-Capture-In-Set "%{LAST-CAPTURE:1}"
 
 # No preceding regex match: LAST-CAPTURE is the empty string, and must not match the set.
 cond %{SEND_RESPONSE_HDR_HOOK} [AND]
 cond %{CLIENT-HEADER:X-No-Capture} "yes" [AND]
 cond %{LAST-CAPTURE:1} ("foo","bar")
-   set-header X-Capture-No-Prior "unexpected"
+  set-header X-Capture-No-Prior "unexpected"
 
 cond %{SEND_RESPONSE_HDR_HOOK} [AND]
 cond %{CLIENT-HEADER:X-No-Capture} "yes" [AND]
 cond %{LAST-CAPTURE:1} =""
-   set-header X-Capture-Empty "yes"
+  set-header X-Capture-Empty "yes"

--- a/tests/gold_tests/pluginTest/header_rewrite/rules/last_capture.conf
+++ b/tests/gold_tests/pluginTest/header_rewrite/rules/last_capture.conf
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LAST-CAPTURE used as a condition (not only as a value expansion).
+
+cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+cond %{CLIENT-HEADER:X-Capture} /^cap_(.+)_end$/ [AND]
+cond %{LAST-CAPTURE:1} ("foo","bar")
+   set-header X-Capture-In-Set "%{LAST-CAPTURE:1}"
+
+# No preceding regex match: LAST-CAPTURE is the empty string, and must not match the set.
+cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+cond %{CLIENT-HEADER:X-No-Capture} "yes" [AND]
+cond %{LAST-CAPTURE:1} ("foo","bar")
+   set-header X-Capture-No-Prior "unexpected"
+
+cond %{SEND_RESPONSE_HDR_HOOK} [AND]
+cond %{CLIENT-HEADER:X-No-Capture} "yes" [AND]
+cond %{LAST-CAPTURE:1} =""
+   set-header X-Capture-Empty "yes"


### PR DESCRIPTION
ConditionLastCapture never overrode initialize(), so its _matcher stayed null and eval() dereferenced it: any config using the documented condition form crashed traffic_server on the first matching request. Only the value expansion form worked, which is why this went unnoticed since #12117 added the condition.

The new autest covers both spellings, including the documented "no previous match implies an empty string" case.