### PR TITLE
Register one ctest test per Catch2 test case

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -59,6 +59,12 @@ if(BUILD_TESTING)
     cmake_parse_arguments(CATCH2_TEST "" "NAME" "COMMAND;ENVIRONMENT" ${ARGN})
 
     list(GET CATCH2_TEST_COMMAND 0 _catch2_command)
+    list(LENGTH CATCH2_TEST_COMMAND _catch2_command_length)
+    if(NOT _catch2_command_length EQUAL 1)
+      # Per-case discovery appends the case name to the command line, so there is
+      # nowhere to put caller-supplied runner arguments. Fail rather than drop them.
+      message(FATAL_ERROR "add_catch2_test(${CATCH2_TEST_NAME}): COMMAND must be a single test executable")
+    endif()
     if(_catch2_command MATCHES "^\\$<TARGET_FILE:(.+)>$")
       set(_catch2_target "${CMAKE_MATCH_1}")
     else()
@@ -70,8 +76,17 @@ if(BUILD_TESTING)
       # into one ;-joined string, so a multi-variable ENVIRONMENT loses every
       # variable but the first and turns the rest into junk property names. The
       # emulator prefix survives intact and also applies to test discovery.
+      #
+      # Prepend rather than replace: a cross-compiling build may already have an
+      # emulator here, and it has to keep running the executable.
+      get_property(
+        _catch2_emulator
+        TARGET ${_catch2_target}
+        PROPERTY CROSSCOMPILING_EMULATOR
+      )
       set_property(
         TARGET ${_catch2_target} PROPERTY CROSSCOMPILING_EMULATOR "${CMAKE_COMMAND}" -E env ${CATCH2_TEST_ENVIRONMENT}
+                                          ${_catch2_emulator}
       )
     endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,6 +32,7 @@ if(BUILD_TESTING)
   #
   # Update the above comment about the version to update.
   add_subdirectory(Catch2)
+  include(Catch)
 
   # Disable -Werror=parentheses for Catch2 to avoid issues with older compilers (GCC <=11)
   # that complain about the use of parentheses in macro expansions. We see errors like this:
@@ -43,14 +44,38 @@ if(BUILD_TESTING)
   target_compile_options(Catch2 INTERFACE -Wno-error=parentheses)
   target_compile_options(Catch2WithMain INTERFACE -Wno-error=parentheses)
 
-  # By default, as of v3.9.0, Catch2 runs tests in random order. Our tests are
-  # written with the expectation that they are run in declared order, with setup
-  # done in one TEST_CASE expected to carry over into the next TEST_CASE. This
-  # macro allows us to add common command line arguments to all tests. For now,
-  # we ensure declaration order execution via --order decl.
+  # Register one ctest test per Catch2 TEST_CASE/SCENARIO rather than one per
+  # executable. ctest then names the failing case instead of the binary, can
+  # schedule cases in parallel, and can run a single case by name. Because each
+  # case gets its own process, cases must not depend on state set up by an
+  # earlier case in the same executable.
+  #
+  # ctest names are "<NAME>.<case name>" so the NAME given here stays a usable
+  # -R filter prefix even where it differs from the target name.
+  #
+  # Discovery is PRE_TEST so that configuring/building does not require running
+  # the test executables.
   macro(add_catch2_test)
-    cmake_parse_arguments(CATCH2_TEST "" "NAME" "COMMAND" ${ARGN})
-    add_test(NAME ${CATCH2_TEST_NAME} COMMAND ${CATCH2_TEST_COMMAND} --order decl)
+    cmake_parse_arguments(CATCH2_TEST "" "NAME" "COMMAND;ENVIRONMENT" ${ARGN})
+
+    list(GET CATCH2_TEST_COMMAND 0 _catch2_command)
+    if(_catch2_command MATCHES "^\\$<TARGET_FILE:(.+)>$")
+      set(_catch2_target "${CMAKE_MATCH_1}")
+    else()
+      set(_catch2_target "${_catch2_command}")
+    endif()
+
+    if(CATCH2_TEST_ENVIRONMENT)
+      # Not ctest's ENVIRONMENT property: catch_discover_tests flattens PROPERTIES
+      # into one ;-joined string, so a multi-variable ENVIRONMENT loses every
+      # variable but the first and turns the rest into junk property names. The
+      # emulator prefix survives intact and also applies to test discovery.
+      set_property(
+        TARGET ${_catch2_target} PROPERTY CROSSCOMPILING_EMULATOR "${CMAKE_COMMAND}" -E env ${CATCH2_TEST_ENVIRONMENT}
+      )
+    endif()
+
+    catch_discover_tests(${_catch2_target} TEST_PREFIX "${CATCH2_TEST_NAME}." DISCOVERY_MODE PRE_TEST)
   endmacro()
 endif()
 

