### PR TITLE
test_rpcserver: scope handler registration to the test case

### DIFF
--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -96,7 +96,9 @@ public:
   ~ScopedMethodHandler()
   {
     if (_registered) {
-      rpc::test_remove_handler(_name);
+      // CHECK rather than REQUIRE: this runs during stack unwinding when a SECTION failed, and a
+      // fatal assertion there would abort instead of reporting.
+      CHECK(rpc::test_remove_handler(_name));
     }
   }
 

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -43,6 +43,7 @@
 #include <cstdlib>
 #include <vector>
 #include <functional>
+#include <iostream>
 
 #include "swoc/swoc_file.h"
 
@@ -77,7 +78,10 @@ add_method_handler(const std::string &name, Func &&call)
 {
   return rpc::JsonRPCManager::instance().add_method_handler(name, std::forward<Func>(call), nullptr, {});
 }
+} // namespace rpc
 
+namespace
+{
 /// Registers a method handler and removes it when the scope ends.
 ///
 /// Catch2 re-runs a TEST_CASE body once per leaf SECTION. Registering at the top of the body and
@@ -93,13 +97,21 @@ public:
     _registered = rpc::add_method_handler(_name, std::forward<Func>(call));
   }
 
-  ~ScopedMethodHandler()
+  ~ScopedMethodHandler() noexcept
   {
-    if (_registered) {
-      // CHECK rather than REQUIRE: this runs during stack unwinding when a SECTION failed, and a
-      // fatal assertion there would abort instead of reporting.
+    if (!_registered) {
+      return;
+    }
+    // CHECK rather than REQUIRE: this runs during stack unwinding when a SECTION failed, and a
+    // fatal assertion there would abort instead of reporting. The try/catch is for the same
+    // reason -- taking the dispatcher lock or building the diagnostic can throw, and an
+    // exception escaping here would take the whole test binary down with it.
+    try {
       INFO("handler: " << _name);
       CHECK(rpc::test_remove_handler(_name));
+    } catch (...) {
+      // CHECK is unavailable here: it may be what threw.
+      std::cerr << "ScopedMethodHandler: exception while removing '" << _name << "'\n";
     }
   }
 
@@ -116,10 +128,7 @@ private:
   std::string _name;
   bool        _registered{false};
 };
-} // namespace rpc
 
