### PR TITLE
Inherit the shared match context configuration in RegexMatchContext

### DIFF
--- a/include/tsutil/Regex.h
+++ b/include/tsutil/Regex.h
@@ -113,12 +113,13 @@ public:
   RegexMatchContext();
   ~RegexMatchContext();
 
-  /// uses pcre2_match_context_copy for a deep copy.
-  RegexMatchContext(RegexMatchContext const &orig);
-  RegexMatchContext &operator=(RegexMatchContext const &orig);
-
-  RegexMatchContext(RegexMatchContext &&)            = default;
-  RegexMatchContext &operator=(RegexMatchContext &&) = default;
+  /// Not copyable or movable. Nothing copies one, the defaulted move copied the
+  /// raw pointer and left both objects freeing it, and the copy constructor could
+  /// leave the pointer null for its own destructor to assert on.
+  RegexMatchContext(RegexMatchContext const &)            = delete;
+  RegexMatchContext &operator=(RegexMatchContext const &) = delete;
+  RegexMatchContext(RegexMatchContext &&)                 = delete;
+  RegexMatchContext &operator=(RegexMatchContext &&)      = delete;
 
   /** Limits the amount of backtracking that can take place.
    * Any regex exec call that fails will return PCRE2_ERROR_MATCHLIMIT(-47)

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -304,32 +304,6 @@ RegexMatchContext::RegexMatchContext()
 }
 
 //----------------------------------------------------------------------------
-RegexMatchContext::RegexMatchContext(RegexMatchContext const &other)
-{
-  auto ptr = _MatchContext::get(other._match_context);
-  if (nullptr != ptr) {
-    pcre2_match_context *const ctx = pcre2_match_context_copy(ptr);
-    _MatchContext::set(_match_context, ctx);
-  }
-}
-
-//----------------------------------------------------------------------------
-RegexMatchContext &
-RegexMatchContext::operator=(RegexMatchContext const &other)
-{
-  if (&other != this) {
-    auto ptr = _MatchContext::get(other._match_context);
-    if (nullptr != ptr) {
-      pcre2_match_context *const ctx = pcre2_match_context_copy(ptr);
-      _MatchContext::set(_match_context, ctx);
-    } else {
-      _MatchContext::set(_match_context, nullptr);
-    }
-  }
-  return *this;
-}
-
-//----------------------------------------------------------------------------
 RegexMatchContext::~RegexMatchContext()
 {
   auto ptr = _MatchContext::get(_match_context);

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -26,6 +26,7 @@
 
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
+#include <pthread.h>
 
 #include <array>
 #include <vector>
@@ -83,42 +84,40 @@ my_free(void *ptr, void * /*caller*/)
 // One match context is shared by every thread that matches through it, and PCRE2
 // requires a distinct JIT stack per thread, so the stack comes from a callback
 // invoked at match time rather than a pointer baked in when the context is built.
-// The pointer and the cleanup object are separate thread locals on purpose:
-// touching a thread local with a destructor here registers it via
-// __cxa_thread_atexit, which takes the loader mutex during a match and deadlocks.
-thread_local pcre2_jit_stack *jit_stack = nullptr;
+//
+// The per thread stack is held in a pthread key rather than a thread_local. A
+// thread_local with a destructor registers it through __cxa_thread_atexit, which
+// takes the dynamic loader lock; doing that from a match would invert lock order
+// against a dlopen caller running a plugin's static initialization. See the same
+// hazard described at Diags::tag_activated. A pthread key registers its destructor
+// once, at key creation, and never from the matching path.
+pthread_key_t  jit_stack_key;
+pthread_once_t jit_stack_key_once = PTHREAD_ONCE_INIT;
 
-struct JitStackCleanup {
-  ~JitStackCleanup()
-  {
-    if (jit_stack != nullptr) {
-      pcre2_jit_stack_free(jit_stack);
-      // Clear it so a match from a thread local destroyed after this one gets a
-      // fresh stack rather than the freed pointer.
-      jit_stack = nullptr;
-    }
-  }
-};
-
-thread_local JitStackCleanup jit_stack_cleanup;
-
-// Taking the address forces this thread's initialization of the cleanup object, which
-// registers its destructor. That has to happen on the matching thread but outside the
-// callback: a thread that only ever reached the callback would never initialize the
-// object and would leak its stack.
 void