--- a/lib/swoc/unit_tests/test_swoc_file.cc
+++ b/lib/swoc/unit_tests/test_swoc_file.cc
@@ -213,11 +213,11 @@ TEST_CASE("file::path::create_directories", "[libswoc][swoc_file]") {
   CHECK(ec.value() == EINVAL);
   CHECK_FALSE(file::create_directories(file::path(), ec));
 
-  file::path testdir1 = tempdir / "dir1";
+  file::path testdir1 = tempdir / "libswoc_mkdir_1";
   CHECK(file::create_directories(testdir1, ec));
   CHECK(file::exists(testdir1));
 
-  file::path testdir2 = testdir1 / "dir2";
+  file::path testdir2 = testdir1 / "libswoc_mkdir_2";
   CHECK(file::create_directories(testdir2, ec));
   CHECK(file::exists(testdir1));
 
@@ -233,8 +233,8 @@ TEST_CASE("ts_file::path::remove", "[libswoc][fs_file]") {
   CHECK_FALSE(file::remove(file::path(), ec));
   CHECK(ec.value() == EINVAL);
 
-  file::path testdir1 = tempdir / "dir1";
-  file::path testdir2 = testdir1 / "dir2";
+  file::path testdir1 = tempdir / "libswoc_rm_1";
+  file::path testdir2 = testdir1 / "libswoc_rm_2";
   file::path file1    = testdir2 / "alpha.txt";
   file::path file2    = testdir2 / "bravo.txt";
   file::path file3    = testdir2 / "charlie.txt";

--- a/plugins/esi/test/CMakeLists.txt
+++ b/plugins/esi/test/CMakeLists.txt
@@ -21,11 +21,10 @@ target_link_libraries(esitest PUBLIC esi-common esicore)
 macro(ADD_ESI_TEST NAME)
   add_executable(${NAME} print_funcs.cc ${ARGN})
   target_link_libraries(${NAME} PRIVATE esitest)
-  add_catch2_test(NAME ${NAME}_esi COMMAND $<TARGET_FILE:${NAME}>)
   # Use ASan leak suppression for intentional DbgCtl leaks (issue #12776)
-  set_tests_properties(
-    ${NAME}_esi PROPERTIES ENVIRONMENT
-                           "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/esi_test_leak_suppression.txt"
+  add_catch2_test(
+    NAME ${NAME}_esi COMMAND $<TARGET_FILE:${NAME}> ENVIRONMENT
+    "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/esi_test_leak_suppression.txt"
   )
 endmacro()
 

--- a/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
+++ b/plugins/experimental/uri_signing/unit_tests/CMakeLists.txt
@@ -46,8 +46,7 @@ target_link_libraries(
           ts::inknet
           ts::overridable_txn_vars
 )
-add_catch2_test(NAME uri_signing_test COMMAND uri_signing_test)
-set_tests_properties(
-  uri_signing_test
-  PROPERTIES ENVIRONMENT "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/uri_signing_test_leak_suppression.txt"
+add_catch2_test(
+  NAME uri_signing_test COMMAND uri_signing_test ENVIRONMENT
+  "LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/uri_signing_test_leak_suppression.txt"
 )

--- a/src/config/unit_tests/config_test_temp_file.h
+++ b/src/config/unit_tests/config_test_temp_file.h
@@ -84,7 +84,11 @@ public:
     ofs << content;
   }
 
-  ~TempFile() { std::filesystem::remove(_path); }
+  ~TempFile()
+  {
+    std::error_code ec; // Best effort: cleanup must not throw out of a destructor.
+    std::filesystem::remove(_path, ec);
+  }
 
   std::string
   path() const

--- a/src/config/unit_tests/config_test_temp_file.h
+++ b/src/config/unit_tests/config_test_temp_file.h
@@ -1,0 +1,99 @@
+/** @file
+
+  Shared helpers for the config unit tests.
+
+  @section license License
+
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <unistd.h>
+
+namespace config::testing
+{
+
+/** Temp directory owned by this process, removed when the process exits.
+ *
+ * Each test case runs as its own concurrent ctest process, so a directory
+ * shared between them would let one case delete another's file mid-read. A
+ * directory per process rather than a unique file name keeps the file names
+ * these tests depend on, e.g. a legacy storage.config finding its sibling
+ * volume.config.
+ */
+inline std::filesystem::path const &
+per_process_temp_dir()
+{
+  class ScopedDir
+  {
+  public:
+    ScopedDir()
+    {
+      _path = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
+      std::filesystem::create_directories(_path);
+    }
+
+    ~ScopedDir()
+    {
+      std::error_code ec; // Best effort: a leftover temp directory must not fail the run.
+      std::filesystem::remove_all(_path, ec);
+    }
+
+    std::filesystem::path const &
+    path() const
+    {
+      return _path;
+    }
+
+  private:
+    std::filesystem::path _path;
+  };
+
+  static ScopedDir const dir;
+
+  return dir.path();
+}
+
+/// A file in per_process_temp_dir(), removed when it goes out of scope.
+class TempFile
+{
+public:
+  TempFile(std::string const &filename, std::string const &content)
+  {
+    _path = per_process_temp_dir() / filename;
+    std::ofstream ofs(_path);
+    ofs << content;
+  }
+
+  ~TempFile() { std::filesystem::remove(_path); }
+
+  std::string
+  path() const
+  {
+    return _path.string();
+  }
+
+private:
+  std::filesystem::path _path;
+};
+
+} // namespace config::testing

--- a/src/config/unit_tests/test_plugin_config.cc
+++ b/src/config/unit_tests/test_plugin_config.cc
@@ -21,57 +21,15 @@
   limitations under the License.
 */
 
-#include <catch2/catch_test_macros.hpp>
-#include <filesystem>
-#include <fstream>
+#include "config_test_temp_file.h"
 
-#include <unistd.h>
+#include <catch2/catch_test_macros.hpp>
 
 #include <yaml-cpp/yaml.h>
 
 #include "config/plugin_config.h"
 
-namespace
-{
-
-// Test cases run as separate, concurrent ctest processes, so they cannot share one
-// temp directory: a fixed file name would let one case delete another's file mid-read.
-// A directory per process rather than a unique file name keeps the file names these
-// tests depend on, e.g. a legacy storage.config finding its sibling volume.config.
-std::filesystem::path const &
-per_process_temp_dir()
-{
-  static std::filesystem::path const dir = [] {
-    auto d = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
-    std::filesystem::create_directories(d);
-    return d;
-  }();
-  return dir;
-}
-
-class TempFile
-{
-public:
-  TempFile(std::string const &filename, std::string const &content)
-  {
-    _path = per_process_temp_dir() / filename;
-    std::ofstream ofs(_path);
-    ofs << content;
-  }
-
-  ~TempFile() { std::filesystem::remove(_path); }
-
-  std::string
-  path() const
-  {
-    return _path.string();
-  }
-
-private:
-  std::filesystem::path _path;
-};
-
-} // namespace
+using config::testing::TempFile;
 
 TEST_CASE("plugin_config parser - basic active plugins", "[plugin_config]")
 {

--- a/src/config/unit_tests/test_plugin_config.cc
+++ b/src/config/unit_tests/test_plugin_config.cc
@@ -25,6 +25,8 @@
 #include <filesystem>
 #include <fstream>
 
+#include <unistd.h>
+
 #include <yaml-cpp/yaml.h>
 
 #include "config/plugin_config.h"
@@ -32,12 +34,27 @@
 namespace
 {
 
+// Test cases run as separate, concurrent ctest processes, so they cannot share one
+// temp directory: a fixed file name would let one case delete another's file mid-read.
+// A directory per process rather than a unique file name keeps the file names these
+// tests depend on, e.g. a legacy storage.config finding its sibling volume.config.
+std::filesystem::path const &
+per_process_temp_dir()
+{
+  static std::filesystem::path const dir = [] {
+    auto d = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
+    std::filesystem::create_directories(d);
+    return d;
+  }();
+  return dir;
+}
+
 class TempFile
 {
 public:
   TempFile(std::string const &filename, std::string const &content)
   {
-    _path = std::filesystem::temp_directory_path() / filename;
+    _path = per_process_temp_dir() / filename;
     std::ofstream ofs(_path);
     ofs << content;
   }

--- a/src/config/unit_tests/test_ssl_multicert.cc
+++ b/src/config/unit_tests/test_ssl_multicert.cc
@@ -23,11 +23,9 @@
 
 #include "config/ssl_multicert.h"
 
-#include <filesystem>
-#include <fstream>
 #include <utility>
 
-#include <unistd.h>
+#include "config_test_temp_file.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
@@ -36,43 +34,7 @@ using namespace config;
 
 namespace
 {
-// Helper to create a temporary file with content.
-// Test cases run as separate, concurrent ctest processes, so they cannot share one
-// temp directory: a fixed file name would let one case delete another's file mid-read.
-// A directory per process rather than a unique file name keeps the file names these
-// tests depend on, e.g. a legacy storage.config finding its sibling volume.config.
-std::filesystem::path const &
-per_process_temp_dir()
-{
-  static std::filesystem::path const dir = [] {
-    auto d = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
-    std::filesystem::create_directories(d);
-    return d;
-  }();
-  return dir;
-}
-
-class TempFile
-{
-public:
-  TempFile(std::string const &filename, std::string const &content)
-  {
-    _path = per_process_temp_dir() / filename;
-    std::ofstream ofs(_path);
-    ofs << content;
-  }
-
-  ~TempFile() { std::filesystem::remove(_path); }
-
-  std::string
-  path() const
-  {
-    return _path.string();
-  }
-
-private:
-  std::filesystem::path _path;
-};
+using config::testing::TempFile;
 
 // Helper to parse content via temp file.
 ConfigResult<SSLMultiCertConfig>

--- a/src/config/unit_tests/test_ssl_multicert.cc
+++ b/src/config/unit_tests/test_ssl_multicert.cc
@@ -27,6 +27,8 @@
 #include <fstream>
 #include <utility>
 
+#include <unistd.h>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
@@ -35,12 +37,27 @@ using namespace config;
 namespace
 {
 // Helper to create a temporary file with content.
+// Test cases run as separate, concurrent ctest processes, so they cannot share one
+// temp directory: a fixed file name would let one case delete another's file mid-read.
+// A directory per process rather than a unique file name keeps the file names these
+// tests depend on, e.g. a legacy storage.config finding its sibling volume.config.
+std::filesystem::path const &
+per_process_temp_dir()
+{
+  static std::filesystem::path const dir = [] {
+    auto d = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
+    std::filesystem::create_directories(d);
+    return d;
+  }();
+  return dir;
+}
+
 class TempFile
 {
 public:
   TempFile(std::string const &filename, std::string const &content)
   {
-    _path = std::filesystem::temp_directory_path() / filename;
+    _path = per_process_temp_dir() / filename;
     std::ofstream ofs(_path);
     ofs << content;
   }

--- a/src/config/unit_tests/test_storage.cc
+++ b/src/config/unit_tests/test_storage.cc
@@ -27,6 +27,8 @@
 #include <fstream>
 #include <string>
 
+#include <unistd.h>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "swoc/Errata.h"
@@ -37,12 +39,27 @@ using namespace config;
 namespace
 {
 
+// Test cases run as separate, concurrent ctest processes, so they cannot share one
+// temp directory: a fixed file name would let one case delete another's file mid-read.
+// A directory per process rather than a unique file name keeps the file names these
+// tests depend on, e.g. a legacy storage.config finding its sibling volume.config.
+std::filesystem::path const &
+per_process_temp_dir()
+{
+  static std::filesystem::path const dir = [] {
+    auto d = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
+    std::filesystem::create_directories(d);
+    return d;
+  }();
+  return dir;
+}
+
 class TempFile
 {
 public:
   TempFile(std::string const &filename, std::string const &content)
   {
-    _path = std::filesystem::temp_directory_path() / filename;
+    _path = per_process_temp_dir() / filename;
     std::ofstream ofs(_path);
     ofs << content;
   }

--- a/src/config/unit_tests/test_storage.cc
+++ b/src/config/unit_tests/test_storage.cc
@@ -23,11 +23,9 @@
 
 #include "config/storage.h"
 
-#include <filesystem>
-#include <fstream>
 #include <string>
 
-#include <unistd.h>
+#include "config_test_temp_file.h"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -39,42 +37,7 @@ using namespace config;
 namespace
 {
 
-// Test cases run as separate, concurrent ctest processes, so they cannot share one
-// temp directory: a fixed file name would let one case delete another's file mid-read.
-// A directory per process rather than a unique file name keeps the file names these
-// tests depend on, e.g. a legacy storage.config finding its sibling volume.config.
-std::filesystem::path const &
-per_process_temp_dir()
-{
-  static std::filesystem::path const dir = [] {
-    auto d = std::filesystem::temp_directory_path() / ("ats_config_test." + std::to_string(getpid()));
-    std::filesystem::create_directories(d);
-    return d;
-  }();
-  return dir;
-}
-
-class TempFile
-{
-public:
-  TempFile(std::string const &filename, std::string const &content)
-  {
-    _path = per_process_temp_dir() / filename;
-    std::ofstream ofs(_path);
-    ofs << content;
-  }
-
-  ~TempFile() { std::filesystem::remove(_path); }
-
-  std::string
-  path() const
-  {
-    return _path.string();
-  }
-
-private:
-  std::filesystem::path _path;
-};
+using config::testing::TempFile;
 
 ConfigResult<StorageConfig>
 parse_file(std::string const &content, std::string const &filename = "storage.yaml")

--- a/src/iocore/cache/unit_tests/test_CacheShm.cc
+++ b/src/iocore/cache/unit_tests/test_CacheShm.cc
@@ -246,7 +246,14 @@ namespace
 {
 
 // A prefix of our own so these tests can never touch a real instance's segments.
-constexpr const char *PURGE_PREFIX_WORD = "atspurgetest";
+// Per process: POSIX shm names are system global and every TEST_CASE runs as its own
+// ctest process, so a fixed word would let concurrent cases fight over one segment.
+std::string const &
+purge_prefix_word()
+{
+  static std::string const word{"atspurgetest" + std::to_string(getpid())};
+  return word;
+}
 
 // Valid magic, one claimed stripe, and `owner_pid` as given. `size` may be short of CONTROL_SIZE -- an older build with a
 // smaller stripe table -- so only what exists is mapped. False if shm is unavailable here.
@@ -327,7 +334,7 @@ segment_size(const std::string &name)
 // the name space, or every stripe segment leaks while `traffic_ctl cache shm clear` reports success.
 TEST_CASE("CacheShm purge sweeps by name when the control layout is foreign", "[cache][shm]")
 {
-  const std::string prefix      = cache_shm::normalize_name_prefix(PURGE_PREFIX_WORD);
+  const std::string prefix      = cache_shm::normalize_name_prefix(purge_prefix_word());
   const std::string stripe_name = cache_shm::stripe_segment_name(prefix, 0);
 
   // Stands in for a build with a larger stripe table.
@@ -351,7 +358,7 @@ TEST_CASE("CacheShm purge sweeps by name when the control layout is foreign", "[
 // The same-size case must walk the table rather than sweep, so a shared name space is not over-swept.
 TEST_CASE("CacheShm purge walks the table when the control layout is ours", "[cache][shm]")
 {
-  const std::string prefix = cache_shm::normalize_name_prefix(PURGE_PREFIX_WORD);
+  const std::string prefix = cache_shm::normalize_name_prefix(purge_prefix_word());
 
   if (!plant_control_segment(prefix, cache_shm::CONTROL_SIZE)) {
     WARN("shm unavailable in this environment; skipping");
@@ -377,7 +384,7 @@ TEST_CASE("CacheShm purge walks the table when the control layout is ours", "[ca
 // header is there so a newer traffic_ctl can recognise that owner, not so it can unlink the names out from under it.
 TEST_CASE("CacheShm purge refuses a smaller foreign control segment with a live owner", "[cache][shm]")
 {
-  const std::string prefix      = cache_shm::normalize_name_prefix(PURGE_PREFIX_WORD);
+  const std::string prefix      = cache_shm::normalize_name_prefix(purge_prefix_word());
   const std::string control     = cache_shm::control_segment_name(prefix);
   const std::string stripe_name = cache_shm::stripe_segment_name(prefix, 0);
 
@@ -415,7 +422,7 @@ TEST_CASE("CacheShm purge refuses a smaller foreign control segment with a live 
 // stale one left by a build that is gone.
 TEST_CASE("CacheShm purge clears a smaller foreign control segment with no owner", "[cache][shm]")
 {
-  const std::string prefix      = cache_shm::normalize_name_prefix(PURGE_PREFIX_WORD);
+  const std::string prefix      = cache_shm::normalize_name_prefix(purge_prefix_word());
   const std::string control     = cache_shm::control_segment_name(prefix);
   const std::string stripe_name = cache_shm::stripe_segment_name(prefix, 0);
 

--- a/src/iocore/cache/unit_tests/test_CacheShm.cc
+++ b/src/iocore/cache/unit_tests/test_CacheShm.cc
@@ -248,10 +248,12 @@ namespace
 // A prefix of our own so these tests can never touch a real instance's segments.
 // Per process: POSIX shm names are system global and every TEST_CASE runs as its own
 // ctest process, so a fixed word would let concurrent cases fight over one segment.
+// Length budget: the word becomes "/<word>-control", so len(word) must stay under
+// MAX_SHM_NAME_LEN - 9 == 22. Eight characters plus a pid leaves ample room.
 std::string const &
 purge_prefix_word()
 {
-  static std::string const word{"atspurgetest" + std::to_string(getpid())};
+  static std::string const word{"atspurge" + std::to_string(getpid())};
   return word;
 }
 

--- a/src/iocore/cache/unit_tests/test_CacheShmShutdown.cc
+++ b/src/iocore/cache/unit_tests/test_CacheShmShutdown.cc
@@ -47,13 +47,15 @@ bool reuse_existing_cache = false;
 namespace
 {
 
-// Our own prefix so these can never touch a real instance's segments, short enough to stay under the 31-char POSIX limit.
+// Our own prefix so these can never touch a real instance's segments.
 // Per process: POSIX shm names are system global and every TEST_CASE runs as its own
 // ctest process, so a fixed word would let concurrent cases fight over one segment.
+// Length budget: the word becomes "/<word>-control", so len(word) must stay under
+// MAX_SHM_NAME_LEN - 9 == 22. Seven characters plus a pid leaves ample room.
 std::string const &
 test_prefix_word()
 {
-  static std::string const word{"atsunittest" + std::to_string(getpid())};
+  static std::string const word{"atsunit" + std::to_string(getpid())};
   return word;
 }
 

--- a/src/iocore/cache/unit_tests/test_CacheShmShutdown.cc
+++ b/src/iocore/cache/unit_tests/test_CacheShmShutdown.cc
@@ -48,14 +48,22 @@ namespace
 {
 
 // Our own prefix so these can never touch a real instance's segments, short enough to stay under the 31-char POSIX limit.
-constexpr const char *TEST_PREFIX_WORD = "atsunittest";
+// Per process: POSIX shm names are system global and every TEST_CASE runs as its own
+// ctest process, so a fixed word would let concurrent cases fight over one segment.
+std::string const &
+test_prefix_word()
+{
+  static std::string const word{"atsunittest" + std::to_string(getpid())};
+  return word;
+}
 
 // False when shm is unavailable here, e.g. a sandbox forbidding shm_open, so the test skips rather than fails.
 bool
 enable_shm()
 {
   REQUIRE(RecSetRecordInt("proxy.config.cache.shm.enabled", 1, REC_SOURCE_EXPLICIT) == REC_ERR_OKAY);
-  REQUIRE(RecSetRecordString("proxy.config.cache.shm.name_prefix", TEST_PREFIX_WORD, REC_SOURCE_EXPLICIT) == REC_ERR_OKAY);
+  REQUIRE(RecSetRecordString("proxy.config.cache.shm.name_prefix", test_prefix_word().c_str(), REC_SOURCE_EXPLICIT) ==
+          REC_ERR_OKAY);
 
   Store store;
   CacheShm::initialize(store);
@@ -66,7 +74,7 @@ enable_shm()
 void
 unlink_test_segments()
 {
-  const std::string prefix = cache_shm::normalize_name_prefix(TEST_PREFIX_WORD);
+  const std::string prefix = cache_shm::normalize_name_prefix(test_prefix_word());
   shm_unlink(cache_shm::control_segment_name(prefix).c_str());
   for (uint32_t i = 0; i < 4; ++i) {
     shm_unlink(cache_shm::stripe_segment_name(prefix, i).c_str());
@@ -78,7 +86,7 @@ unlink_test_segments()
 bool
 stripe_marked_untrusted(uint32_t idx)
 {
-  const std::string prefix = cache_shm::normalize_name_prefix(TEST_PREFIX_WORD);
+  const std::string prefix = cache_shm::normalize_name_prefix(test_prefix_word());
   int               fd     = shm_open(cache_shm::control_segment_name(prefix).c_str(), O_RDONLY, 0600);
   REQUIRE(fd >= 0);
   void *addr = mmap(nullptr, cache_shm::CONTROL_SIZE, PROT_READ, MAP_SHARED, fd, 0);
@@ -94,7 +102,7 @@ stripe_marked_untrusted(uint32_t idx)
 uint32_t
 control_stripe_count()
 {
-  const std::string prefix = cache_shm::normalize_name_prefix(TEST_PREFIX_WORD);
+  const std::string prefix = cache_shm::normalize_name_prefix(test_prefix_word());
   int               fd     = shm_open(cache_shm::control_segment_name(prefix).c_str(), O_RDONLY, 0600);
   REQUIRE(fd >= 0);
   void *addr = mmap(nullptr, cache_shm::CONTROL_SIZE, PROT_READ, MAP_SHARED, fd, 0);

--- a/src/iocore/hostdb/unit_tests/CMakeLists.txt
+++ b/src/iocore/hostdb/unit_tests/CMakeLists.txt
@@ -32,9 +32,7 @@ add_catch2_test(NAME test_hostdb_HostFile COMMAND $<TARGET_FILE:test_HostFile>)
 # test_RefCountCache
 add_executable(test_RefCountCache test_RefCountCache.cc)
 target_include_directories(test_RefCountCache PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
-target_link_libraries(
-  test_RefCountCache PRIVATE ts::tscore ts::tsutil ts::inkevent configmanager Catch2::Catch2WithMain
-)
-# test_RefCountCache has its own main() and is not a Catch2 runner, so it cannot
-# be split into per-case ctest entries.
+target_link_libraries(test_RefCountCache PRIVATE ts::tscore ts::tsutil ts::inkevent configmanager)
+# test_RefCountCache has its own main() and uses no Catch2 at all, so it cannot be
+# split into per-case ctest entries.
 add_test(NAME test_hostdb_RefCountCache COMMAND $<TARGET_FILE:test_RefCountCache>)

--- a/src/iocore/hostdb/unit_tests/CMakeLists.txt
+++ b/src/iocore/hostdb/unit_tests/CMakeLists.txt
@@ -35,4 +35,6 @@ target_include_directories(test_RefCountCache PRIVATE "${CMAKE_CURRENT_SOURCE_DI
 target_link_libraries(
   test_RefCountCache PRIVATE ts::tscore ts::tsutil ts::inkevent configmanager Catch2::Catch2WithMain
 )
-add_catch2_test(NAME test_hostdb_RefCountCache COMMAND $<TARGET_FILE:test_RefCountCache>)
+# test_RefCountCache has its own main() and is not a Catch2 runner, so it cannot
+# be split into per-case ctest entries.
+add_test(NAME test_hostdb_RefCountCache COMMAND $<TARGET_FILE:test_RefCountCache>)

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -225,7 +225,7 @@ if(BUILD_TESTING)
   if(APPLE)
     add_catch2_test(NAME test_net COMMAND test_net)
   else()
-    # Disable ORD violation caused by double definition inside a stub file libinknet_stub.cc
+    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
     # see remap_test_dlopen_leak_suppression.txt for more info.
     add_catch2_test(NAME test_net COMMAND test_net ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
   endif()

--- a/src/iocore/net/CMakeLists.txt
+++ b/src/iocore/net/CMakeLists.txt
@@ -222,12 +222,12 @@ if(BUILD_TESTING)
   endif()
   set(LIBINKNET_UNIT_TEST_DIR "${CMAKE_SOURCE_DIR}/src/iocore/net/unit_tests")
   target_compile_definitions(test_net PRIVATE LIBINKNET_UNIT_TEST_DIR=${LIBINKNET_UNIT_TEST_DIR})
-  add_catch2_test(NAME test_net COMMAND test_net)
-
-  if(NOT APPLE)
+  if(APPLE)
+    add_catch2_test(NAME test_net COMMAND test_net)
+  else()
     # Disable ORD violation caused by double definition inside a stub file libinknet_stub.cc
     # see remap_test_dlopen_leak_suppression.txt for more info.
-    set_tests_properties(test_net PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
+    add_catch2_test(NAME test_net COMMAND test_net ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
   endif()
 endif()
 

--- a/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
+++ b/src/mgmt/rpc/server/unit_tests/test_rpcserver.cc
@@ -185,12 +185,15 @@ struct RPCServerTestListener : Catch::EventListenerBase {
                  R"(",  "backlog": 5,"max_retry_on_transient_errors": 64, "incoming_request_max_size": 32000 }}})"};
     YAML::Node configNode = YAML::Load(confStr);
     serverConfig.load(configNode["rpc"]);
+    // Report this loudly: otherwise every socket test just fails later with a
+    // confusing "no such file" on the socket path, which is especially noisy
+    // now that each test case runs as its own process.
     try {
       jsonrpcServer = new rpc::RPCServer(serverConfig);
 
       jsonrpcServer->start_thread();
     } catch (std::exception const &ex) {
-      Dbg(dbg_ctl, "Oops: %s", ex.what());
+      std::fprintf(stderr, "Failed to start the JSONRPC test server on %s: %s\n", sockPath.c_str(), ex.what());
     }
   }
 

--- a/src/proxy/http/remap/unit-tests/CMakeLists.txt
+++ b/src/proxy/http/remap/unit-tests/CMakeLists.txt
@@ -94,7 +94,16 @@ if(NOT APPLE)
 endif()
 
 if(NOT APPLE)
-  add_catch2_test(NAME test_PluginDso COMMAND $<TARGET_FILE:test_PluginDso>)
+  add_catch2_test(
+    NAME
+    test_PluginDso
+    COMMAND
+    $<TARGET_FILE:test_PluginDso>
+    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
+    # see remap_test_dlopen_leak_suppression.txt for more info.
+    ENVIRONMENT
+    "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
+  )
 endif()
 ### test_PluginFactory ########################################################################
 
@@ -133,7 +142,16 @@ target_link_libraries(
 )
 
 if(NOT APPLE)
-  add_catch2_test(NAME test_PluginFactory COMMAND $<TARGET_FILE:test_PluginFactory>)
+  add_catch2_test(
+    NAME
+    test_PluginFactory
+    COMMAND
+    $<TARGET_FILE:test_PluginFactory>
+    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
+    # see remap_test_dlopen_leak_suppression.txt for more info.
+    ENVIRONMENT
+    "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
+  )
 endif()
 ### test_RemapPluginInfo ########################################################################
 
@@ -166,18 +184,15 @@ target_link_libraries(
 )
 
 if(NOT APPLE)
-  add_catch2_test(NAME test_RemapPluginInfo COMMAND $<TARGET_FILE:test_RemapPluginInfo>)
-endif()
-
-# not in the same if as the above will be removed shortly.
-if(NOT APPLE)
-  # Disable ORD violation caused by double definition inside a stub file libinknet_stub.cc
-  # see remap_test_dlopen_leak_suppression.txt for more info.
-  set_tests_properties(
-    test_RemapPluginInfo test_PluginDso test_PluginFactory
-    PROPERTIES
-      ENVIRONMENT
-      "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
+  add_catch2_test(
+    NAME
+    test_RemapPluginInfo
+    COMMAND
+    $<TARGET_FILE:test_RemapPluginInfo>
+    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
+    # see remap_test_dlopen_leak_suppression.txt for more info.
+    ENVIRONMENT
+    "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
   )
 endif()
 ### test_NextHopStrategyFactory ########################################################################

--- a/src/proxy/http/remap/unit-tests/CMakeLists.txt
+++ b/src/proxy/http/remap/unit-tests/CMakeLists.txt
@@ -93,17 +93,14 @@ if(NOT APPLE)
   target_link_options(test_PluginDso PRIVATE -Wl,--allow-multiple-definition)
 endif()
 
-if(NOT APPLE)
-  add_catch2_test(
-    NAME
-    test_PluginDso
-    COMMAND
-    $<TARGET_FILE:test_PluginDso>
-    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
-    # see remap_test_dlopen_leak_suppression.txt for more info.
-    ENVIRONMENT
+# These tests dlopen plugins, and the stub file libinknet_stub.cc double-defines symbols.
+# Disable the resulting ODR violation report; see remap_test_dlopen_leak_suppression.txt.
+set(REMAP_DSO_TEST_ENVIRONMENT
     "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
-  )
+)
+
+if(NOT APPLE)
+  add_catch2_test(NAME test_PluginDso COMMAND $<TARGET_FILE:test_PluginDso> ENVIRONMENT "${REMAP_DSO_TEST_ENVIRONMENT}")
 endif()
 ### test_PluginFactory ########################################################################
 
@@ -143,14 +140,7 @@ target_link_libraries(
 
 if(NOT APPLE)
   add_catch2_test(
-    NAME
-    test_PluginFactory
-    COMMAND
-    $<TARGET_FILE:test_PluginFactory>
-    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
-    # see remap_test_dlopen_leak_suppression.txt for more info.
-    ENVIRONMENT
-    "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
+    NAME test_PluginFactory COMMAND $<TARGET_FILE:test_PluginFactory> ENVIRONMENT "${REMAP_DSO_TEST_ENVIRONMENT}"
   )
 endif()
 ### test_RemapPluginInfo ########################################################################
@@ -185,14 +175,7 @@ target_link_libraries(
 
 if(NOT APPLE)
   add_catch2_test(
-    NAME
-    test_RemapPluginInfo
-    COMMAND
-    $<TARGET_FILE:test_RemapPluginInfo>
-    # Disable ODR violation caused by double definition inside a stub file libinknet_stub.cc
-    # see remap_test_dlopen_leak_suppression.txt for more info.
-    ENVIRONMENT
-    "ASAN_OPTIONS=detect_odr_violation=0;LSAN_OPTIONS=suppressions=${CMAKE_CURRENT_SOURCE_DIR}/remap_test_dlopen_leak_suppression.txt"
+    NAME test_RemapPluginInfo COMMAND $<TARGET_FILE:test_RemapPluginInfo> ENVIRONMENT "${REMAP_DSO_TEST_ENVIRONMENT}"
   )
 endif()
 ### test_NextHopStrategyFactory ########################################################################

--- a/src/proxy/http2/unit_tests/main.cc
+++ b/src/proxy/http2/unit_tests/main.cc
@@ -34,6 +34,7 @@
 #include "iocore/utils/diags.i"
 
 #include "proxy/hdrs/HuffmanCodec.h"
+#include "proxy/http2/HTTP2.h"
 
 #define TEST_THREADS 1
 
@@ -53,6 +54,13 @@ struct EventProcessorListener : Catch::EventListenerBase {
 
     EThread *main_thread = new EThread;
     main_thread->set_specific();
+
+    // Every TEST_CASE runs in its own process, so the header subsystems must be
+    // initialized here rather than by whichever case happens to run first.
+    url_init();
+    mime_init();
+    http_init();
+    http2_init();
   }
 
   void

--- a/src/proxy/http2/unit_tests/test_HTTP2.cc
+++ b/src/proxy/http2/unit_tests/test_HTTP2.cc
@@ -31,11 +31,6 @@
 
 TEST_CASE("Convert HTTPHdr", "[HTTP2]")
 {
-  url_init();
-  mime_init();
-  http_init();
-  http2_init();
-
   HTTPParser     parser;
   ts::PostScript parser_defer([&]() -> void { http_parser_clear(&parser); });
   http_parser_init(&parser);

--- a/src/proxy/unit_tests/test_PluginYAML.cc
+++ b/src/proxy/unit_tests/test_PluginYAML.cc
@@ -47,7 +47,11 @@ public:
     f << content;
   }
 
-  ~TempYAML() { std::filesystem::remove(_path); }
+  ~TempYAML()
+  {
+    std::error_code ec; // Best effort: cleanup must not throw out of a destructor.
+    std::filesystem::remove(_path, ec);
+  }
 
   const char *
   path() const

--- a/src/proxy/unit_tests/test_PluginYAML.cc
+++ b/src/proxy/unit_tests/test_PluginYAML.cc
@@ -22,9 +22,11 @@
 */
 
 #include <catch2/catch_test_macros.hpp>
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <unistd.h>
 
 #include "proxy/Plugin.h"
 
@@ -35,7 +37,12 @@ class TempYAML
 public:
   explicit TempYAML(const std::string &content)
   {
-    _path = std::filesystem::temp_directory_path() / "test_plugin_yaml.yaml";
+    // Unique per instance: test cases run as separate, concurrent ctest processes,
+    // so a fixed name would let one case delete another's file mid-read.
+    static std::atomic<unsigned> seq{0};
+
+    _path = std::filesystem::temp_directory_path() /
+            ("test_plugin_yaml." + std::to_string(getpid()) + "." + std::to_string(seq++) + ".yaml");
     std::ofstream f(_path);
     f << content;
   }


### PR DESCRIPTION
Resurrecting #12703 but with help from Claude


Registering whole executables means a failure names the binary rather than the case that broke, a single case cannot be run on its own, and ctest can only schedule at executable granularity. Use catch_discover_tests so ctest sees each TEST_CASE, which takes the suite from ~100 entries to 1022.

That only works if cases stop depending on each other, since each now runs in its own process concurrently with the rest. Fixed the fallout:

- test_http2 relied on whichever case ran first calling url_init() and friends; moved that into the test-run listener.
- The plugin.yaml, storage/plugin/ssl_multicert config, and cache shm tests each shared one fixed temp file or POSIX shm name across every case, so concurrent cases deleted each other's state. Made those per process. The config tests get a directory per process rather than unique file names, which preserves the names they depend on.
- test_RefCountCache has its own main() and is not a Catch2 runner, so it stays a single add_test.

add_catch2_test grows an ENVIRONMENT argument. It applies the variables via a `cmake -E env` prefix instead of ctest's ENVIRONMENT property because catch_discover_tests flattens PROPERTIES into one ;-joined string, which silently dropped all but the first variable and clobbered SKIP_RETURN_CODE. --order decl is gone: with one case per process there is no order left to pin.