-namespace
-{
 constexpr std::string_view rpc_test_dir_template{"ats_rpc_XXXXXX"};
 constexpr std::string_view rpc_test_socket_name{"s"};
 constexpr std::string_view rpc_test_lock_name{"l"};
@@ -463,8 +472,8 @@ TEST_CASE("Sending 'concurrent' requests to the rpc server.", "[thread]")
 {
   SECTION("A registered handlers")
   {
-    rpc::ScopedMethodHandler some_foo_handler{"some_foo", &some_foo};
-    rpc::ScopedMethodHandler some_foo2_handler{"some_foo2", &some_foo};
+    ScopedMethodHandler some_foo_handler{"some_foo", &some_foo};
+    ScopedMethodHandler some_foo2_handler{"some_foo2", &some_foo};
     REQUIRE(some_foo_handler.registered());
     REQUIRE(some_foo2_handler.registered());
 
@@ -521,7 +530,7 @@ DEFINE_JSONRPC_PROTO_FUNCTION(do_nothing) // id, params, resp
 
 TEST_CASE("Basic message sending to a running server", "[socket]")
 {
-  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  ScopedMethodHandler handler{"do_nothing", &do_nothing};
   REQUIRE(handler.registered());
   SECTION("Basic single request to the rpc server")
   {
@@ -576,7 +585,7 @@ TEST_CASE("JSONRPC socket inode permissions reflect restricted_api config", "[so
 
 TEST_CASE("Sending a message bigger than the internal server's buffer. 32000", "[buffer][error]")
 {
-  rpc::ScopedMethodHandler handler{"do_nothing32000", &do_nothing};
+  ScopedMethodHandler handler{"do_nothing32000", &do_nothing};
   REQUIRE(handler.registered());
   const int S{32000}; // + the rest of the json message.
   auto json{R"({"jsonrpc": "2.0", "method": "do_nothing32000", "params": {"msg":")" + random_string(S) + R"("}, "id":"32k_1"})"};
@@ -615,7 +624,7 @@ TEST_CASE("Sending a message bigger than the internal server's buffer. 32000", "
 
 TEST_CASE("Test with invalid json message", "[socket]")
 {
-  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  ScopedMethodHandler handler{"do_nothing", &do_nothing};
   REQUIRE(handler.registered());
 
   SECTION("A rpc server")
@@ -633,7 +642,7 @@ TEST_CASE("Test with invalid json message", "[socket]")
 
 TEST_CASE("Test with chunks", "[socket][chunks]")
 {
-  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  ScopedMethodHandler handler{"do_nothing", &do_nothing};
   REQUIRE(handler.registered());
 
   SECTION("Sending request by chunks")
@@ -655,7 +664,7 @@ TEST_CASE("Test with chunks", "[socket][chunks]")
 
 TEST_CASE("Test with chunks - disconnect after second part", "[socket][chunks]")
 {
-  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  ScopedMethodHandler handler{"do_nothing", &do_nothing};
   REQUIRE(handler.registered());
 
   SECTION("Sending request by chunks")
@@ -678,7 +687,7 @@ TEST_CASE("Test with chunks - disconnect after second part", "[socket][chunks]")
 
 TEST_CASE("Test with chunks - incomplete message", "[socket][chunks]")
 {
-  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  ScopedMethodHandler handler{"do_nothing", &do_nothing};
   REQUIRE(handler.registered());
 
   SECTION("Sending request by chunks, broken message")

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -43,7 +43,6 @@
 #include <cstdlib>
 #include <vector>
 #include <functional>
-#include <iostream>
 
 #include "swoc/swoc_file.h"
 
@@ -92,7 +91,7 @@ namespace
 class ScopedMethodHandler
 {
 public:
-  template <typename Func> ScopedMethodHandler(std::string name, Func &&call) : _name{std::move(name)}
+  template <typename Func> explicit ScopedMethodHandler(std::string name, Func &&call) : _name{std::move(name)}
   {
     _registered = rpc::add_method_handler(_name, std::forward<Func>(call));
   }
@@ -102,16 +101,17 @@ public:
     if (!_registered) {
       return;
     }
-    // CHECK rather than REQUIRE: this runs during stack unwinding when a SECTION failed, and a
-    // fatal assertion there would abort instead of reporting. The try/catch is for the same
-    // reason -- taking the dispatcher lock or building the diagnostic can throw, and an
-    // exception escaping here would take the whole test binary down with it.
+    // Non-fatal assertions throughout: this runs during stack unwinding when a SECTION failed,
+    // and a fatal one would abort instead of reporting. The try/catch is for the same reason --
+    // taking the dispatcher lock or building the diagnostic can throw, and an exception escaping
+    // a destructor ends the whole test binary rather than the one assertion.
     try {
       INFO("handler: " << _name);
       CHECK(rpc::test_remove_handler(_name));
+    } catch (std::exception const &ex) {
+      FAIL_CHECK("exception while removing handler '" << _name << "': " << ex.what());
     } catch (...) {
-      // CHECK is unavailable here: it may be what threw.
-      std::cerr << "ScopedMethodHandler: exception while removing '" << _name << "'\n";
+      FAIL_CHECK("unknown exception while removing handler '" << _name << "'");
     }
   }
 

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -98,6 +98,7 @@ public:
     if (_registered) {
       // CHECK rather than REQUIRE: this runs during stack unwinding when a SECTION failed, and a
       // fatal assertion there would abort instead of reporting.
+      INFO("handler: " << _name);
       CHECK(rpc::test_remove_handler(_name));
     }
   }
@@ -105,7 +106,7 @@ public:
   ScopedMethodHandler(ScopedMethodHandler const &)            = delete;
   ScopedMethodHandler &operator=(ScopedMethodHandler const &) = delete;
 
-  bool
+  [[nodiscard]] bool
   registered() const
   {
     return _registered;

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -77,6 +77,42 @@ add_method_handler(const std::string &name, Func &&call)
 {
   return rpc::JsonRPCManager::instance().add_method_handler(name, std::forward<Func>(call), nullptr, {});
 }
+
+/// Registers a method handler and removes it when the scope ends.
+///
+/// Catch2 re-runs a TEST_CASE body once per leaf SECTION. Registering at the top of the body and
+/// removing at the bottom only works while every assertion passes: REQUIRE is fatal, so a failure
+/// inside a SECTION unwinds before the trailing removal and the handler survives into the next
+/// SECTION's run, where re-registering it fails. One real failure then reports as two, and the
+/// second points at a registration that was never the problem.
+class ScopedMethodHandler
+{
+public:
+  template <typename Func> ScopedMethodHandler(std::string name, Func &&call) : _name{std::move(name)}
+  {
+    _registered = rpc::add_method_handler(_name, std::forward<Func>(call));
+  }
+
+  ~ScopedMethodHandler()
+  {
+    if (_registered) {
+      rpc::test_remove_handler(_name);
+    }
+  }
+
+  ScopedMethodHandler(ScopedMethodHandler const &)            = delete;
+  ScopedMethodHandler &operator=(ScopedMethodHandler const &) = delete;
+
+  bool
+  registered() const
+  {
+    return _registered;
+  }
+
+private:
+  std::string _name;
+  bool        _registered{false};
+};
 } // namespace rpc
 
 namespace
@@ -424,8 +460,10 @@ TEST_CASE("Sending 'concurrent' requests to the rpc server.", "[thread]")
 {
   SECTION("A registered handlers")
   {
-    rpc::add_method_handler("some_foo", &some_foo);
-    rpc::add_method_handler("some_foo2", &some_foo);
+    rpc::ScopedMethodHandler some_foo_handler{"some_foo", &some_foo};
+    rpc::ScopedMethodHandler some_foo2_handler{"some_foo2", &some_foo};
+    REQUIRE(some_foo_handler.registered());
+    REQUIRE(some_foo2_handler.registered());
 
     std::promise<std::string> p1;
     std::promise<std::string> p2;
@@ -480,7 +518,8 @@ DEFINE_JSONRPC_PROTO_FUNCTION(do_nothing) // id, params, resp
 
 TEST_CASE("Basic message sending to a running server", "[socket]")
 {
-  REQUIRE(rpc::add_method_handler("do_nothing", &do_nothing));
+  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  REQUIRE(handler.registered());
   SECTION("Basic single request to the rpc server")
   {
     const int S{500};
@@ -492,7 +531,6 @@ TEST_CASE("Basic message sending to a running server", "[socket]")
       REQUIRE(resp == R"({"jsonrpc": "2.0", "result": {"size": ")" + std::to_string(S) + R"("}, "id": "EfGh-1"})");
     }());
   }
-  REQUIRE(rpc::test_remove_handler("do_nothing"));
 }
 
 TEST_CASE("JSONRPC socket inode permissions reflect restricted_api config", "[socket][permissions]")
@@ -535,7 +573,8 @@ TEST_CASE("JSONRPC socket inode permissions reflect restricted_api config", "[so
 
 TEST_CASE("Sending a message bigger than the internal server's buffer. 32000", "[buffer][error]")
 {
-  REQUIRE(rpc::add_method_handler("do_nothing32000", &do_nothing));
+  rpc::ScopedMethodHandler handler{"do_nothing32000", &do_nothing};
+  REQUIRE(handler.registered());
   const int S{32000}; // + the rest of the json message.
   auto json{R"({"jsonrpc": "2.0", "method": "do_nothing32000", "params": {"msg":")" + random_string(S) + R"("}, "id":"32k_1"})"};
 
@@ -569,12 +608,12 @@ TEST_CASE("Sending a message bigger than the internal server's buffer. 32000", "
       REQUIRE(resp.empty());
     }());
   }
-  REQUIRE(rpc::test_remove_handler("do_nothing32000"));
 }
 
 TEST_CASE("Test with invalid json message", "[socket]")
 {
-  REQUIRE(rpc::add_method_handler("do_nothing", &do_nothing));
+  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  REQUIRE(handler.registered());
 
   SECTION("A rpc server")
   {
@@ -587,12 +626,12 @@ TEST_CASE("Test with invalid json message", "[socket]")
       CHECK(resp == R"({"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}})");
     }());
   }
-  REQUIRE(rpc::test_remove_handler("do_nothing"));
 }
 
 TEST_CASE("Test with chunks", "[socket][chunks]")
 {
-  REQUIRE(rpc::add_method_handler("do_nothing", &do_nothing));
+  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  REQUIRE(handler.registered());
 
   SECTION("Sending request by chunks")
   {
@@ -609,12 +648,12 @@ TEST_CASE("Test with chunks", "[socket][chunks]")
       REQUIRE(resp == R"({"jsonrpc": "2.0", "result": {"size": ")" + std::to_string(S) + R"("}, "id": "chunk-parts-3"})");
     }());
   }
-  REQUIRE(rpc::test_remove_handler("do_nothing"));
 }
 
 TEST_CASE("Test with chunks - disconnect after second part", "[socket][chunks]")
 {
-  REQUIRE(rpc::add_method_handler("do_nothing", &do_nothing));
+  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  REQUIRE(handler.registered());
 
   SECTION("Sending request by chunks")
   {
@@ -632,12 +671,12 @@ TEST_CASE("Test with chunks - disconnect after second part", "[socket][chunks]")
       REQUIRE(resp == "");
     }());
   }
-  REQUIRE(rpc::test_remove_handler("do_nothing"));
 }
 
 TEST_CASE("Test with chunks - incomplete message", "[socket][chunks]")
 {
-  REQUIRE(rpc::add_method_handler("do_nothing", &do_nothing));
+  rpc::ScopedMethodHandler handler{"do_nothing", &do_nothing};
+  REQUIRE(handler.registered());
 
   SECTION("Sending request by chunks, broken message")
   {
@@ -655,7 +694,6 @@ TEST_CASE("Test with chunks - incomplete message", "[socket][chunks]")
       REQUIRE(resp == R"({"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}})");
     }());
   }
-  REQUIRE(rpc::test_remove_handler("do_nothing"));
 }
 
 // Enable toggle


### PR DESCRIPTION
A failing assertion inside a SECTION reports twice. Catch2 re-runs the TEST_CASE body once per SECTION, and the trailing test_remove_handler() never runs when a fatal REQUIRE unwinds first, so the handler survives into the next run and its add_method_handler() fails as well. The second failure points at a registration that was never the problem.

Tie registration to a scope guard instead, so the handler is removed on the way out however the body exits. The concurrent-request case never removed its two handlers at all, and never checked that registering them worked; it uses the guard now as well.