-arm_jit_stack_cleanup()
+destroy_jit_stack(void *stack)
 {
-  [[maybe_unused]] auto const *cleanup = &jit_stack_cleanup;
+  if (stack != nullptr) {
+    pcre2_jit_stack_free(static_cast<pcre2_jit_stack *>(stack));
+  }
+}
+
+void
+make_jit_stack_key()
+{
+  pthread_key_create(&jit_stack_key, destroy_jit_stack);
 }
 
 pcre2_jit_stack *
 jit_stack_for_this_thread(void *)
 {
-  if (jit_stack == nullptr) {
-    jit_stack = pcre2_jit_stack_create(4096, 1024 * 1024, nullptr); // 1 page min and 1MB max
+  pthread_once(&jit_stack_key_once, make_jit_stack_key);
+  auto *stack = static_cast<pcre2_jit_stack *>(pthread_getspecific(jit_stack_key));
+  if (stack == nullptr) {
+    stack = pcre2_jit_stack_create(4096, 1024 * 1024, nullptr); // 1 page min and 1MB max
+    pthread_setspecific(jit_stack_key, stack);
   }
-  return jit_stack;
+  return stack;
 }
 
 //----------------------------------------------------------------------------
@@ -513,8 +512,6 @@ Regex::exec(std::string_view subject, RegexMatches &matches, uint32_t flags, Reg
 
   bool const     full_match  = (flags & RE_FULL_MATCH) != 0;
   uint32_t const pcre2_flags = flags & ~RE_FULL_MATCH;
-
-  arm_jit_stack_cleanup();
 
   int rc = pcre2_match(code, reinterpret_cast<PCRE2_SPTR>(subject.data()), subject.size(), 0, pcre2_flags,
                        RegexMatches::_MatchData::get(matches._match_data), match_context);

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -80,6 +80,12 @@ my_free(void *ptr, void * /*caller*/)
 }
 
 //----------------------------------------------------------------------------
+// PCRE2 requires a distinct JIT stack per thread. A match context may be copied
+// and used on another thread, so the stack is supplied through a callback that
+// resolves to the calling thread's stack rather than assigned directly.
+pcre2_jit_stack *thread_jit_stack(void *);
+
+//----------------------------------------------------------------------------
 class RegexContext
 {
 public:
@@ -119,6 +125,11 @@ public:
   {
     return _match_context;
   }
+  pcre2_jit_stack *
+  get_jit_stack()
+  {
+    return _jit_stack;
+  }
 
 private:
   RegexContext()
@@ -127,13 +138,19 @@ private:
     _compile_context = pcre2_compile_context_create(_general_context);
     _match_context   = pcre2_match_context_create(_general_context);
     _jit_stack       = pcre2_jit_stack_create(4096, 1024 * 1024, nullptr); // 1 page min and 1MB max
-    pcre2_jit_stack_assign(_match_context, nullptr, _jit_stack);
+    pcre2_jit_stack_assign(_match_context, &thread_jit_stack, nullptr);
   }
   pcre2_general_context *_general_context = nullptr;
   pcre2_compile_context *_compile_context = nullptr;
   pcre2_match_context   *_match_context   = nullptr;
   pcre2_jit_stack       *_jit_stack       = nullptr;
 };
+
+pcre2_jit_stack *
+thread_jit_stack(void *)
+{
+  return RegexContext::get_instance()->get_jit_stack();
+}
 
 } // namespace
 
@@ -257,7 +274,11 @@ struct RegexMatchContext::_MatchContext {
 //----------------------------------------------------------------------------
 RegexMatchContext::RegexMatchContext()
 {
-  auto ctx = pcre2_match_context_create(nullptr);
+  // Copy the shared context rather than building a blank one. A blank context
+  // silently drops everything the shared context configures, which is how this
+  // type came to run with PCRE2's fallback 32KiB JIT stack instead of the 1MiB
+  // one every other caller gets. Callers override only the fields they mean to.
+  auto ctx = pcre2_match_context_copy(RegexContext::get_instance()->get_match_context());
   debug_assert_message(ctx, "Failed to allocate custom pcre2 match context");
   _MatchContext::set(_match_context, ctx);
 }

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -80,17 +80,12 @@ my_free(void *ptr, void * /*caller*/)
 }
 
 //----------------------------------------------------------------------------
-// PCRE2 needs a distinct JIT stack per thread, and a match context can be copied
-// and then used on a different thread. Handing over a plain stack pointer would
-// bake in the stack owned by whichever thread built the context, and two threads
-// matching at once on one stack corrupts memory. PCRE2 accepts a callback for
-// exactly this case and invokes it at match time, on the matching thread.
-// The stack is held in a raw thread local pointer and freed by a separate thread
-// local object, rather than by one object that owns both. Touching a thread local
-// with a destructor runs the TLS init function, which calls __cxa_thread_atexit and
-// takes the loader mutex. Doing that from inside this callback, which PCRE2 invokes
-// during a match, deadlocked. This split is how the pre-PCRE2 implementation solved
-// it; the arrangement was lost when the JIT stack moved into RegexContext.
+// A match context can be copied and used on another thread, and PCRE2 requires a
+// distinct JIT stack per thread, so the stack comes from a callback invoked at
+// match time rather than a pointer baked in when the context is built.
+// The pointer and the cleanup object are separate thread locals on purpose:
+// touching a thread local with a destructor here registers it via
+// __cxa_thread_atexit, which takes the loader mutex during a match and deadlocks.
 thread_local pcre2_jit_stack *jit_stack = nullptr;
 
 struct JitStackCleanup {

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -85,16 +85,32 @@ my_free(void *ptr, void * /*caller*/)
 // bake in the stack owned by whichever thread built the context, and two threads
 // matching at once on one stack corrupts memory. PCRE2 accepts a callback for
 // exactly this case and invokes it at match time, on the matching thread.
+// The stack is held in a raw thread local pointer and freed by a separate thread
+// local object, rather than by one object that owns both. Touching a thread local
+// with a destructor runs the TLS init function, which calls __cxa_thread_atexit and
+// takes the loader mutex. Doing that from inside this callback, which PCRE2 invokes
+// during a match, deadlocked. This split is how the pre-PCRE2 implementation solved
+// it; the arrangement was lost when the JIT stack moved into RegexContext.
+thread_local pcre2_jit_stack *jit_stack = nullptr;
+
+struct JitStackCleanup {
+  ~JitStackCleanup()
+  {
+    if (jit_stack != nullptr) {
+      pcre2_jit_stack_free(jit_stack);
+    }
+  }
+};
+
+thread_local JitStackCleanup jit_stack_cleanup;
+
 pcre2_jit_stack *
 jit_stack_for_this_thread(void *)
 {
-  struct ThreadStack {
-    ThreadStack() : stack{pcre2_jit_stack_create(4096, 1024 * 1024, nullptr)} {} // 1 page min and 1MB max
-    ~ThreadStack() { pcre2_jit_stack_free(stack); }
-    pcre2_jit_stack *stack;
-  };
-  thread_local ThreadStack owner;
-  return owner.stack;
+  if (jit_stack == nullptr) {
+    jit_stack = pcre2_jit_stack_create(4096, 1024 * 1024, nullptr); // 1 page min and 1MB max
+  }
+  return jit_stack;
 }
 
 //----------------------------------------------------------------------------

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -89,7 +89,6 @@ my_free(void *ptr, void * /*caller*/)
 thread_local pcre2_jit_stack *jit_stack = nullptr;
 
 struct JitStackCleanup {
-  bool armed = true;
   ~JitStackCleanup()
   {
     if (jit_stack != nullptr) {
@@ -100,16 +99,14 @@ struct JitStackCleanup {
 
 thread_local JitStackCleanup jit_stack_cleanup;
 
-// Reading the member forces the thread local to be initialized, which registers its
-// destructor. That has to happen here, on the matching thread but before the match,
-// rather than inside the callback. A thread that only ever reached the callback
-// would otherwise never initialize the cleanup object and would leak its stack.
+// Taking the address forces this thread's initialization of the cleanup object, which
+// registers its destructor. That has to happen on the matching thread but outside the
+// callback: a thread that only ever reached the callback would never initialize the
+// object and would leak its stack.
 void
 arm_jit_stack_cleanup()
 {
-  if (!jit_stack_cleanup.armed) {
-    return;
-  }
+  [[maybe_unused]] auto const *cleanup = &jit_stack_cleanup;
 }
 
 pcre2_jit_stack *

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -93,6 +93,9 @@ struct JitStackCleanup {
   {
     if (jit_stack != nullptr) {
       pcre2_jit_stack_free(jit_stack);
+      // Clear it so a match from a thread local destroyed after this one gets a
+      // fresh stack rather than the freed pointer.
+      jit_stack = nullptr;
     }
   }
 };

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -80,9 +80,9 @@ my_free(void *ptr, void * /*caller*/)
 }
 
 //----------------------------------------------------------------------------
-// A match context can be copied and used on another thread, and PCRE2 requires a
-// distinct JIT stack per thread, so the stack comes from a callback invoked at
-// match time rather than a pointer baked in when the context is built.
+// One match context is shared by every thread that matches through it, and PCRE2
+// requires a distinct JIT stack per thread, so the stack comes from a callback
+// invoked at match time rather than a pointer baked in when the context is built.
 // The pointer and the cleanup object are separate thread locals on purpose:
 // touching a thread local with a destructor here registers it via
 // __cxa_thread_atexit, which takes the loader mutex during a match and deadlocks.

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -94,6 +94,7 @@ my_free(void *ptr, void * /*caller*/)
 thread_local pcre2_jit_stack *jit_stack = nullptr;
 
 struct JitStackCleanup {
+  bool armed = true;
   ~JitStackCleanup()
   {
     if (jit_stack != nullptr) {
@@ -103,6 +104,18 @@ struct JitStackCleanup {
 };
 
 thread_local JitStackCleanup jit_stack_cleanup;
+
+// Reading the member forces the thread local to be initialized, which registers its
+// destructor. That has to happen here, on the matching thread but before the match,
+// rather than inside the callback. A thread that only ever reached the callback
+// would otherwise never initialize the cleanup object and would leak its stack.
+void
+arm_jit_stack_cleanup()
+{
+  if (!jit_stack_cleanup.armed) {
+    return;
+  }
+}
 
 pcre2_jit_stack *
 jit_stack_for_this_thread(void *)
@@ -531,6 +544,8 @@ Regex::exec(std::string_view subject, RegexMatches &matches, uint32_t flags, Reg
 
   bool const     full_match  = (flags & RE_FULL_MATCH) != 0;
   uint32_t const pcre2_flags = flags & ~RE_FULL_MATCH;
+
+  arm_jit_stack_cleanup();
 
   int rc = pcre2_match(code, reinterpret_cast<PCRE2_SPTR>(subject.data()), subject.size(), 0, pcre2_flags,
                        RegexMatches::_MatchData::get(matches._match_data), match_context);

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -296,7 +296,7 @@ RegexMatchContext::RegexMatchContext()
   // type came to run with PCRE2's fallback 32KiB JIT stack instead of the 1MiB
   // one every other caller gets. Callers override only the fields they mean to.
   auto ctx = pcre2_match_context_copy(RegexContext::get_instance()->get_match_context());
-  debug_assert_message(ctx, "Failed to allocate custom pcre2 match context");
+  debug_assert_message(ctx, "Failed to copy the shared pcre2 match context");
   _MatchContext::set(_match_context, ctx);
 }
 

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -80,10 +80,22 @@ my_free(void *ptr, void * /*caller*/)
 }
 
 //----------------------------------------------------------------------------
-// PCRE2 requires a distinct JIT stack per thread. A match context may be copied
-// and used on another thread, so the stack is supplied through a callback that
-// resolves to the calling thread's stack rather than assigned directly.
-pcre2_jit_stack *thread_jit_stack(void *);
+// PCRE2 needs a distinct JIT stack per thread, and a match context can be copied
+// and then used on a different thread. Handing over a plain stack pointer would
+// bake in the stack owned by whichever thread built the context, and two threads
+// matching at once on one stack corrupts memory. PCRE2 accepts a callback for
+// exactly this case and invokes it at match time, on the matching thread.
+pcre2_jit_stack *
+jit_stack_for_this_thread(void *)
+{
+  struct ThreadStack {
+    ThreadStack() : stack{pcre2_jit_stack_create(4096, 1024 * 1024, nullptr)} {} // 1 page min and 1MB max
+    ~ThreadStack() { pcre2_jit_stack_free(stack); }
+    pcre2_jit_stack *stack;
+  };
+  thread_local ThreadStack owner;
+  return owner.stack;
+}
 
 //----------------------------------------------------------------------------
 class RegexContext
@@ -106,9 +118,6 @@ public:
     if (_match_context != nullptr) {
       pcre2_match_context_free(_match_context);
     }
-    if (_jit_stack != nullptr) {
-      pcre2_jit_stack_free(_jit_stack);
-    }
   }
   pcre2_general_context *
   get_general_context()
@@ -125,11 +134,6 @@ public:
   {
     return _match_context;
   }
-  pcre2_jit_stack *
-  get_jit_stack()
-  {
-    return _jit_stack;
-  }
 
 private:
   RegexContext()
@@ -137,20 +141,12 @@ private:
     _general_context = pcre2_general_context_create(my_malloc, my_free, nullptr);
     _compile_context = pcre2_compile_context_create(_general_context);
     _match_context   = pcre2_match_context_create(_general_context);
-    _jit_stack       = pcre2_jit_stack_create(4096, 1024 * 1024, nullptr); // 1 page min and 1MB max
-    pcre2_jit_stack_assign(_match_context, &thread_jit_stack, nullptr);
+    pcre2_jit_stack_assign(_match_context, jit_stack_for_this_thread, nullptr);
   }
   pcre2_general_context *_general_context = nullptr;
   pcre2_compile_context *_compile_context = nullptr;
   pcre2_match_context   *_match_context   = nullptr;
-  pcre2_jit_stack       *_jit_stack       = nullptr;
 };
-
-pcre2_jit_stack *
-thread_jit_stack(void *)
-{
-  return RegexContext::get_instance()->get_jit_stack();
-}
 
 } // namespace
 

--- a/src/tsutil/Regex.cc
+++ b/src/tsutil/Regex.cc
@@ -92,7 +92,8 @@ my_free(void *ptr, void * /*caller*/)
 // hazard described at Diags::tag_activated. A pthread key registers its destructor
 // once, at key creation, and never from the matching path.
 pthread_key_t  jit_stack_key;
-pthread_once_t jit_stack_key_once = PTHREAD_ONCE_INIT;
+bool           jit_stack_key_valid = false;
+pthread_once_t jit_stack_key_once  = PTHREAD_ONCE_INIT;
 
 void
 destroy_jit_stack(void *stack)
@@ -105,13 +106,20 @@ destroy_jit_stack(void *stack)
 void
 make_jit_stack_key()
 {
-  pthread_key_create(&jit_stack_key, destroy_jit_stack);
+  jit_stack_key_valid = pthread_key_create(&jit_stack_key, destroy_jit_stack) == 0;
 }
 
 pcre2_jit_stack *
 jit_stack_for_this_thread(void *)
 {
   pthread_once(&jit_stack_key_once, make_jit_stack_key);
+  if (!jit_stack_key_valid) {
+    // Without a key there is nowhere to keep a stack, and jit_stack_key holds a
+    // default value that may name an unrelated key. Returning null tells PCRE2 to
+    // use its own default stack, which pcre2jit documents as thread safe.
+    return nullptr;
+  }
+
   auto *stack = static_cast<pcre2_jit_stack *>(pthread_getspecific(jit_stack_key));
   if (stack == nullptr) {
     stack = pcre2_jit_stack_create(4096, 1024 * 1024, nullptr); // 1 page min and 1MB max

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -1124,10 +1124,12 @@ TEST_CASE("Regex reports resource exhaustion rather than crashing", "[libts][Reg
   Regex re;
   REQUIRE(re.compile(pattern));
 
-  // Past what a 1MiB JIT stack holds for this pattern, which starts failing at
-  // roughly 43KiB of subject, so the bound is still exercised.
+  // This pattern starts failing at roughly 43KiB of subject against a 1MiB JIT
+  // stack, measured identically on x86_64 and arm64. 256KiB keeps a six times
+  // margin for a platform whose JIT frames are larger, without allocating more
+  // than the bound needs. Do not trim this to just above 43KiB.
   std::string subject{"/alpha/bravo/?"};
-  subject.append(2 * 1024 * 1024, 'x');
+  subject.append(256 * 1024, 'x');
 
   RegexMatches matches;
   int const    rc = re.exec(subject, matches);

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -1085,8 +1085,8 @@ TEST_CASE("Regex reports resource exhaustion rather than crashing", "[libts][Reg
   Regex re;
   REQUIRE(re.compile(R"(^/alpha/bravo/[?]((?!action=(newsfeed|calendar|contacts|notepad)).)*$)"));
 
-  // Well past what a 1MiB JIT stack can hold, so the bound is still exercised
-  // now that the plugin no longer sets its own smaller one.
+  // Past what a 1MiB JIT stack holds for this pattern, which starts failing at
+  // roughly 43KiB of subject, so the bound is still exercised.
   std::string subject{"/alpha/bravo/?"};
   subject.append(2 * 1024 * 1024, 'x');
 

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -1050,3 +1050,51 @@ TEST_CASE("Regex end-anchor with alternation", "[libts][Regex]")
   CHECK(r.exec("cdn.example.com.evil.com", matches) == RE_ERROR_NOMATCH);
   CHECK(r.exec("prefix.cdn.example.com", matches) == RE_ERROR_NOMATCH);
 }
+
+// A caller-supplied RegexMatchContext must behave like the shared context that
+// Regex::exec uses when none is supplied. A context built from scratch silently
+// drops everything the shared one configures, which is how regex_remap came to
+// run with PCRE2's fallback 32KiB JIT stack instead of the 1MiB one.
+TEST_CASE("RegexMatchContext matches the shared context", "[libts][Regex][RegexMatchContext]")
+{
+  // Quantified alternation of capture groups: every subject character pushes a
+  // backtracking frame, so the JIT stack size is what bounds this.
+  Regex re;
+  REQUIRE(re.compile(R"(^(?:(a)|(b))+$)"));
+
+  std::string const subject(1000, 'a');
+
+  RegexMatches      shared_matches;
+  RegexMatchContext match_context;
+  RegexMatches      own_matches;
+
+  int const shared_rc = re.exec(subject, shared_matches);
+  int const own_rc    = re.exec(subject, own_matches, 0, &match_context);
+  CAPTURE(shared_rc, own_rc);
+
+  REQUIRE(shared_rc > 0);
+  REQUIRE(own_rc == shared_rc);
+}
+
+// The guard from #5762: a pattern that backtracks once per character must fail
+// cleanly rather than run the thread out of stack. PCRE1 recursed on the machine
+// stack and a long enough subject crashed the server; PCRE2 must report an error
+// instead. If this ever crashes rather than fails, that regression is back.
+TEST_CASE("Regex reports resource exhaustion rather than crashing", "[libts][Regex][limits]")
+{
+  Regex re;
+  REQUIRE(re.compile(R"(^/alpha/bravo/[?]((?!action=(newsfeed|calendar|contacts|notepad)).)*$)"));
+
+  // Well past what a 1MiB JIT stack can hold, so the bound is still exercised
+  // now that the plugin no longer sets its own smaller one.
+  std::string subject{"/alpha/bravo/?"};
+  subject.append(2 * 1024 * 1024, 'x');
+
+  RegexMatches matches;
+  int const    rc = re.exec(subject, matches);
+  CAPTURE(rc);
+
+  // Reaching this line at all is the crash assertion.
+  REQUIRE(rc < 0);
+  REQUIRE(rc != RE_ERROR_NOMATCH);
+}

--- a/src/tsutil/unit_tests/test_Regex.cc
+++ b/src/tsutil/unit_tests/test_Regex.cc
@@ -1051,6 +1051,32 @@ TEST_CASE("Regex end-anchor with alternation", "[libts][Regex]")
   CHECK(r.exec("prefix.cdn.example.com", matches) == RE_ERROR_NOMATCH);
 }
 
+namespace
+{
+/** Does PCRE2 have JIT code for this pattern?
+ *
+ * The two tests below are about the JIT stack, and PCRE2 consults it only when it
+ * has JIT code to run. Without it both a blank context and the shared one take the
+ * interpreter and return the same answer, so the tests would pass whether or not
+ * the behaviour they describe is present. Ask PCRE2 rather than assume.
+ */
+bool
+pattern_has_jit(char const *pattern)
+{
+  int         errnum    = 0;
+  PCRE2_SIZE  erroffset = 0;
+  pcre2_code *code = pcre2_compile(reinterpret_cast<PCRE2_SPTR>(pattern), PCRE2_ZERO_TERMINATED, 0, &errnum, &erroffset, nullptr);
+  if (code == nullptr) {
+    return false;
+  }
+  pcre2_jit_compile(code, PCRE2_JIT_COMPLETE);
+  size_t jit_size = 0;
+  pcre2_pattern_info(code, PCRE2_INFO_JITSIZE, &jit_size);
+  pcre2_code_free(code);
+  return jit_size > 0;
+}
+} // namespace
+
 // A caller-supplied RegexMatchContext must behave like the shared context that
 // Regex::exec uses when none is supplied. A context built from scratch silently
 // drops everything the shared one configures, which is how regex_remap came to
@@ -1059,8 +1085,13 @@ TEST_CASE("RegexMatchContext matches the shared context", "[libts][Regex][RegexM
 {
   // Quantified alternation of capture groups: every subject character pushes a
   // backtracking frame, so the JIT stack size is what bounds this.
+  char const *const pattern = R"(^(?:(a)|(b))+$)";
+  if (!pattern_has_jit(pattern)) {
+    SKIP("PCRE2 has no JIT for this pattern, so the JIT stack is never consulted");
+  }
+
   Regex re;
-  REQUIRE(re.compile(R"(^(?:(a)|(b))+$)"));
+  REQUIRE(re.compile(pattern));
 
   std::string const subject(1000, 'a');
 
@@ -1082,8 +1113,16 @@ TEST_CASE("RegexMatchContext matches the shared context", "[libts][Regex][RegexM
 // instead. If this ever crashes rather than fails, that regression is back.
 TEST_CASE("Regex reports resource exhaustion rather than crashing", "[libts][Regex][limits]")
 {
+  // Only the JIT path has a bound to exhaust here. PCRE2's interpreter keeps its
+  // backtracking frames on the heap, so it matches this subject rather than running
+  // out of anything, and there is no resource error to assert.
+  char const *const pattern = R"(^/alpha/bravo/[?]((?!action=(newsfeed|calendar|contacts|notepad)).)*$)";
+  if (!pattern_has_jit(pattern)) {
+    SKIP("PCRE2 has no JIT for this pattern, so there is no stack bound to exhaust");
+  }
+
   Regex re;
-  REQUIRE(re.compile(R"(^/alpha/bravo/[?]((?!action=(newsfeed|calendar|contacts|notepad)).)*$)"));
+  REQUIRE(re.compile(pattern));
 
   // Past what a 1MiB JIT stack holds for this pattern, which starts failing at
   // roughly 43KiB of subject, so the bound is still exercised.

--- a/tests/gold_tests/pluginTest/regex_remap/regex_remap.test.py
+++ b/tests/gold_tests/pluginTest/regex_remap/regex_remap.test.py
@@ -88,7 +88,9 @@ ts.Disk.records_config.update(
         'proxy.config.diags.debug.enabled': 1,
         'proxy.config.diags.debug.tags': 'http|regex_remap',
         'proxy.config.dns.nameservers': f"127.0.0.1:{nameserver.Variables.Port}",
-        'proxy.config.dns.resolv_conf': 'NULL'
+        'proxy.config.dns.resolv_conf': 'NULL',
+        # The crash-guard run below needs a request larger than the 32 KB default.
+        'proxy.config.http.request_header_max_size': 131072
     })
 
 # 0 Test - Load cache (miss) (path1)
@@ -123,12 +125,29 @@ tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/regex_remap_simple.gold"
 tr.StillRunningAfter = ts
 
-# 3 Test - Preserve the original crash guard from #5762. This request must
-# survive resource exhaustion without redirecting, regardless of which matching
-# resource limit is reached (JIT stack, match work, depth, or heap).
-tr = Test.AddTestRun("resource exhaustion does not crash ATS")
+# 3 Test - A 3 KB query redirects. This rule backtracks once per subject
+# character, so it used to exhaust the 32 KB stack PCRE2 falls back to when a
+# match context carries none, and the rule was skipped. The plugin's context now
+# inherits the shared 1 MB stack, so the rule matches and the redirect fires.
+tr = Test.AddTestRun("long query redirects rather than exhausting the JIT stack")
 creq = replay_txns[1]['client-request']
-tr.MakeCurlCommand(curl_and_args + f"--header 'uuid: {creq['headers']['fields'][1][1]}' '{creq['url']}'", ts=ts)
+tr.MakeCurlCommand(
+    curl_and_args + f"--header 'uuid: {creq['headers']['fields'][1][1]}' '{creq['url']}'" + " | grep -e '^HTTP/' -e '^Location'",
+    ts=ts)
+tr.Processes.Default.ReturnCode = 0
+tr.Processes.Default.Streams.stdout = "gold/regex_remap_redirect.gold"
+tr.StillRunningAfter = ts
+
+# 3b Test - Preserve the original crash guard from #5762. This request must
+# survive resource exhaustion without redirecting, regardless of which matching
+# resource limit is reached (JIT stack, match work, depth, or heap). Against the
+# shared 1 MB stack this rule needs a subject past 43 KB to exhaust it, which is
+# why the request header limit is raised above. Shortening this query silently
+# turns the run into a plain redirect test.
+crash_guard_query = 'x' * 64000
+tr = Test.AddTestRun("resource exhaustion does not crash ATS")
+tr.MakeCurlCommand(
+    curl_and_args + "--header 'uuid: 180' " + f"'http://example.one/alpha/bravo/?action=newsfed;{crash_guard_query}'", ts=ts)
 tr.Processes.Default.ReturnCode = 0
 tr.Processes.Default.Streams.stdout = "gold/regex_remap_crash.gold"
 ts.Disk.diags_log.Content += Testers.ContainsExpression(


### PR DESCRIPTION
`RegexMatchContext` builds an empty PCRE2 match context, so a caller that supplies its
own context silently loses everything the shared context configures. Today that is a
1 MB JIT stack, replaced by PCRE2's 32 KB fallback. `regex_remap` and `esi` are the only
two users of the type, and both ran on the fallback.

Nobody chose 32 KB. It is what PCRE2 uses when no stack is assigned, and it arrived by
omission when the type was introduced in #12575. That shipped in 10.2.0.

This builds the context as a copy of the shared one instead, so a caller cannot silently
lack what the shared context has, and anything added to the shared context later applies
automatically. There is no change to `regex_remap.cc`; the plugin keeps its context and
the context now starts correct.

Issue: https://github.com/apache/trafficserver/issues/13660

## What this changes in behaviour

Measured with `pcre2test` 10.47 against the rule and the 3071 byte URL already in
`replay/yts-2819.replay.json`:

```
~^/alpha/bravo/[?]((?!action=(newsfeed|calendar|contacts|notepad)).)*$~
  jitstack=32     Failed: error -46: JIT stack limit reached
  jitstack=1024   matches
```

That URL now redirects rather than falling through to origin, which is what the rule
always intended. The first `-46` threshold for this rule moves from 1377 bytes to 43702
bytes, which is past the 32768 byte default of
`proxy.config.http.request_header_max_size`. So after this change the request size limit
binds before the JIT stack does, which is where that bound belongs.

The 32 KB fallback lives on the machine stack. An assigned stack is heap allocated. So
this reduces thread stack pressure rather than raising it, which is worth stating because
the limit this rule has been hitting traces back to #5762, where the concern was machine
stack exhaustion.

1 MB is not a new number. It is what ATS has used since #11014, and the same 4 KB floor
and 1 MB ceiling the pre-PCRE2 code used before that.

## Why the stack is supplied through a callback

`regex_remap.cc:810` holds one `RegexMatchContext` per remap instance, built once at
config load and used by every `ET_NET` thread. One object, many threads.

Assigning a stack pointer to that context would give every thread the same stack:

```mermaid
flowchart LR
    CTX["one RegexMatchContext<br/>shared by every thread"] --> T0["ET_NET 0"]
    CTX --> T1["ET_NET 1"]
    CTX --> T2["ET_NET 2"]
    T0 --> S["one JIT stack"]
    T1 --> S
    T2 --> S
    S --> X["concurrent matches<br/>corrupt it"]
    style CTX fill:#F1EFE8,stroke:#5F5E5A,color:#2C2C2A
    style S fill:#FCEBEB,stroke:#A32D2D,color:#501313
    style X fill:#FCEBEB,stroke:#A32D2D,color:#501313
```

`pcre2jit` is explicit: "if you assign or pass back a non-NULL JIT stack, this must be a
different stack for each thread so that the application is thread-safe."

So the context carries a callback instead. PCRE2 invokes it at match time, on the thread
that is matching, and it returns that thread's own stack:

```mermaid
flowchart LR
    CTX["one RegexMatchContext<br/>shared by every thread"] --> T0["ET_NET 0"]
    CTX --> T1["ET_NET 1"]
    CTX --> T2["ET_NET 2"]
    T0 --> S0["stack for thread 0"]
    T1 --> S1["stack for thread 1"]
    T2 --> S2["stack for thread 2"]
    style CTX fill:#F1EFE8,stroke:#5F5E5A,color:#2C2C2A
    style S0 fill:#E1F5EE,stroke:#0F6E56,color:#04342C
    style S1 fill:#E1F5EE,stroke:#0F6E56,color:#04342C
    style S2 fill:#E1F5EE,stroke:#0F6E56,color:#04342C
```

This is the arrangement the pre-PCRE2 code used, and the pattern the `pcre2jit` manual
recommends. Note the sharing is a property of one context being used by many threads, not
of the type being copyable: the callback is still required with the copy and move members
deleted, as they now are.

Verified under ThreadSanitizer: eight threads, two thousand matches each, one shared
context, clean. Cost is below noise, 19.9 to 25.4 ns per match assigning a stack directly
against 20.4 to 21.7 ns through the callback, on a short ordinary match.

## Also deletes the copy and move members

Nothing in the tree copies or moves a `RegexMatchContext`. Every use is a plain member or
local: `regex_remap.cc:810`, `IncludeUrlValidator.h:83`, and two unit tests. The four
special members were dead code carrying two defects:

- The defaulted move copied the raw pointer and left the source holding it, so both
  destructors called `pcre2_match_context_free` on the same object.
- The copy constructor left the pointer null when the source was null, which its own
  destructor asserts on in a debug build and silently ignores in a release build.

They are now `= delete`, which makes both unrepresentable rather than fixing them. Neither
had ever fired, because nothing exercises them. This removes 24 lines of dead definitions
from `Regex.cc`.

## The per thread stack uses a pthread key, not a thread local

A `thread_local` with a destructor registers it through `__cxa_thread_atexit`, which takes
the dynamic loader lock. Registering that from `Regex::exec` inverts lock order against a
`dlopen` caller running a plugin's static initialization. `Diags::tag_activated` already
documents this hazard and works around it, and the pre-PCRE2 implementation of this file
worked around it too, with the arrangement lost in #11014.

Earlier revisions of this branch reproduced the whole trade: a thread local holding the
stack deadlocked, splitting the pointer from the cleanup object leaked the stack instead,
and arming the cleanup from `exec` only moved the registration out of PCRE2's callback
while leaving it on `exec`, and extended it to the caller-supplied context path that never
had it.

The stack now lives in a `pthread_key_t` whose destructor is registered once at key
creation through `pthread_once` and never from the matching path. That removes both
thread locals, the arming function and its call, so the hazard is gone rather than
balanced.

## The #5762 crash guard is preserved, not removed

The AuTest run that guards #5762 previously used the 3071 byte URL. Since that URL now
matches, the run would no longer have exercised a resource limit. Rather than drop the
guard, the run keeps its shape at a subject large enough to still exhaust 1 MB, and the
request header limit is raised for it. Verified in the sandbox:

```
Bad regular expression result -46 ("JIT stack limit reached") from "^/alpha/bravo/..."
Bad regular expression result -47 ("match limit exceeded") from "^/match_limit/(a+)+$"
```

Two unit tests are added in `test_Regex.cc`: one asserting a caller-supplied context
reaches the same verdict as the shared one, and one asserting that resource exhaustion is
reported rather than crashing. The second asserts directly the property #5762 was
protecting, which the AuTest can only reach indirectly.

Both ask PCRE2 for the pattern's JIT size and skip when there is none, because both are
about the JIT stack and PCRE2 consults it only when it has JIT code to run. Without JIT a
blank context and the shared one both take the interpreter and return the same answer, so
the parity test would pass whether or not the fix were present, and the exhaustion test
would fail outright: the interpreter keeps its backtracking frames on the heap and matches
a 2 MiB subject rather than running out of anything. Measured, not assumed.

## Testing

On a dev-asan build:

- Full `ctest` suite: 134 of 134 pass. This touches shared `tsutil` code, so the whole
  suite is the relevant blast radius rather than the Regex tests alone.
- `regex_remap` and `regex_remap_long_query` AuTests pass, with the 3 KB URL returning
  301 and exactly one `-46` and one `-47` in the diags log.

## AuTest flakes seen while testing this, both pre-existing

Neither is introduced by this change. Recording them because both cost time to rule out.

**`connect_attempts`** failed once on this PR in CI and passed on a retrigger of the
identical commit. The gold file pins the HTTP state machine id, which is an ordering
artifact rather than the retry behaviour under test. Filed as #13664. That test does not
use regex, and it passed five out of five locally on this branch.

**`regex_remap`** is nondeterministic under an ASAN build because LeakSanitizer reports a
104 byte leak from `ConfigReloadTask::start_progress_checker()` at
`src/mgmt/config/ConfigReloadTrace.cc:394`, which fails the `traffic_server` exit code.
Filed as #13662. This one does not affect CI, because `ci-fedora-autest` does not enable
ASAN; it shows up only in a local `dev-asan` build.

## Out of scope

Whether `regex_remap` should carry a CPU bound at all, and what it should be, is a
separate question from whether a caller-supplied context should silently differ from the
shared one. The remaining design problems with this type, including replacing it with a
value, are #13663. Related: #13654.


